### PR TITLE
Add an Uninstall Button next to Update Button

### DIFF
--- a/frontend/package.json.md5
+++ b/frontend/package.json.md5
@@ -1,1 +1,1 @@
-e3f398fdd951ff52abcbe066da72be38
+2e83aeb70fd94cf4f363372ae1b7fbd4

--- a/frontend/src/components/project/ProjectInfo.tsx
+++ b/frontend/src/components/project/ProjectInfo.tsx
@@ -90,10 +90,17 @@ export function ProjectInfo({ type, item, latestVersion, latestCompatibleVersion
       );
     }
     return (
+      <>
       <Button size="sm" onClick={() => handleInstallClick(v.version, v.prerelease)}>
         <Download className="h-4 w-4 mr-1.5" />
         {label}
       </Button>
+      {label.toLowerCase().includes("update") && (
+      <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => setUninstallOpen(true)}>
+        <Trash2 className="h-4 w-4" />
+      </Button>
+      )}
+      </>
     );
   };
 


### PR DESCRIPTION
Closes #39 

Fixes an error where assets couldn't be uninstalled if they were outdated and needed an update.