### PR TITLE
Change to Linux Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Build Linux (amd64)
         run: |
           echo $VERSION > internal/constants/version.txt
-          wails build -platform linux/amd64
+          wails build -platform linux/amd64 -tags webkit2_41
 
       - name: Create AppImage
         run: |


### PR DESCRIPTION
Should hopefully resolve #54. Adds a tag to the linux build to support webkit2gtk-4.1

After merge, I'll be pushing an RC to test linux support