### PR TITLE
Initialize Registry before Update Checking

### DIFF
--- a/app.go
+++ b/app.go
@@ -102,12 +102,12 @@ func (a *App) startup(ctx context.Context) {
 	activeProfile := resolveStartupProfile(a)
 	a.Logger.Info("Active user profile loaded on startup", "profile_id", activeProfile.ID)
 
-	if a.Config.Cfg.CheckForUpdatesOnLaunch {
-		updater.CheckForUpdates(a.ctx, a.Downloader.OnProgress, a.Logger)
-	}
-
 	if err := a.Registry.Initialize(); err != nil {
 		a.Logger.Warn("Failed to ensure local registry repository", "error", err)
+	}
+
+	if a.Config.Cfg.CheckForUpdatesOnLaunch {
+		updater.CheckForUpdates(a.ctx, a.Downloader.OnProgress, a.Logger)
 	}
 
 	// Registry must be initialized + startup profile ready so that initial Frontend state is viable.


### PR DESCRIPTION
Prevents a potential overwrite of installed_mods and installed_maps by loading the registry into memory before Railyard is potentially shutdown to install a new update