### PR TITLE
[Frontend/ Backend] Propagate update timestamps to search

### DIFF
--- a/frontend/src/components/dialogs/UninstallDialog.tsx
+++ b/frontend/src/components/dialogs/UninstallDialog.tsx
@@ -11,11 +11,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { AlertTriangle, Loader2 } from "lucide-react";
+import type { AssetType } from "@/lib/asset-types";
 
 interface UninstallDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  type: "mods" | "maps";
+  type: AssetType;
   id: string;
   name: string;
 }
@@ -27,7 +28,7 @@ export function UninstallDialog({ open, onOpenChange, type, id, name }: Uninstal
   const handleUninstall = async () => {
     setLoading(true);
     try {
-      if (type === "mods") {
+      if (type === "mod") {
         await uninstallMod(id);
       } else {
         await uninstallMap(id);
@@ -50,7 +51,7 @@ export function UninstallDialog({ open, onOpenChange, type, id, name }: Uninstal
             Uninstall {name}?
           </DialogTitle>
           <DialogDescription>
-            This will remove all installed files for this {type === "mods" ? "mod" : "map"}. You can reinstall it later from the registry.
+            This will remove all installed files for this {type === "mod" ? "mod" : "map"}. You can reinstall it later from the registry.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/frontend/src/components/project/ProjectHero.tsx
+++ b/frontend/src/components/project/ProjectHero.tsx
@@ -4,9 +4,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { GetGalleryImage } from "../../../wailsjs/go/registry/Registry";
+import { assetTypeToListingPath, type AssetType } from "@/lib/asset-types";
 
 interface ProjectHeroProps {
-  type: "mods" | "maps";
+  type: AssetType;
   id: string;
   gallery: string[];
 }
@@ -24,7 +25,7 @@ export function ProjectHero({ type, id, gallery }: ProjectHeroProps) {
 
     Promise.all(
       gallery.map((path) =>
-        GetGalleryImage(type, id, path).catch(() => null)
+        GetGalleryImage(assetTypeToListingPath(type), id, path).catch(() => null)
       )
     ).then((urls) => {
       setImages(urls);

--- a/frontend/src/components/project/ProjectInfo.tsx
+++ b/frontend/src/components/project/ProjectInfo.tsx
@@ -29,9 +29,10 @@ import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime";
 import { types } from "../../../wailsjs/go/models";
 import { formatSourceQuality } from "@/lib/map-filter-values";
 import { useDownloadQueueStore } from "@/stores/download-queue-store";
+import type { AssetType } from "@/lib/asset-types";
 
 interface ProjectInfoProps {
-  type: "mods" | "maps";
+  type: AssetType;
   item: types.ModManifest | types.MapManifest;
   latestVersion?: types.VersionInfo;
   latestCompatibleVersion?: types.VersionInfo;
@@ -84,7 +85,7 @@ export function ProjectInfo({
 
   const handleInstall = async (version: string) => {
     try {
-      if (type === "mods") {
+      if (type === "mod") {
         await installMod(item.id, version);
       } else {
         await installMap(item.id, version);
@@ -162,7 +163,7 @@ export function ProjectInfo({
           <p className="text-muted-foreground mt-1">by {item.author}</p>
         </div>
 
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           {versionsLoading ? (
             <Button size="sm" disabled>
               <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />

--- a/frontend/src/components/project/VersionsTable.tsx
+++ b/frontend/src/components/project/VersionsTable.tsx
@@ -26,9 +26,10 @@ import { PrereleaseConfirmDialog } from "@/components/dialogs/PrereleaseConfirmD
 import { isCompatible } from "@/lib/semver";
 import { toast } from "sonner";
 import { useDownloadQueueStore } from "@/stores/download-queue-store";
+import type { AssetType } from "@/lib/asset-types";
 
 interface VersionsTableProps {
-  type: "mods" | "maps";
+  type: AssetType;
   itemId: string;
   itemName: string;
   update: types.UpdateConfig;
@@ -46,7 +47,7 @@ export function VersionsTable({ type, itemId, itemName, versions, loading, error
 
   const doInstall = async (version: string) => {
     try {
-      if (type === "mods") {
+      if (type === "mod") {
         await installMod(itemId, version);
       } else {
         await installMap(itemId, version);

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -4,12 +4,13 @@ import { TypeToggle } from "./TypeToggle";
 import { TagsFilter } from "./TagsFilter";
 import { SortSelect } from "./SortSelect";
 import type { SortState } from "@/lib/constants";
+import type { AssetType } from "@/lib/asset-types";
 
 interface SearchFiltersProps {
   query: string;
   onQueryChange: (query: string) => void;
-  type: "mods" | "maps";
-  onTypeChange: (type: "mods" | "maps") => void;
+  type: AssetType;
+  onTypeChange: (type: AssetType) => void;
   availableTags: string[];
   selectedTags: string[];
   onTagsChange: (tags: string[]) => void;

--- a/frontend/src/components/search/SidebarFilters.tsx
+++ b/frontend/src/components/search/SidebarFilters.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/map-filter-values";
 import { SEARCH_FILTER_EMPTY_LABELS } from "@/lib/search";
 import { type SearchFilterState } from "@/stores/search-store";
+import type { AssetType } from "@/lib/asset-types";
 
 const FILTER_SECTION_TITLE_CLASS =
   "text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-2 px-1";
@@ -36,8 +37,8 @@ interface SidebarFiltersProps {
 }
 
 const typeOptions = [
-  { value: "maps" as const, label: "Maps", icon: MapPin },
-  { value: "mods" as const, label: "Mods", icon: Package },
+  { value: "map" as const, label: "Maps", icon: MapPin },
+  { value: "mod" as const, label: "Mods", icon: Package },
 ];
 
 export function SidebarFilters({
@@ -48,9 +49,9 @@ export function SidebarFilters({
   modCount,
   mapCount,
 }: SidebarFiltersProps) {
-  const counts: Record<"mods" | "maps", number> = {
-    mods: modCount,
-    maps: mapCount,
+  const counts: Record<AssetType, number> = {
+    mod: modCount,
+    map: mapCount,
   };
 
   return (
@@ -92,7 +93,7 @@ export function SidebarFilters({
         </nav>
       </div>
 
-      {filters.type !== "maps" && (
+      {filters.type !== "map" && (
         <>
           <Separator />
           <ChecklistFilterSection
@@ -111,7 +112,7 @@ export function SidebarFilters({
         </>
       )}
 
-      {filters.type !== "mods" && (
+      {filters.type !== "mod" && (
         <>
           <Separator />
           <ChecklistFilterSection

--- a/frontend/src/components/search/SortSelect.tsx
+++ b/frontend/src/components/search/SortSelect.tsx
@@ -6,18 +6,20 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  DEFAULT_SORT_STATE,
   getSortOptionsForType,
+  SortKey,
   sortKeyToState,
   sortStateToOptionKey,
   type SortState,
-  type ListingType,
 } from "@/lib/constants";
 import { useEffect } from "react";
+import type { AssetType } from "@/lib/asset-types";
 
 interface SortSelectProps {
   value: SortState;
   onChange: (value: SortState) => void;
-  tab: ListingType;
+  tab: AssetType;
 }
 
 export function SortSelect({ value, onChange, tab }: SortSelectProps) {
@@ -27,7 +29,13 @@ export function SortSelect({ value, onChange, tab }: SortSelectProps) {
   // Reset to default if current value is not available in filtered options
   useEffect(() => {
     if (!sortOptions.some((opt) => opt.value === selectedOptionKey)) {
-      onChange(sortOptions[0].sort);
+      const defaultKey = SortKey.fromState(DEFAULT_SORT_STATE);
+      const defaultOption =
+        sortOptions.find((opt) => SortKey.equals(opt.value, defaultKey)) ??
+        sortOptions[0];
+      if (defaultOption) {
+        onChange(defaultOption.sort);
+      }
     }
   }, [onChange, selectedOptionKey, sortOptions]);
 
@@ -46,6 +54,7 @@ export function SortSelect({ value, onChange, tab }: SortSelectProps) {
         position="popper"
         align="end"
         avoidCollisions={false}
+        className="max-h-72 overflow-y-auto"
       >
         {sortOptions.map((opt) => (
           <SelectItem key={opt.value} value={opt.value}>

--- a/frontend/src/components/search/TypeToggle.tsx
+++ b/frontend/src/components/search/TypeToggle.tsx
@@ -1,9 +1,10 @@
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Package, MapPin } from "lucide-react";
+import type { AssetType } from "@/lib/asset-types";
 
 interface TypeToggleProps {
-  value: "mods" | "maps";
-  onChange: (value: "mods" | "maps") => void;
+  value: AssetType;
+  onChange: (value: AssetType) => void;
 }
 
 export function TypeToggle({ value, onChange }: TypeToggleProps) {
@@ -12,14 +13,14 @@ export function TypeToggle({ value, onChange }: TypeToggleProps) {
       type="single"
       value={value}
       onValueChange={(v) => {
-        if (v) onChange(v as "mods" | "maps");
+        if (v === "mod" || v === "map") onChange(v);
       }}
     >
-      <ToggleGroupItem value="maps" aria-label="Maps">
+      <ToggleGroupItem value="map" aria-label="Maps">
         <MapPin className="h-4 w-4 mr-1.5" />
         Maps
       </ToggleGroupItem>
-      <ToggleGroupItem value="mods" aria-label="Mods">
+      <ToggleGroupItem value="mod" aria-label="Mods">
         <Package className="h-4 w-4 mr-1.5" />
         Mods
       </ToggleGroupItem>

--- a/frontend/src/components/shared/GalleryImage.tsx
+++ b/frontend/src/components/shared/GalleryImage.tsx
@@ -2,9 +2,10 @@ import { useGalleryImage } from "@/hooks/use-gallery-image";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Package, MapPin } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { AssetType } from "@/lib/asset-types";
 
 interface GalleryImageProps {
-  type: "mods" | "maps";
+  type: AssetType;
   id: string;
   imagePath?: string;
   className?: string;
@@ -12,7 +13,7 @@ interface GalleryImageProps {
 
 export function GalleryImage({ type, id, imagePath, className }: GalleryImageProps) {
   const { imageUrl, loading, error } = useGalleryImage(type, id, imagePath);
-  const FallbackIcon = type === "mods" ? Package : MapPin;
+  const FallbackIcon = type === "mod" ? Package : MapPin;
 
   if (loading) {
     return <Skeleton className={cn("w-full", className)} />;

--- a/frontend/src/components/shared/ItemCard.tsx
+++ b/frontend/src/components/shared/ItemCard.tsx
@@ -7,9 +7,10 @@ import { formatSourceQuality } from "@/lib/map-filter-values";
 import { MAX_CARD_BADGES } from "@/lib/search";
 import { getCountryFlagIcon } from "@/lib/flags";
 import { types } from "../../../wailsjs/go/models";
+import { assetTypeToListingPath, type AssetType } from "@/lib/asset-types";
 
 interface ItemCardProps {
-  type: "mods" | "maps";
+  type: AssetType;
   item: types.ModManifest | types.MapManifest;
   installedVersion?: string;
   totalDownloads?: number;
@@ -44,7 +45,7 @@ export function ItemCard({
   const showDownloads = typeof totalDownloads === "number";
 
   return (
-    <Link href={`/project/${type}/${item.id}`}>
+    <Link href={`/project/${assetTypeToListingPath(type)}/${item.id}`}>
       <article
         className={cn(
           "group relative bg-card border border-border rounded-lg overflow-hidden cursor-pointer transition-all duration-150 hover:border-foreground/20 hover:shadow-sm h-full flex flex-col",

--- a/frontend/src/hooks/use-filtered-items.ts
+++ b/frontend/src/hooks/use-filtered-items.ts
@@ -12,8 +12,8 @@ import { useProfileStore } from "@/stores/profile-store";
 import { type SearchFilterState, useSearchStore } from "@/stores/search-store";
 
 export type TaggedItem =
-  | { type: "mods"; item: types.ModManifest }
-  | { type: "maps"; item: types.MapManifest };
+  | { type: "mod"; item: types.ModManifest }
+  | { type: "map"; item: types.MapManifest };
 
 export type { TypeFilter, SearchFilterState } from "@/stores/search-store";
 
@@ -33,7 +33,7 @@ function buildSearchText(item: TaggedItem): string {
   const base = item.item;
   const values: string[] = [base.name ?? "", base.author ?? "", base.description ?? ""];
 
-  if (item.type === "mods") {
+  if (item.type === "mod") {
     values.push(...(base.tags ?? []));
   } else {
     const map = base as types.MapManifest;
@@ -63,7 +63,7 @@ function matchesZeroOrManyValuesFilter(values: string[] | undefined, selected: s
 }
 
 function matchesMapAttributeFilters(item: TaggedItem, filters: SearchFilterState["map"]): boolean {
-  if (item.type !== "maps") return true;
+  if (item.type !== "map") return true;
 
   const map = item.item as types.MapManifest;
   return (
@@ -83,9 +83,16 @@ function getTotalDownloads(
   modDownloadTotals: Record<string, number>,
   mapDownloadTotals: Record<string, number>
 ): number {
-  return item.type === "mods"
+  return item.type === "mod"
     ? modDownloadTotals[item.item.id] ?? 0
     : mapDownloadTotals[item.item.id] ?? 0;
+}
+
+function getLastUpdated(item: TaggedItem): number {
+  const timestamp = item.item.last_updated;
+  return typeof timestamp === "number" && Number.isFinite(timestamp)
+    ? timestamp
+    : 0;
 }
 
 // Helper to determine comparation logic based on sort field and direction
@@ -106,14 +113,19 @@ function compareItems(
       case "author":
         return compareText(a.item.author ?? "", b.item.author ?? "", sort.direction);
       case "population": {
-        const popA = a.type === "maps" ? (a.item as types.MapManifest).population ?? 0 : 0;
-        const popB = b.type === "maps" ? (b.item as types.MapManifest).population ?? 0 : 0;
+        const popA = a.type === "map" ? (a.item as types.MapManifest).population ?? 0 : 0;
+        const popB = b.type === "map" ? (b.item as types.MapManifest).population ?? 0 : 0;
         return compareByDirection(popA, popB, sort.direction);
       }
       case "downloads": {
         const downloadsA = getTotalDownloads(a, modDownloadTotals, mapDownloadTotals);
         const downloadsB = getTotalDownloads(b, modDownloadTotals, mapDownloadTotals);
         return compareByDirection(downloadsA, downloadsB, sort.direction);
+      }
+      case "last_updated": {
+        const updatedA = getLastUpdated(a);
+        const updatedB = getLastUpdated(b);
+        return compareByDirection(updatedA, updatedB, sort.direction);
       }
       default:
         return 0;
@@ -180,8 +192,8 @@ export function useFilteredItems({
   }, [filters, setPage]);
 
   const allItems = useMemo<TaggedItem[]>(() => {
-    const modItems: TaggedItem[] = (mods || []).map((m) => ({ type: "mods" as const, item: m }));
-    const mapItems: TaggedItem[] = (maps || []).map((m) => ({ type: "maps" as const, item: m }));
+    const modItems: TaggedItem[] = (mods || []).map((m) => ({ type: "mod" as const, item: m }));
+    const mapItems: TaggedItem[] = (maps || []).map((m) => ({ type: "map" as const, item: m }));
     return [...modItems, ...mapItems];
   }, [mods, maps]);
 
@@ -190,7 +202,7 @@ export function useFilteredItems({
 
     if (filters.mod.tags.length > 0) {
       result = result.filter((i) =>
-        i.type === "mods" ? matchesZeroOrManyValuesFilter(i.item.tags, filters.mod.tags) : true
+        i.type === "mod" ? matchesZeroOrManyValuesFilter(i.item.tags, filters.mod.tags) : true
       );
     }
 
@@ -212,7 +224,13 @@ export function useFilteredItems({
     }
 
     return [...result].sort((a, b) =>
-      compareItems(a, b, filters.sort, modDownloadTotals, mapDownloadTotals)
+      compareItems(
+        a,
+        b,
+        filters.sort,
+        modDownloadTotals,
+        mapDownloadTotals
+      )
     );
   }, [allItems, filters, mapDownloadTotals, modDownloadTotals]);
 

--- a/frontend/src/hooks/use-gallery-image.ts
+++ b/frontend/src/hooks/use-gallery-image.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { GetGalleryImage } from '../../wailsjs/go/registry/Registry';
+import { assetTypeToListingPath, type AssetType } from "@/lib/asset-types";
 
-export function useGalleryImage(type: "mods" | "maps", id: string, imagePath?: string) {
+export function useGalleryImage(type: AssetType, id: string, imagePath?: string) {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -16,7 +17,7 @@ export function useGalleryImage(type: "mods" | "maps", id: string, imagePath?: s
     setLoading(true);
     setError(false);
 
-    GetGalleryImage(type, id, imagePath)
+    GetGalleryImage(assetTypeToListingPath(type), id, imagePath)
       .then((url) => {
         if (!cancelled) {
           setImageUrl(url);

--- a/frontend/src/lib/asset-types.ts
+++ b/frontend/src/lib/asset-types.ts
@@ -1,0 +1,20 @@
+export const ASSET_TYPES = ["mod", "map"] as const;
+export type AssetType = (typeof ASSET_TYPES)[number];
+
+export const ASSET_LISTING_PATHS = ["mods", "maps"] as const;
+export type AssetListingPath = (typeof ASSET_LISTING_PATHS)[number];
+
+export const ASSET_TYPE_TO_LISTING_PATH: Record<AssetType, AssetListingPath> = {
+  map: "maps",
+  mod: "mods",
+};
+
+export function assetTypeToListingPath(assetType: AssetType): AssetListingPath {
+  return ASSET_TYPE_TO_LISTING_PATH[assetType];
+}
+
+export function listingPathToAssetType(path: string): AssetType | undefined {
+  if (path === "maps") return "map";
+  if (path === "mods") return "mod";
+  return undefined;
+}

--- a/frontend/src/lib/constants.test.ts
+++ b/frontend/src/lib/constants.test.ts
@@ -14,6 +14,10 @@ describe("sort helpers", () => {
       field: "downloads",
       direction: "desc",
     });
+    expect(sortKeyToState("last_updated:desc")).toEqual({
+      field: "last_updated",
+      direction: "desc",
+    });
     expect(sortKeyToState("random:asc")).toEqual({
       field: "random",
       direction: "asc",
@@ -22,7 +26,7 @@ describe("sort helpers", () => {
 
   it("maps structured state to sort key", () => {
     const state: SortState = { field: "downloads", direction: "asc" };
-    expect(sortStateToOptionKey(state, "mods")).toBe("downloads:asc");
+    expect(sortStateToOptionKey(state, "mod")).toBe("downloads:asc");
   });
 
   it("compares sort keys via helper", () => {
@@ -31,19 +35,24 @@ describe("sort helpers", () => {
   });
 
   it("hides population options for mods only", () => {
-    const modOptions = getSortOptionsForType("mods");
-    const mapOptions = getSortOptionsForType("maps");
+    const modOptions = getSortOptionsForType("mod");
+    const mapOptions = getSortOptionsForType("map");
 
-    expect(modOptions).toHaveLength(7);
+    expect(modOptions).toHaveLength(9);
     expect(modOptions.map((opt) => opt.value)).not.toContain("population:asc");
     expect(modOptions.map((opt) => opt.value)).not.toContain("population:desc");
+    expect(modOptions.map((opt) => opt.value)).toContain("last_updated:asc");
+    expect(modOptions.map((opt) => opt.value)).toContain("last_updated:desc");
     expect(modOptions.map((opt) => opt.value)).toContain("random:asc");
     expect(modOptions.map((opt) => opt.value)).not.toContain("random:desc");
-    expect(mapOptions).toHaveLength(9);
+    expect(mapOptions).toHaveLength(11);
     expect(mapOptions).toEqual(SORT_OPTIONS);
   });
 
   it("falls back to default when sort key is invalid", () => {
-    expect(sortKeyToState("nope")).toEqual({ field: "name", direction: "asc" });
+    expect(sortKeyToState("nope")).toEqual({
+      field: "last_updated",
+      direction: "desc",
+    });
   });
 });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,10 +1,15 @@
+import type { AssetType } from "@/lib/asset-types";
+
 export const PER_PAGE_OPTIONS = [12, 24, 48] as const;
 export type PerPage = typeof PER_PAGE_OPTIONS[number];
 
-export type ListingType = "mods" | "maps";
-
-// Union type of valid sort dimensions (TODO: Include "updated" once the corresponding BE endpoint is added)
-export type SortField = "name" | "author" | "population" | "downloads" | "random";
+export type SortField =
+  | "name"
+  | "author"
+  | "population"
+  | "downloads"
+  | "last_updated"
+  | "random";
 // Union type of valid sort directions
 export type SortDirection = "asc" | "desc";
 export type SortKey = `${SortField}:${SortDirection}`; // Template literal type to help encapsulate logic of converting between SortState and string keys
@@ -21,8 +26,15 @@ export interface SortOption {
   mapOnly?: boolean;
 }
 
-const SORT_FIELDS = ["name", "author", "population", "downloads", "random"] as const;
-const SORT_DIRECTIONS = ["asc", "desc"] as const;
+const SORT_FIELDS = [
+  "last_updated",
+  "downloads",
+  "population",
+  "name",
+  "author",
+  "random",
+] as const;
+const SORT_DIRECTIONS = ["desc", "asc"] as const;
 
 function directionsForField(field: SortField): readonly SortDirection[] {
   return field === "random" ? (["asc"] as const) : SORT_DIRECTIONS;
@@ -31,13 +43,15 @@ function directionsForField(field: SortField): readonly SortDirection[] {
 function sortOptionLabel(field: SortField, direction: SortDirection): string {
   switch (field) {
     case "name":
-      return direction === "asc" ? "Name A-Z" : "Name Z-A";
+      return direction === "asc" ? "Name (A-Z)" : "Name (Z-A)";
     case "author":
-      return direction === "asc" ? "Author A-Z" : "Author Z-A";
+      return direction === "asc" ? "Author (A-Z)" : "Author (Z-A)";
     case "population":
-      return direction === "asc" ? "Population Low-High" : "Population High-Low";
+      return direction === "asc" ? "Population \u2191" : "Population \u2193";
     case "downloads":
       return direction === "asc" ? "Total Downloads \u2191" : "Total Downloads \u2193";
+    case "last_updated":
+      return direction === "asc" ? "Last Updated \u2191" : "Last Updated \u2193";
     case "random":
       return "Random";
     default: // Default case to ensure all fields are handled. Programmer error if this is ever reached
@@ -54,10 +68,13 @@ export const SORT_OPTIONS = SORT_FIELDS.flatMap((field) =>
   }))
 ) satisfies SortOption[];
 
-export const DEFAULT_SORT_STATE: SortState = { field: "name", direction: "asc" };
+export const DEFAULT_SORT_STATE: SortState = {
+  field: "last_updated",
+  direction: "desc",
+};
 
-export function getSortOptionsForType(type: ListingType): SortOption[] {
-  return SORT_OPTIONS.filter((opt) => !opt.mapOnly || type === "maps");
+export function getSortOptionsForType(type: AssetType): SortOption[] {
+  return SORT_OPTIONS.filter((opt) => !opt.mapOnly || type === "map");
 }
 
 const SORT_STATE_BY_KEY = Object.fromEntries(
@@ -80,14 +97,18 @@ export function sortKeyToState(value: string): SortState {
   return SortKey.toState(value) ?? DEFAULT_SORT_STATE;
 }
 
-export function sortStateToOptionKey(state: SortState, type: ListingType): SortKey {
+export function sortStateToOptionKey(state: SortState, type: AssetType): SortKey {
   const options = getSortOptionsForType(type);
   const requestedKey = SortKey.fromState(state);
+  const defaultKey = SortKey.fromState(DEFAULT_SORT_STATE);
+  const defaultOption =
+    options.find((opt) => SortKey.equals(opt.value, defaultKey)) ??
+    options[0] ??
+    SORT_OPTIONS[0];
   const option =
     options.find((opt) => SortKey.equals(opt.value, requestedKey)) ??
     options.find((opt) => opt.sort.field === state.field) ??
-    options[0] ??
-    SORT_OPTIONS[0];
+    defaultOption;
 
   return option.value;
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -8,20 +8,21 @@ import { CardSkeletonGrid } from "@/components/shared/CardSkeletonGrid";
 import { ErrorBanner } from "@/components/shared/ErrorBanner";
 import { Button } from "@/components/ui/button";
 import { Download, Compass, ArrowRight } from "lucide-react";
+import type { AssetType } from "@/lib/asset-types";
 
 export function HomePage() {
   const { mods, maps, loading, error } = useRegistryStore();
   const { installedMods, installedMaps } = useInstalledStore();
 
   const installedItems = useMemo(() => {
-    const items: Array<{ type: "mods" | "maps"; item: typeof mods[number] | typeof maps[number]; installedVersion: string }> = [];
+    const items: Array<{ type: AssetType; item: typeof mods[number] | typeof maps[number]; installedVersion: string }> = [];
     for (const installed of installedMods) {
       const manifest = mods.find((m) => m.id === installed.id);
-      if (manifest) items.push({ type: "mods", item: manifest, installedVersion: installed.version });
+      if (manifest) items.push({ type: "mod", item: manifest, installedVersion: installed.version });
     }
     for (const installed of installedMaps) {
       const manifest = maps.find((m) => m.id === installed.id);
-      if (manifest) items.push({ type: "maps", item: manifest, installedVersion: installed.version });
+      if (manifest) items.push({ type: "map", item: manifest, installedVersion: installed.version });
     }
     return items;
   }, [mods, maps, installedMods, installedMaps]);
@@ -34,12 +35,12 @@ export function HomePage() {
   }, [installedMods, installedMaps]);
 
   const discoverItems = useMemo(() => {
-    const items: Array<{ type: "mods" | "maps"; item: typeof mods[number] | typeof maps[number] }> = [];
+    const items: Array<{ type: AssetType; item: typeof mods[number] | typeof maps[number] }> = [];
     // Interleave mods and maps for variety, excluding already-installed items
     const maxLen = Math.max(mods.length, maps.length);
     for (let i = 0; i < maxLen && items.length < 8; i++) {
-      if (i < mods.length && items.length < 8 && !installedIds.has(mods[i].id)) items.push({ type: "mods", item: mods[i] });
-      if (i < maps.length && items.length < 8 && !installedIds.has(maps[i].id)) items.push({ type: "maps", item: maps[i] });
+      if (i < mods.length && items.length < 8 && !installedIds.has(mods[i].id)) items.push({ type: "mod", item: mods[i] });
+      if (i < maps.length && items.length < 8 && !installedIds.has(maps[i].id)) items.push({ type: "map", item: maps[i] });
     }
     return items;
   }, [mods, maps, installedIds]);

--- a/frontend/src/pages/ProjectPage.tsx
+++ b/frontend/src/pages/ProjectPage.tsx
@@ -20,19 +20,21 @@ import { VersionsTable } from "@/components/project/VersionsTable";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { Separator } from "@/components/ui/separator";
 import { CircleAlert } from "lucide-react";
+import { listingPathToAssetType } from "@/lib/asset-types";
 
 export function ProjectPage() {
   const [, params] = useRoute("/project/:type/:id");
   const mods = useRegistryStore((s) => s.mods);
   const maps = useRegistryStore((s) => s.maps);
 
-  const type = params?.type as "mods" | "maps" | undefined;
+  const routeType = params?.type;
+  const type = routeType ? listingPathToAssetType(routeType) : undefined;
   const id = params?.id;
 
   const item =
-    type === "mods"
+    type === "mod"
       ? mods.find((m) => m.id === id)
-      : type === "maps"
+      : type === "map"
         ? maps.find((m) => m.id === id)
         : undefined;
 
@@ -46,7 +48,7 @@ export function ProjectPage() {
   }, []);
 
   useEffect(() => {
-    if (!item) return;
+    if (!item || !type) return;
     const source = item.update.type === "github" ? item.update.repo : item.update.url;
     if (!source) {
       setVersionsLoading(false);
@@ -60,24 +62,23 @@ export function ProjectPage() {
       .then(async (v) => {
         if (cancelled) return;
         const all = v || [];
-        const visibleVersions = type === "mods" ? all.filter((ver) => ver.manifest) : all;
+        const visibleVersions = type === "mod" ? all.filter((ver) => ver.manifest) : all;
 
         let mergedVersions = withZeroDownloads(visibleVersions);
-        const assetType = type === "mods" ? "mod" : "map";
         try {
-          const countsResult = await GetAssetDownloadCounts(assetType, item.id);
+          const countsResult = await GetAssetDownloadCounts(type, item.id);
           if (countsResult.status === "success") {
             mergedVersions = mergeVersionDownloads(
               visibleVersions,
               countsResult.counts ?? {},
-              `${assetType}:${item.id}`,
+              `${type}:${item.id}`,
             );
           } else {
-            console.warn(`[${assetType}:${item.id}] Failed to fetch download counts: ${countsResult.message}`);
+            console.warn(`[${type}:${item.id}] Failed to fetch download counts: ${countsResult.message}`);
           }
         } catch (countErr) {
           const message = countErr instanceof Error ? countErr.message : String(countErr);
-          console.warn(`[${assetType}:${item.id}] Failed to fetch download counts: ${message}`);
+          console.warn(`[${type}:${item.id}] Failed to fetch download counts: ${message}`);
         }
 
         if (!cancelled) {

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -12,6 +12,7 @@ import { SortSelect } from "@/components/search/SortSelect";
 import { SearchX } from "lucide-react";
 import { useInstalledStore } from "@/stores/installed-store";
 import { createRandomSeed } from "@/stores/search-store";
+import type { AssetType } from "@/lib/asset-types";
 
 export function SearchPage() {
   const {
@@ -26,7 +27,7 @@ export function SearchPage() {
   const { installedMaps, installedMods } = useInstalledStore();
   const installedItems = useMemo(() => {
     const items: Array<{
-      type: "mods" | "maps";
+      type: AssetType;
       item: (typeof mods)[number] | (typeof maps)[number];
       installedVersion: string;
     }> = [];
@@ -34,7 +35,7 @@ export function SearchPage() {
       const manifest = mods.find((m) => m.id === installed.id);
       if (manifest)
         items.push({
-          type: "mods",
+          type: "mod",
           item: manifest,
           installedVersion: installed.version,
         });
@@ -43,7 +44,7 @@ export function SearchPage() {
       const manifest = maps.find((m) => m.id === installed.id);
       if (manifest)
         items.push({
-          type: "maps",
+          type: "map",
           item: manifest,
           installedVersion: installed.version,
         });
@@ -180,7 +181,7 @@ export function SearchPage() {
                         ?.installedVersion
                     }
                     totalDownloads={
-                      itemType === "mods"
+                      itemType === "mod"
                         ? (modDownloadTotals[item.id] ?? 0)
                         : (mapDownloadTotals[item.id] ?? 0)
                     }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { useConfigStore } from "@/stores/config-store";
 import { useProfileStore } from "@/stores/profile-store";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -40,7 +46,9 @@ export function SettingsPage() {
   const resetProfile = useProfileStore((s) => s.resetProfile);
   const updateUIPreferences = useProfileStore((s) => s.updateUIPreferences);
 
-  const [confirmAction, setConfirmAction] = useState<"config" | "profile" | null>(null);
+  const [confirmAction, setConfirmAction] = useState<
+    "config" | "profile" | null
+  >(null);
 
   const handleUpdatesCheck = async () => {
     try {
@@ -49,23 +57,32 @@ export function SettingsPage() {
     } catch (error: any) {
       toast.error("Failed to check for updates.");
     }
-  }
+  };
 
   const handleChangeUpdatesOnLaunch = async () => {
     try {
       const newValue = !config?.checkForUpdatesOnLaunch;
       await updateCheckForUpdatesOnLaunch(newValue);
-      toast.success(`Check for updates on launch ${newValue ? "enabled" : "disabled"}.`);
+      toast.success(
+        `Check for updates on launch ${newValue ? "enabled" : "disabled"}.`,
+      );
     } catch {
       toast.error("Failed to update check for updates on launch setting.");
     }
   };
 
   const handleThemeChange = async (theme: string) => {
-    if (!profile || !THEME_OPTIONS.includes(theme as (typeof THEME_OPTIONS)[number])) return;
+    if (
+      !profile ||
+      !THEME_OPTIONS.includes(theme as (typeof THEME_OPTIONS)[number])
+    )
+      return;
 
     try {
-      await updateUIPreferences(theme, profile.uiPreferences?.defaultPerPage ?? 12);
+      await updateUIPreferences(
+        theme,
+        profile.uiPreferences?.defaultPerPage ?? 12,
+      );
       toast.success("Theme updated.");
     } catch {
       toast.error("Failed to update theme.");
@@ -76,7 +93,10 @@ export function SettingsPage() {
     if (!profile) return;
     const parsed = Number.parseInt(value, 10);
 
-    if (!PAGE_SIZE_OPTIONS.includes(parsed as (typeof PAGE_SIZE_OPTIONS)[number])) return;
+    if (
+      !PAGE_SIZE_OPTIONS.includes(parsed as (typeof PAGE_SIZE_OPTIONS)[number])
+    )
+      return;
 
     try {
       await updateUIPreferences(profile.uiPreferences?.theme ?? "dark", parsed);
@@ -131,7 +151,9 @@ export function SettingsPage() {
       <Card>
         <CardHeader>
           <CardTitle>Game Paths</CardTitle>
-          <CardDescription>Configure paths to your Metro Maker data and game executable.</CardDescription>
+          <CardDescription>
+            Configure paths to your Metro Maker data and game executable.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex items-center justify-between gap-4">
@@ -145,10 +167,26 @@ export function SettingsPage() {
               </div>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-              <Badge variant={validation?.metroMakerDataPathValid ? "default" : config?.metroMakerDataPath ? "destructive" : "outline"}>
-                {validation?.metroMakerDataPathValid ? "Valid" : config?.metroMakerDataPath ? "Invalid" : "Not Set"}
+              <Badge
+                variant={
+                  validation?.metroMakerDataPathValid
+                    ? "default"
+                    : config?.metroMakerDataPath
+                      ? "destructive"
+                      : "outline"
+                }
+              >
+                {validation?.metroMakerDataPathValid
+                  ? "Valid"
+                  : config?.metroMakerDataPath
+                    ? "Invalid"
+                    : "Not Set"}
               </Badge>
-              <Button variant="outline" size="sm" onClick={handleChangeDataFolder}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleChangeDataFolder}
+              >
                 Change
               </Button>
             </div>
@@ -165,10 +203,26 @@ export function SettingsPage() {
               </div>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-              <Badge variant={validation?.executablePathValid ? "default" : config?.executablePath ? "destructive" : "outline"}>
-                {validation?.executablePathValid ? "Valid" : config?.executablePath ? "Invalid" : "Not Set"}
+              <Badge
+                variant={
+                  validation?.executablePathValid
+                    ? "default"
+                    : config?.executablePath
+                      ? "destructive"
+                      : "outline"
+                }
+              >
+                {validation?.executablePathValid
+                  ? "Valid"
+                  : config?.executablePath
+                    ? "Invalid"
+                    : "Not Set"}
               </Badge>
-              <Button variant="outline" size="sm" onClick={handleChangeExecutable}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleChangeExecutable}
+              >
                 Change
               </Button>
             </div>
@@ -179,13 +233,18 @@ export function SettingsPage() {
       <Card>
         <CardHeader>
           <CardTitle>Preferences</CardTitle>
-          <CardDescription>Display and behavior preferences from your profile.</CardDescription>
+          <CardDescription>
+            Display and behavior preferences from your profile.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex items-center justify-between">
             <label className="text-sm font-medium">Theme</label>
-            <Select value={profile?.uiPreferences?.theme ?? "system"} onValueChange={handleThemeChange}>
-              <SelectTrigger className="w-[140px]">
+            <Select
+              value={profile?.uiPreferences?.theme ?? "system"}
+              onValueChange={handleThemeChange}
+            >
+              <SelectTrigger className="w-35">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -198,8 +257,11 @@ export function SettingsPage() {
 
           <div className="flex items-center justify-between">
             <label className="text-sm font-medium">Default Per Page</label>
-            <Select value={String(profile?.uiPreferences?.defaultPerPage ?? 12)} onValueChange={handleDefaultPerPageChange}>
-              <SelectTrigger className="w-[140px]">
+            <Select
+              value={String(profile?.uiPreferences?.defaultPerPage ?? 12)}
+              onValueChange={handleDefaultPerPageChange}
+            >
+              <SelectTrigger className="w-35">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -211,10 +273,21 @@ export function SettingsPage() {
           </div>
 
           <div className="flex items-center justify-between">
-            <label className="text-sm font-medium">Check For Updates On Launch</label>
+            <label className="text-sm font-medium">
+              Check For Updates On Launch
+            </label>
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={handleChangeUpdatesOnLaunch}>{config?.checkForUpdatesOnLaunch ? "Disable" : "Enable"}</Button>
-              <Button variant="outline" size="sm" onClick={handleUpdatesCheck}><RefreshCw/>Check For Updates</Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleChangeUpdatesOnLaunch}
+              >
+                {config?.checkForUpdatesOnLaunch ? "Disable" : "Enable"}
+              </Button>
+              <Button variant="outline" size="sm" onClick={handleUpdatesCheck}>
+                <RefreshCw />
+                Check For Updates
+              </Button>
             </div>
           </div>
         </CardContent>
@@ -223,31 +296,48 @@ export function SettingsPage() {
       <Card className="border-destructive/50">
         <CardHeader>
           <CardTitle className="text-destructive">Danger Zone</CardTitle>
-          <CardDescription>Irreversible actions that reset your data.</CardDescription>
+          <CardDescription>
+            Irreversible actions that reset your data.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium">Reset Configuration</p>
-              <p className="text-xs text-muted-foreground">Clear all saved paths and settings.</p>
+              <p className="text-xs text-muted-foreground">
+                Clear all saved paths and settings.
+              </p>
             </div>
-            <Button variant="destructive" size="sm" onClick={() => setConfirmAction("config")}>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setConfirmAction("config")}
+            >
               Reset Config
             </Button>
           </div>
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium">Reset Profile</p>
-              <p className="text-xs text-muted-foreground">Clear your profile and preferences.</p>
+              <p className="text-xs text-muted-foreground">
+                Clear your profile and preferences.
+              </p>
             </div>
-            <Button variant="destructive" size="sm" onClick={() => setConfirmAction("profile")}>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setConfirmAction("profile")}
+            >
               Reset Profile
             </Button>
           </div>
         </CardContent>
       </Card>
 
-      <Dialog open={confirmAction !== null} onOpenChange={(open) => !open && setConfirmAction(null)}>
+      <Dialog
+        open={confirmAction !== null}
+        onOpenChange={(open) => !open && setConfirmAction(null)}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">

--- a/frontend/src/stores/installed-store.test.ts
+++ b/frontend/src/stores/installed-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInstalledStore } from "./installed-store";
 import { activeProfileResultSuccess, updateSubscriptionsError, updateSubscriptionsSuccess, updateSubscriptionsWarn } from "@/test/helpers/profileMutationFixtures";
+import type { AssetType } from "@/lib/asset-types";
 
 const {
   mockGetInstalledMods,
@@ -28,7 +29,7 @@ type ProfilesRequest = {
   profileId: string;
   action: "subscribe" | "unsubscribe";
   assetId: string;
-  assetType: "map" | "mod";
+  assetType: AssetType;
   version: string;
 };
 

--- a/frontend/src/stores/installed-store.ts
+++ b/frontend/src/stores/installed-store.ts
@@ -3,6 +3,7 @@ import { types } from '../../wailsjs/go/models';
 import { GetInstalledMods, GetInstalledMaps } from '../../wailsjs/go/registry/Registry';
 import { GetActiveProfile, UpdateSubscriptions } from '../../wailsjs/go/profiles/UserProfiles';
 import { useDownloadQueueStore } from './download-queue-store';
+import type { AssetType } from "@/lib/asset-types";
 
 interface InstalledState {
   installedMods: types.InstalledModInfo[];
@@ -28,7 +29,7 @@ export const useInstalledStore = create<InstalledState>((set, get) => {
   const applySubscriptionMutation = async (
     id: string,
     version: string,
-    assetType: "map" | "mod",
+    assetType: AssetType,
     action: "subscribe" | "unsubscribe",
   ) => {
     const activeProfileResult = await GetActiveProfile();

--- a/frontend/src/stores/profile-store.ts
+++ b/frontend/src/stores/profile-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { types } from '../../wailsjs/go/models';
 import { GetActiveProfile, UpdateSubscriptions, ResetUserProfiles, UpdateUIPreferences } from '../../wailsjs/go/profiles/UserProfiles';
+import type { AssetType } from "@/lib/asset-types";
 
 interface ProfileState {
   profile: types.UserProfile | null;
@@ -9,12 +10,12 @@ interface ProfileState {
   initialized: boolean;
 
   initialize: () => Promise<void>;
-  isSubscribed: (type: "mods" | "maps", id: string) => boolean;
+  isSubscribed: (type: AssetType, id: string) => boolean;
   theme: () => string;
   defaultPerPage: () => number;
   updateUIPreferences: (theme: string, defaultPerPage: number) => Promise<void>;
   updateSubscription: (
-    type: "mods" | "maps",
+    type: AssetType,
     id: string,
     action: "subscribe" | "unsubscribe",
     version: string,
@@ -39,10 +40,10 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
     }
   },
 
-  isSubscribed: (type: "mods" | "maps", id: string) => {
+  isSubscribed: (type: AssetType, id: string) => {
     const profile = get().profile;
     if (!profile?.subscriptions) return false;
-    const subs = type === "mods" ? profile.subscriptions.mods : profile.subscriptions.maps;
+    const subs = type === "mod" ? profile.subscriptions.mods : profile.subscriptions.maps;
     return subs ? id in subs : false;
   },
 
@@ -65,10 +66,9 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
     }
     const freshProfile = activeResult.profile;
 
-    const assetType = type === "mods" ? "mod" : "map";
     const request = new types.UpdateSubscriptionsRequest({
       profileId: freshProfile.id,
-      assets: { [id]: new types.SubscriptionUpdateItem({ version, type: assetType }) },
+      assets: { [id]: new types.SubscriptionUpdateItem({ version, type }) },
       action,
       forceSync: true,
     });

--- a/frontend/src/stores/registry-store.ts
+++ b/frontend/src/stores/registry-store.ts
@@ -6,6 +6,7 @@ import {
   GetMods,
   Refresh,
 } from "../../wailsjs/go/registry/Registry";
+import { ASSET_TYPES, type AssetType } from "@/lib/asset-types";
 import { toCumulativeDownloadTotals } from "@/lib/download-totals";
 
 interface RegistryState {
@@ -23,7 +24,13 @@ interface RegistryState {
   refresh: () => Promise<void>;
 }
 
-let requests: Promise<void> | null = null;
+let downloadTotalsRequest: Promise<void> | null = null;
+
+function emptyRecordByAssetType<T>(factory: () => T): Record<AssetType, T> {
+  return Object.fromEntries(
+    ASSET_TYPES.map((assetType) => [assetType, factory()])
+  ) as Record<AssetType, T>;
+}
 
 export const useRegistryStore = create<RegistryState>((set, get) => ({
   mods: [],
@@ -36,46 +43,37 @@ export const useRegistryStore = create<RegistryState>((set, get) => ({
   error: null,
   initialized: false,
 
-  // Ensure that download totals are loaded on Browse page, but only fetch them when needed
   ensureDownloadTotals: async () => {
     if (get().downloadTotalsLoaded) return;
-    if (requests) {
-      await requests;
+    if (downloadTotalsRequest) {
+      await downloadTotalsRequest;
       return;
     }
 
-    requests = (async () => {
+    downloadTotalsRequest = (async () => {
       try {
-        // Request download counts for each asset type in parallel
-        const [modCountsResult, mapCountsResult] = await Promise.all([
-          GetDownloadCountsByAssetType("mod"),
-          GetDownloadCountsByAssetType("map"),
-        ]);
+        const results = await Promise.all(
+          ASSET_TYPES.map((assetType) => GetDownloadCountsByAssetType(assetType))
+        );
 
-        // TODO: Make this iterate over all asset types in the future
-        const modDownloadTotals =
-          modCountsResult.status === "success"
-            ? toCumulativeDownloadTotals(modCountsResult.counts)
-            : {};
-        if (modCountsResult.status !== "success") {
-          console.warn(
-            `[downloads:mod] Failed to load download counts: ${modCountsResult.message}`
-          );
-        }
+        const totalsByAsset = emptyRecordByAssetType<Record<string, number>>(
+          () => ({})
+        );
 
-        const mapDownloadTotals =
-          mapCountsResult.status === "success"
-            ? toCumulativeDownloadTotals(mapCountsResult.counts)
-            : {};
-        if (mapCountsResult.status !== "success") {
+        results.forEach((result, index) => {
+          const assetType = ASSET_TYPES[index];
+          if (result.status === "success") {
+            totalsByAsset[assetType] = toCumulativeDownloadTotals(result.counts);
+            return;
+          }
           console.warn(
-            `[downloads:map] Failed to load download counts: ${mapCountsResult.message}`
+            `[downloads:${assetType}] Failed to load download counts: ${result.message}`
           );
-        }
+        });
 
         set({
-          modDownloadTotals,
-          mapDownloadTotals,
+          modDownloadTotals: totalsByAsset.mod,
+          mapDownloadTotals: totalsByAsset.map,
           downloadTotalsLoaded: true,
         });
       } catch (err) {
@@ -87,14 +85,13 @@ export const useRegistryStore = create<RegistryState>((set, get) => ({
           downloadTotalsLoaded: true,
         });
       } finally {
-        requests = null;
+        downloadTotalsRequest = null;
       }
     })();
 
-    await requests;
+    await downloadTotalsRequest;
   },
 
-  // On initial load, fetch mod and map manifests
   initialize: async () => {
     if (get().initialized) return;
     set({ loading: true, error: null });
@@ -111,7 +108,6 @@ export const useRegistryStore = create<RegistryState>((set, get) => ({
     }
   },
 
-  // On refresh, re-fetch mod and map manifests and reset download totals so they will be re-fetched on demand with ensureDownloadTotals (to avoid stale data)
   refresh: async () => {
     set({ refreshing: true, error: null });
     try {

--- a/frontend/src/stores/search-store.ts
+++ b/frontend/src/stores/search-store.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
+import type { AssetType } from "@/lib/asset-types";
 import { DEFAULT_SORT_STATE, type PerPage, type SortState } from "@/lib/constants";
 
-export type TypeFilter = "mods" | "maps";
+export type TypeFilter = AssetType;
 
 export interface SearchFilterState {
   query: string;
@@ -35,7 +36,7 @@ export function createRandomSeed(): number {
 
 const defaultSearchFilters: SearchFilterState = {
   query: "",
-  type: "maps",
+  type: "map",
   sort: DEFAULT_SORT_STATE,
   randomSeed: createRandomSeed(),
   perPage: 12,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -255,6 +255,7 @@ export namespace types {
 	    name: string;
 	    author: string;
 	    github_id: number;
+	    last_updated: number;
 	    city_code: string;
 	    country: string;
 	    location: string;
@@ -280,6 +281,7 @@ export namespace types {
 	        this.name = source["name"];
 	        this.author = source["author"];
 	        this.github_id = source["github_id"];
+	        this.last_updated = source["last_updated"];
 	        this.city_code = source["city_code"];
 	        this.country = source["country"];
 	        this.location = source["location"];
@@ -319,6 +321,7 @@ export namespace types {
 	    name: string;
 	    author: string;
 	    github_id: number;
+	    last_updated: number;
 	    description: string;
 	    tags: string[];
 	    gallery: string[];
@@ -336,6 +339,7 @@ export namespace types {
 	        this.name = source["name"];
 	        this.author = source["author"];
 	        this.github_id = source["github_id"];
+	        this.last_updated = source["last_updated"];
 	        this.description = source["description"];
 	        this.tags = source["tags"];
 	        this.gallery = source["gallery"];

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -16,6 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testRegistryLogSink struct{}
+
+func (testRegistryLogSink) Info(string, ...any)         {}
+func (testRegistryLogSink) Warn(string, ...any)         {}
+func (testRegistryLogSink) Error(string, error, ...any) {}
+
 func newTestDownloader() *Downloader {
 	return &Downloader{}
 }
@@ -288,7 +294,7 @@ func TestEnqueueOperationRunsSequentially(t *testing.T) {
 }
 
 func TestInstallMapForExistingIsNoOp(t *testing.T) {
-	reg := registry.NewRegistry(nil)
+	reg := registry.NewRegistry(testRegistryLogSink{})
 	expectedConfig := types.ConfigData{
 		Code:        "ABC",
 		Name:        "Map A",
@@ -311,7 +317,7 @@ func TestInstallMapForExistingIsNoOp(t *testing.T) {
 }
 
 func TestInstallModPreservesNoOpThroughStateMutation(t *testing.T) {
-	reg := registry.NewRegistry(nil)
+	reg := registry.NewRegistry(testRegistryLogSink{})
 	d := &Downloader{
 		Registry: reg,
 		Config:   config.NewConfig(),

--- a/internal/registry/download_counts.go
+++ b/internal/registry/download_counts.go
@@ -11,9 +11,7 @@ import (
 func (r *Registry) GetAssetDownloadCounts(assetType types.AssetType, assetID string) types.AssetDownloadCountsResponse {
 	if !types.IsValidAssetType(assetType) {
 		// This is validation of frontend input. If this occurs, it's an implementation error
-		if r.logger != nil {
-			r.logger.Warn("GetAssetDownloadCounts rejected invalid asset type", "asset_type", assetType, "asset_id", assetID)
-		}
+		r.logger.Warn("GetAssetDownloadCounts rejected invalid asset type", "asset_type", assetType, "asset_id", assetID)
 		return types.AssetDownloadCountsResponse{
 			GenericResponse: types.ErrorResponse(fmt.Sprintf("invalid asset type %q: valid types are %q and %q", assetType, types.AssetTypeMap, types.AssetTypeMod)),
 			AssetType:       string(assetType),
@@ -25,9 +23,7 @@ func (r *Registry) GetAssetDownloadCounts(assetType types.AssetType, assetID str
 	countsByAssetID := r.downloadCounts[assetType]
 	countsByAssetID = utils.OrEmptyNestedMap(countsByAssetID)
 	assetCounts := utils.CloneMap(countsByAssetID[assetID])
-	if r.logger != nil {
-		r.logger.Info("Fetched asset download counts", "asset_type", assetType, "asset_id", assetID, "version_count", len(assetCounts), "counts", assetCounts)
-	}
+	r.logger.Info("Fetched asset download counts", "asset_type", assetType, "asset_id", assetID, "version_count", len(assetCounts), "counts", assetCounts)
 
 	return types.AssetDownloadCountsResponse{
 		GenericResponse: types.SuccessResponse("Asset download counts loaded"),
@@ -41,9 +37,7 @@ func (r *Registry) GetAssetDownloadCounts(assetType types.AssetType, assetID str
 func (r *Registry) GetDownloadCountsByAssetType(assetType types.AssetType) types.DownloadCountsByAssetTypeResponse {
 	if !types.IsValidAssetType(assetType) {
 		// This is validation of frontend input. If this occurs, it's an implementation error
-		if r.logger != nil {
-			r.logger.Warn("GetDownloadCountsByAssetType rejected invalid asset type", "asset_type", assetType)
-		}
+		r.logger.Warn("GetDownloadCountsByAssetType rejected invalid asset type", "asset_type", assetType)
 		return types.DownloadCountsByAssetTypeResponse{
 			GenericResponse: types.ErrorResponse(fmt.Sprintf("invalid asset type %q: valid types are %q and %q", assetType, types.AssetTypeMap, types.AssetTypeMod)),
 			AssetType:       string(assetType),
@@ -53,9 +47,7 @@ func (r *Registry) GetDownloadCountsByAssetType(assetType types.AssetType) types
 
 	countsByAssetID := r.downloadCounts[assetType]
 	countsByAssetID = utils.OrEmptyNestedMap(countsByAssetID)
-	if r.logger != nil {
-		r.logger.Info("Fetched download counts by asset type", "asset_type", assetType, "asset_count", len(countsByAssetID))
-	}
+	r.logger.Info("Fetched download counts by asset type", "asset_type", assetType, "asset_count", len(countsByAssetID))
 
 	return types.DownloadCountsByAssetTypeResponse{
 		GenericResponse: types.SuccessResponse("Download counts loaded"),

--- a/internal/registry/download_counts_test.go
+++ b/internal/registry/download_counts_test.go
@@ -33,7 +33,7 @@ func loadedRegistryWithDownloads(t *testing.T) *Registry {
 		},
 	})
 
-	reg := NewRegistry(nil)
+	reg := NewRegistry(testLogSink{})
 	require.NoError(t, reg.fetchFromDisk())
 	return reg
 }

--- a/internal/registry/last_updated.go
+++ b/internal/registry/last_updated.go
@@ -1,0 +1,207 @@
+package registry
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"railyard/internal/types"
+)
+
+const lastUpdatedWorkerLimit = 6
+
+type lastUpdatedArgs struct {
+	id         string
+	updateType string
+	source     string
+}
+
+func (r *Registry) loadLastUpdated(
+	mods []types.ModManifest,
+	maps []types.MapManifest,
+) (map[string]int64, map[string]int64) {
+	r.logger.Info(
+		"Resolving last updated metadata",
+		"mod_count",
+		len(mods),
+		"map_count",
+		len(maps),
+	)
+
+	mapSources := getLastUpdatedArgs(
+		maps,
+		func(manifest types.MapManifest) string { return manifest.ID },
+		func(manifest types.MapManifest) types.UpdateConfig { return manifest.Update },
+	)
+	modSources := getLastUpdatedArgs(
+		mods,
+		func(manifest types.ModManifest) string { return manifest.ID },
+		func(manifest types.ModManifest) types.UpdateConfig { return manifest.Update },
+	)
+
+	mapEntries, mapWarnings := r.resolveLastUpdated(mapSources)
+	modEntries, modWarnings := r.resolveLastUpdated(modSources)
+
+	if len(mapWarnings) > 0 {
+		r.logger.Warn("Last updated metadata resolved with warnings", "asset_type", types.AssetTypeMap, "warning_count", len(mapWarnings))
+	}
+	if len(modWarnings) > 0 {
+		r.logger.Warn("Last updated metadata resolved with warnings", "asset_type", types.AssetTypeMod, "warning_count", len(modWarnings))
+	}
+	r.logger.Info(
+		"Resolved last updated metadata",
+		"resolved_mods",
+		len(modEntries),
+		"resolved_maps",
+		len(mapEntries),
+	)
+
+	return modEntries, mapEntries
+}
+
+func updateManifestLastUpdated(
+	mods []types.ModManifest,
+	maps []types.MapManifest,
+	modLastUpdated map[string]int64,
+	mapLastUpdated map[string]int64,
+) {
+	for i := range mods {
+		mods[i].LastUpdated = modLastUpdated[mods[i].ID]
+	}
+	for i := range maps {
+		maps[i].LastUpdated = mapLastUpdated[maps[i].ID]
+	}
+}
+
+// resolveLastUpdated fetches version information for each source in parallel, returning a map of the latest update timestamp for each asset ID.
+func (r *Registry) resolveLastUpdated(
+	sources []lastUpdatedArgs,
+) (map[string]int64, []error) {
+	results := make(map[string]int64, len(sources))
+	warnings := make([]error, 0)
+
+	if len(sources) == 0 {
+		return results, warnings
+	}
+
+	workerLimit := lastUpdatedWorkerLimit
+	if len(sources) < workerLimit {
+		workerLimit = len(sources)
+	}
+	sem := make(chan struct{}, workerLimit)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, source := range sources {
+		current := source
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			versions, err := r.GetVersions(current.updateType, current.source)
+			if err != nil {
+				r.logger.Warn("Failed to fetch versions for last updated", "asset_id", current.id, "update_type", current.updateType, "source", current.source, "error", err)
+				mu.Lock()
+				warnings = append(warnings, fmt.Errorf("failed to fetch versions for %q: %w", current.id, err))
+				results[current.id] = 0 // Default to epoch start if we can't fetch version
+				mu.Unlock()
+				return
+			}
+
+			latest, err := determineLatestTimestamp(r.logger, versions, current.updateType)
+			if err != nil {
+				r.logger.Warn("Failed to parse version dates for last updated", "asset_id", current.id, "version_count", len(versions), "error", err)
+				mu.Lock()
+				warnings = append(warnings, fmt.Errorf("failed to resolve latest update for %q: %w", current.id, err))
+				results[current.id] = 0 // Default to epoch start if we can't parse version dates
+				mu.Unlock()
+				return
+			}
+
+			mu.Lock()
+			results[current.id] = latest
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+	return results, warnings
+}
+
+// getLastUpdatedArgs retrieves the Source and UpdateType for a list of manifests, converting each into the lastUpdatedArgs function input struct.
+func getLastUpdatedArgs[T any](
+	manifests []T,
+	idFn func(manifest T) string,
+	updateFn func(manifest T) types.UpdateConfig,
+) []lastUpdatedArgs {
+	sources := make([]lastUpdatedArgs, 0, len(manifests))
+	for _, manifest := range manifests {
+		id := idFn(manifest)
+		update := updateFn(manifest)
+		updateType := update.Type
+		source := update.Source()
+
+		sources = append(sources, lastUpdatedArgs{
+			id:         id,
+			updateType: updateType,
+			source:     source,
+		})
+	}
+	return sources
+}
+
+// determineLatestTimestamp iterates through a list of versions to find the most recent stable release timestamp, falling back to a prerelease timestamp if no stable version is available.
+func determineLatestTimestamp(logger logSink, versions []types.VersionInfo, updateType string) (int64, error) {
+	const unset = int64(math.MinInt64)
+	bestStable := unset
+	bestAny := unset
+
+	for _, version := range versions {
+		timestamp, ok := parseVersionDate(version.Date, updateType)
+		if !ok {
+			continue
+		}
+
+		if timestamp > bestAny {
+			bestAny = timestamp
+		}
+		// If the version is a release (not a prerelease), consider it for the best stable timestamp
+		if !version.Prerelease && timestamp > bestStable {
+			bestStable = timestamp
+		}
+	}
+
+	if bestStable != unset {
+		return bestStable, nil
+	}
+	if bestAny != unset {
+		logger.Warn("No stable version found, using latest available version", "timestamp", bestAny)
+		return bestAny, nil
+	}
+	return 0, fmt.Errorf("no parseable version dates")
+}
+
+func parseVersionDate(value, updateType string) (int64, bool) {
+	if value == "" {
+		return 0, false
+	}
+
+	var layout string
+	switch updateType {
+	case "github": // GitHub updates provide full timestamps in RFC3339 format
+		layout = time.RFC3339
+	case "custom": // Custom URL updates only provide a date without a time component -- assume start of day UTC
+		layout = "2006-01-02"
+	default:
+		return 0, false
+	}
+
+	parsed, err := time.Parse(layout, value)
+	if err != nil {
+		return 0, false
+	}
+	return parsed.Unix(), true
+}

--- a/internal/registry/last_updated_test.go
+++ b/internal/registry/last_updated_test.go
@@ -1,0 +1,109 @@
+package registry
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"railyard/internal/testutil/registrytest"
+	"railyard/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mustUnix(t *testing.T, value string) int64 {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+	return parsed.Unix()
+}
+func TestResolveLastUpdated(t *testing.T) {
+	reg := NewRegistry(testLogSink{})
+	closeServer := registrytest.MockLastUpdatedServer(t, reg, []registrytest.LastUpdatedFixture{
+		{
+			AssetID:   "mod-a",
+			AssetType: types.AssetTypeMod,
+			Path:      "/updates/mod-a.json",
+			Versions: []types.CustomUpdateVersion{
+				{Version: "1.0.0", Date: "2025-01-01"},
+				{Version: "1.1.0", Date: "2025-02-01"},
+			},
+			Status: http.StatusOK,
+		},
+		{
+			AssetID:   "map-a",
+			AssetType: types.AssetTypeMap,
+			Path:      "/updates/map-a.json",
+			Versions: []types.CustomUpdateVersion{
+				{Version: "2.0.0", Date: "2025-03-01"},
+			},
+			Status: http.StatusOK,
+		},
+	})
+	defer closeServer()
+
+	modLastUpdated, mapLastUpdated := reg.loadLastUpdated(reg.mods, reg.maps)
+	updateManifestLastUpdated(reg.mods, reg.maps, modLastUpdated, mapLastUpdated)
+
+	require.Equal(t, mustUnix(t, "2025-02-01T00:00:00Z"), reg.mods[0].LastUpdated)
+	require.Equal(t, mustUnix(t, "2025-03-01T00:00:00Z"), reg.maps[0].LastUpdated)
+}
+
+func TestDetermineLatestTimestampWithStable(t *testing.T) {
+	versions := []types.VersionInfo{
+		{Version: "2.0.0", Date: "2026-01-02T00:00:00Z", Prerelease: true},
+		{Version: "1.5.0", Date: "2026-01-01T00:00:00Z", Prerelease: false},
+	}
+
+	latest, err := determineLatestTimestamp(testLogSink{}, versions, "github")
+	require.NoError(t, err)
+	require.Equal(t, mustUnix(t, "2026-01-01T00:00:00Z"), latest)
+}
+
+func TestDetermineLatestTimestampFallbackToPreRelease(t *testing.T) {
+	versions := []types.VersionInfo{
+		{Version: "1.0.0", Date: "2026-01-01T00:00:00Z", Prerelease: true},
+		{Version: "1.0.1", Date: "2026-01-03T00:00:00Z", Prerelease: true},
+	}
+
+	latest, err := determineLatestTimestamp(testLogSink{}, versions, "github")
+	require.NoError(t, err)
+	require.Equal(t, mustUnix(t, "2026-01-03T00:00:00Z"), latest)
+}
+
+func TestDetermineLatestTimestampRejectsWrongLayout(t *testing.T) {
+	githubVersions := []types.VersionInfo{
+		{Version: "1.0.0", Date: "2026-01-01"},
+	}
+	_, githubErr := determineLatestTimestamp(testLogSink{}, githubVersions, "github")
+	require.Error(t, githubErr)
+
+	customVersions := []types.VersionInfo{
+		{Version: "1.0.0", Date: "2026-01-01T00:00:00Z"},
+	}
+	_, customErr := determineLatestTimestamp(testLogSink{}, customVersions, "custom")
+	require.Error(t, customErr)
+}
+
+func TestLoadLastUpdatedFallsBackToEpochOnFailures(t *testing.T) {
+	reg := NewRegistry(testLogSink{})
+	closeServer := registrytest.MockLastUpdatedServer(t, reg, []registrytest.LastUpdatedFixture{
+		{
+			AssetID:   "mod-bad",
+			AssetType: types.AssetTypeMod,
+			Path:      "/updates/mod-bad.json",
+			Status:    http.StatusInternalServerError,
+		},
+		{
+			AssetID:   "map-bad",
+			AssetType: types.AssetTypeMap,
+			Path:      "/updates/map-bad.json",
+			Status:    http.StatusInternalServerError,
+		},
+	})
+	defer closeServer()
+
+	modLastUpdated, mapLastUpdated := reg.loadLastUpdated(reg.mods, reg.maps)
+	require.Equal(t, int64(0), modLastUpdated["mod-bad"])
+	require.Equal(t, int64(0), mapLastUpdated["map-bad"])
+}

--- a/internal/registry/manifests.go
+++ b/internal/registry/manifests.go
@@ -40,6 +40,9 @@ func (r *Registry) fetchFromDisk() error {
 		return fmt.Errorf("failed to load installed maps from disk: %w", err)
 	}
 
+	modLastUpdated, mapLastUpdated := r.loadLastUpdated(mods, maps)
+	updateManifestLastUpdated(mods, maps, modLastUpdated, mapLastUpdated)
+
 	// Make updates only when all reads are successful to avoid partial registry updates
 	r.mods = mods
 	r.maps = maps

--- a/internal/registry/test_logger_test.go
+++ b/internal/registry/test_logger_test.go
@@ -1,0 +1,7 @@
+package registry
+
+type testLogSink struct{}
+
+func (testLogSink) Info(string, ...any)         {}
+func (testLogSink) Warn(string, ...any)         {}
+func (testLogSink) Error(string, error, ...any) {}

--- a/internal/registry/versions.go
+++ b/internal/registry/versions.go
@@ -88,6 +88,7 @@ func (r *Registry) getGitHubVersions(repo string) ([]types.VersionInfo, error) {
 		versions = append(versions, v)
 	}
 
+	versions = r.filterSemverVersions(versions, "github:"+repo)
 	// Fetch manifest.json assets in parallel to extract game_version
 	r.enrichGameVersions(versions)
 
@@ -181,5 +182,20 @@ func (r *Registry) getCustomVersions(updateURL string) ([]types.VersionInfo, err
 		})
 	}
 
-	return versions, nil
+	return r.filterSemverVersions(versions, "custom:"+updateURL), nil
+}
+
+func (r *Registry) filterSemverVersions(
+	versions []types.VersionInfo,
+	sourceLabel string,
+) []types.VersionInfo {
+	filtered := make([]types.VersionInfo, 0, len(versions))
+	for _, version := range versions {
+		if !types.IsValidSemverVersion(types.Version(version.Version)) {
+			r.logger.Warn("Skipping non-semver version", "version", version.Version, "source", sourceLabel)
+			continue
+		}
+		filtered = append(filtered, version)
+	}
+	return filtered
 }

--- a/internal/registry/versions_test.go
+++ b/internal/registry/versions_test.go
@@ -1,0 +1,26 @@
+package registry
+
+import (
+	"testing"
+
+	"railyard/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterSemverVersions(t *testing.T) {
+	reg := NewRegistry(testLogSink{})
+	filtered := reg.filterSemverVersions([]types.VersionInfo{
+		{Version: "1.2.3"},
+		{Version: "v2.3.4"},
+		{Version: "1.2"},
+		{Version: "1.2.3-beta.1"},
+		{Version: "1.2.3+build.1"},
+		{Version: "not-semver"},
+		{Version: ""},
+	}, "test")
+
+	require.Len(t, filtered, 2)
+	require.Equal(t, "1.2.3", filtered[0].Version)
+	require.Equal(t, "v2.3.4", filtered[1].Version)
+}

--- a/internal/testutil/registrytest/registry_last_updated_mock.go
+++ b/internal/testutil/registrytest/registry_last_updated_mock.go
@@ -1,0 +1,66 @@
+package registrytest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"railyard/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+type LastUpdatedFixture struct {
+	AssetID   string
+	AssetType types.AssetType
+	Path      string
+	Versions  []types.CustomUpdateVersion
+	Status    int
+}
+
+// MockLastUpdatedServer starts an HTTP server that serves custom update payloads
+// and wires the provided registry instance with matching manifests + test HTTP client.
+func MockLastUpdatedServer(t *testing.T, reg any, fixtures []LastUpdatedFixture) func() {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mods := make([]types.ModManifest, 0)
+	maps := make([]types.MapManifest, 0)
+
+	for _, fixture := range fixtures {
+		current := fixture
+		mux.HandleFunc(current.Path, func(w http.ResponseWriter, r *http.Request) {
+			if current.Status != 0 && current.Status != http.StatusOK {
+				http.Error(w, "failed", current.Status)
+				return
+			}
+
+			payload := types.CustomUpdateFile{
+				SchemaVersion: 1,
+				Versions:      current.Versions,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(payload))
+		})
+	}
+
+	server := httptest.NewServer(mux)
+
+	for _, fixture := range fixtures {
+		update := types.UpdateConfig{
+			Type: "custom",
+			URL:  server.URL + fixture.Path,
+		}
+		switch fixture.AssetType {
+		case types.AssetTypeMap:
+			maps = append(maps, types.MapManifest{ID: fixture.AssetID, Update: update})
+		case types.AssetTypeMod:
+			mods = append(mods, types.ModManifest{ID: fixture.AssetID, Update: update})
+		}
+	}
+
+	SetUnexportedField(t, reg, "httpClient", server.Client())
+	SetManifestsForTest(t, reg, mods, maps)
+	return server.Close
+}

--- a/internal/types/registry_types.go
+++ b/internal/types/registry_types.go
@@ -23,6 +23,7 @@ type ModManifest struct {
 	Name          string       `json:"name"`
 	Author        string       `json:"author"`
 	GithubID      int          `json:"github_id"`
+	LastUpdated   int64        `json:"last_updated"`
 	Description   string       `json:"description"`
 	Tags          []string     `json:"tags"`
 	Gallery       []string     `json:"gallery"`
@@ -56,6 +57,7 @@ type MapManifest struct {
 	Name          string       `json:"name"`
 	Author        string       `json:"author"`
 	GithubID      int          `json:"github_id"`
+	LastUpdated   int64        `json:"last_updated"`
 	CityCode      string       `json:"city_code"`
 	Country       string       `json:"country"`
 	Location      string       `json:"location"`


### PR DESCRIPTION
Update `Registry` to enrich the Mod/MapManifest classes with timestamp data on initialization and on every refresh
 - Custom URLs are pure dates..
 - Regular Updates from Github are in RFC3339 format
Update FE to have a new Last Updated sort dimension
Unify frontend types (`mods`/`maps`/`mod`/`map`) into AssetType to mirror BE

<img width="1007" height="438" alt="image" src="https://github.com/user-attachments/assets/29cd354f-aea0-4504-aa2c-951a963becc3" />
