### PR TITLE
[Linux] Reconcile app name (org.SBM.Railyard)

### DIFF
--- a/build/linux/org.SBM.Railyard.metainfo.xml
+++ b/build/linux/org.SBM.Railyard.metainfo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.SBM.Railyard</id>
+  <name>Railyard</name>
+  <summary>Mod manager for Subway Builder</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>
+      Railyard helps you browse, install, update, and manage Subway Builder maps and mods.
+    </p>
+  </description>
+  <launchable type="desktop-id">org.SBM.Railyard.desktop</launchable>
+  <url type="homepage">https://github.com/Subway-Builder-Modded/railyard</url>
+  <url type="bugtracker">https://github.com/Subway-Builder-Modded/railyard/issues</url>
+</component>

--- a/build/linux/org.SBM.Railyard.yml
+++ b/build/linux/org.SBM.Railyard.yml
@@ -30,5 +30,6 @@ modules:
     build-commands:
       - cd frontend && npm run build
       - go build -mod=vendor -tags "desktop,production,webkit2_41" -ldflags "-s -w" -o /app/bin/railyard .
-      - install -Dm644 ./build/linux/railyard.desktop /app/share/applications/railyard.desktop
-      - install -Dm644 ./build/appicon_small.png /app/share/icons/hicolor/512x512/apps/railyard.png
+      - install -Dm644 ./build/linux/railyard.desktop /app/share/applications/org.SBM.Railyard.desktop
+      - install -Dm644 ./build/linux/org.SBM.Railyard.metainfo.xml /app/share/metainfo/org.SBM.Railyard.metainfo.xml
+      - install -Dm644 ./build/appicon_small.png /app/share/icons/hicolor/512x512/apps/org.SBM.Railyard.png


### PR DESCRIPTION
This should hopefully help, reconciles following names:

- App ID: `org.SBM.Railyard`
- Desktop ID: `org.SBM.Railyard.desktop`
- metainfo: `org.SBM.Railyard.desktop`