### PR TITLE
Fix version comparison logic in updater

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -186,11 +186,11 @@ func VersionIsNewerThanInstalled(version string) bool {
 	for i := 0; i < len(installedParts) && i < len(versionParts); i++ {
 		versionPart, err1 := strconv.Atoi(versionParts[i])
 		installedPart, err2 := strconv.Atoi(installedParts[i])
-		if err1 == nil && err2 == nil && versionPart > installedPart {
-			return true
+		if err1 == nil && err2 == nil && versionPart < installedPart {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func pullReleases(log logger.Logger, githubToken string) ([]types.RailyardVersionInfo, error) {


### PR DESCRIPTION
im dumb (thisll stop update prompts for 0.1.5+rc.3 on 0.1.6+rc.2)