### PR TITLE
[Backend] Add import map support in downloader + centralize map validation

### DIFF
--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -10,12 +10,12 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"slices"
 	"strings"
 	"sync"
 
 	"railyard/internal/config"
 	"railyard/internal/constants"
+	"railyard/internal/files"
 	"railyard/internal/logger"
 	"railyard/internal/paths"
 	"railyard/internal/registry"
@@ -204,6 +204,7 @@ func (d *Downloader) cancelPendingQueuedInstall(assetType types.AssetType, asset
 	pending.completed <- pending.supersededResult
 	close(pending.completed)
 	d.OnCancelled(assetID, assetType, cancelledPhaseQueued)
+
 	return true
 }
 
@@ -316,7 +317,15 @@ func (d *Downloader) toDownloadResponse(base types.GenericResponse, path string)
 	}
 }
 
-func (d *Downloader) installResponse(assetType types.AssetType, assetID string, version string, config types.ConfigData, base types.GenericResponse, errorCode types.DownloaderErrorType) types.AssetInstallResponse {
+func (d *Downloader) installResponse(
+	assetType types.AssetType,
+	assetID string,
+	version string,
+	config types.ConfigData,
+	base types.GenericResponse,
+	errorCode types.DownloaderErrorType,
+	mapCodeConflict *types.MapCodeConflict,
+) types.AssetInstallResponse {
 	return types.AssetInstallResponse{
 		GenericResponse: base,
 		AssetType:       assetType,
@@ -324,19 +333,20 @@ func (d *Downloader) installResponse(assetType types.AssetType, assetID string, 
 		Version:         version,
 		Config:          config,
 		ErrorType:       errorCode,
+		MapCodeConflict: mapCodeConflict,
 	}
 }
 
 func (d *Downloader) installSuccess(assetType types.AssetType, assetID string, version string, config types.ConfigData, message string, attrs ...any) types.AssetInstallResponse {
-	return d.installResponse(assetType, assetID, version, config, d.successResponse(message, attrs...), "")
+	return d.installResponse(assetType, assetID, version, config, d.successResponse(message, attrs...), "", nil)
 }
 
-func (d *Downloader) installWarn(assetType types.AssetType, assetID string, version string, config types.ConfigData, message string, attrs ...any) types.AssetInstallResponse {
-	return d.installResponse(assetType, assetID, version, config, d.warnResponse(message, attrs...), "")
+func (d *Downloader) installWarn(assetType types.AssetType, assetID string, version string, config types.ConfigData, mapCodeConflict *types.MapCodeConflict, message string, attrs ...any) types.AssetInstallResponse {
+	return d.installResponse(assetType, assetID, version, config, d.warnResponse(message, attrs...), "", mapCodeConflict)
 }
 
 func (d *Downloader) installError(assetType types.AssetType, assetID string, version string, config types.ConfigData, errorCode types.DownloaderErrorType, message string, err error, attrs ...any) types.AssetInstallResponse {
-	return d.installResponse(assetType, assetID, version, config, d.throwError(message, err, attrs...), errorCode)
+	return d.installResponse(assetType, assetID, version, config, d.throwError(message, err, attrs...), errorCode, nil)
 }
 
 func (d *Downloader) uninstallResponse(assetType types.AssetType, assetID string, base types.GenericResponse, errorCode types.DownloaderErrorType) types.AssetUninstallResponse {
@@ -346,6 +356,18 @@ func (d *Downloader) uninstallResponse(assetType types.AssetType, assetID string
 		AssetID:         assetID,
 		ErrorType:       errorCode,
 	}
+}
+
+func (d *Downloader) installConfigError(assetType types.AssetType, assetID string, version string) types.AssetInstallResponse {
+	return d.installError(
+		types.AssetTypeMod,
+		assetID,
+		version,
+		types.ConfigData{},
+		types.InstallErrorInvalidConfig,
+		"Cannot install "+string(assetType)+" because app config paths are not properly configured. Please set valid paths in the config before installing.",
+		nil,
+	)
 }
 
 func (d *Downloader) uninstallSuccess(assetType types.AssetType, assetID string, message string, attrs ...any) types.AssetUninstallResponse {
@@ -409,13 +431,127 @@ func (d *Downloader) supersededOperationResult(action operationAction, assetType
 
 	if action == operationActionInstall {
 		return operationResult{
-			assetInstallResponse: d.installResponse(assetType, assetID, version, types.ConfigData{}, base, ""),
+			assetInstallResponse: d.installResponse(assetType, assetID, version, types.ConfigData{}, base, "", nil),
 		}
 	}
 	return operationResult{
 		genericResponse:        base,
 		assetUninstallResponse: d.uninstallResponse(assetType, assetID, base, ""),
 	}
+}
+
+// FindMapCodeConflict resolves whether the provided map city code would collide with an already-installed (local/remote) or vanilla map.
+func (d *Downloader) FindMapCodeConflict(targetAssetID string, cityCode string, ignoreTargetAsset bool) (*types.MapCodeConflict, bool) {
+	if cityCode == "" {
+		return nil, false
+	}
+
+	for _, installedMap := range d.Registry.GetInstalledMaps() {
+		// During normal install flow, ignore the target asset itself when checking for conflicts to allow for updates
+		if ignoreTargetAsset && installedMap.ID == targetAssetID {
+			continue
+		}
+		// Check for map code conflict with installed maps based on the map code in the config
+		if installedMap.MapConfig.Code != cityCode {
+			continue
+		}
+
+		return &types.MapCodeConflict{
+			AssetConflict: types.AssetConflict{
+				ExistingAssetID:   installedMap.ID,
+				ExistingAssetType: types.AssetTypeMap,
+				ExistingVersion:   installedMap.Version,
+				ExistingIsLocal:   installedMap.IsLocal,
+			},
+			CityCode: cityCode,
+		}, true
+	}
+
+	// Vanilla map code conflicts are determined based on the known list of vanilla map codes from latest-cities.yml.
+	// Vanilla map codes will always conflict regardless of the type of install.
+	for _, vanillaCode := range d.getVanillaMapCodes() {
+		if vanillaCode != cityCode {
+			continue
+		}
+
+		return &types.MapCodeConflict{
+			AssetConflict: types.AssetConflict{
+				ExistingAssetID:   "vanilla:" + cityCode,
+				ExistingAssetType: types.AssetTypeMap,
+				ExistingVersion:   "",
+				ExistingIsLocal:   false,
+			},
+			CityCode: cityCode,
+		}, true
+	}
+
+	return nil, false
+}
+
+func (d *Downloader) resolveMapInstallConflict(
+	mapID string,
+	version string,
+	config types.ConfigData,
+	replaceOnConflict bool,
+	ignoreTargetAsset bool,
+	conflictWarnMessage string,
+	conflictUninstallErrorMessage string,
+	baseLogAttrs ...any,
+) (*types.MapCodeConflict, types.AssetInstallResponse, bool) {
+	conflict, hasConflict := d.FindMapCodeConflict(mapID, config.Code, ignoreTargetAsset)
+	if !hasConflict {
+		return nil, types.AssetInstallResponse{}, false
+	}
+
+	warnLogAttrs := append([]any{}, baseLogAttrs...)
+	warnLogAttrs = append(warnLogAttrs,
+		"city_code", conflict.CityCode,
+		"conflicting_asset_id", conflict.ExistingAssetID,
+		"conflicting_is_local", conflict.ExistingIsLocal,
+	)
+
+	if !replaceOnConflict {
+		return conflict, d.installWarn(
+			types.AssetTypeMap,
+			mapID,
+			version,
+			config,
+			conflict,
+			conflictWarnMessage,
+			warnLogAttrs...,
+		), true
+	}
+
+	if strings.HasPrefix(conflict.ExistingAssetID, "vanilla:") {
+		return conflict, d.installError(
+			types.AssetTypeMap,
+			mapID,
+			version,
+			config,
+			types.InstallErrorMapCodeConflict,
+			"Cannot replace a vanilla map city code",
+			nil,
+			warnLogAttrs...,
+		), true
+	}
+
+	uninstallResp := d.uninstallMapNow(conflict.ExistingAssetID)
+	if uninstallResp.Status == types.ResponseError {
+		errAttrs := append([]any{}, baseLogAttrs...)
+		errAttrs = append(errAttrs, "conflicting_asset_id", conflict.ExistingAssetID)
+		return conflict, d.installError(
+			types.AssetTypeMap,
+			mapID,
+			version,
+			config,
+			types.InstallErrorMapCodeConflict,
+			conflictUninstallErrorMessage,
+			nil,
+			errAttrs...,
+		), true
+	}
+
+	return conflict, types.AssetInstallResponse{}, false
 }
 
 // UninstallAsset handles uninstallation for all supported asset types.
@@ -461,6 +597,85 @@ func (d *Downloader) UninstallAsset(assetType types.AssetType, assetID string) t
 		}
 	}, d.supersededOperationResult(operationActionUninstall, assetType, assetID, ""), nil)
 	return result.assetUninstallResponse
+}
+
+func (d *Downloader) ImportAsset(assetType types.AssetType, zipPath string, replaceOnConflict bool) types.AssetInstallResponse {
+
+	// TODO: Remove this and replace with isValidAssetType check once mod support is added
+	if assetType != types.AssetTypeMap {
+		return d.installError(
+			assetType,
+			"",
+			"",
+			types.ConfigData{},
+			types.InstallErrorInvalidAssetType,
+			"ImportAsset currently supports map assets only",
+			nil,
+			"asset_type", assetType,
+		)
+	}
+
+	if !d.Config.GetConfig().Validation.IsValid() {
+		return d.installConfigError(assetType, zipPath, "Local")
+	}
+
+	key := d.operationKey(operationActionInstall, assetType, zipPath, "import")
+	assetKey := downloadQueueKey{assetType: assetType, assetID: zipPath}
+	result := d.enqueueOperation(operationActionInstall, assetKey, key, func() operationResult {
+		// TODO: Add support for local mods/other assets
+		return operationResult{assetInstallResponse: d.importMapNow(zipPath, replaceOnConflict)}
+	}, d.supersededOperationResult(operationActionInstall, assetType, zipPath, "import"), nil)
+	return result.assetInstallResponse
+}
+
+func (d *Downloader) importMapNow(zipPath string, replaceOnConflict bool) types.AssetInstallResponse {
+	configData, configErrType, configErr := files.ValidateMapArchive(zipPath)
+	if configErr != nil {
+		return d.installError(types.AssetTypeMap, "", "", types.ConfigData{}, configErrType, "Failed to inspect map archive", configErr, "zip_path", zipPath)
+	}
+
+	mapID := configData.Code
+	version := strings.TrimSpace(configData.Version)
+	if version == "" {
+		version = "0.0.0"
+	}
+
+	// For local imports, detect conflicts even when the existing installed asset has the same local asset ID (e.g. same city code maps) so that local->local replacements use the standard warn-first override flow.
+	conflict, conflictResp, handled := d.resolveMapInstallConflict(
+		mapID,
+		version,
+		configData,
+		replaceOnConflict,
+		false,
+		"Map import conflicts with an installed map. Confirm replacement to continue.",
+		"Failed to remove conflicting installed map before import",
+		"map_id", mapID,
+		"zip_path", zipPath,
+	)
+	var replacedConflict *types.MapCodeConflict
+	if handled {
+		return conflictResp
+	}
+	if conflict != nil && replaceOnConflict {
+		replacedConflict = conflict
+	}
+
+	extractResp := d.handleMapExtract(zipPath, mapID, version)
+	if extractResp.Status == types.ResponseError {
+		return extractResp
+	}
+
+	d.Registry.AddInstalledMap(mapID, version, true, extractResp.Config)
+	if err := d.Registry.WriteInstalledToDisk(); err != nil {
+		return d.installError(types.AssetTypeMap, mapID, version, extractResp.Config, types.InstallErrorPersistStateFailed, "Failed to persist installed state after importing map", err, "map_id", mapID)
+	}
+
+	response := d.installSuccess(types.AssetTypeMap, mapID, version, extractResp.Config, "Map imported successfully", "map_id", mapID, "zip_path", zipPath)
+	if extractResp.Status == types.ResponseWarn {
+		response = d.installWarn(types.AssetTypeMap, mapID, version, extractResp.Config, replacedConflict, extractResp.Message, "map_id", mapID, "zip_path", zipPath)
+	}
+	response.MapCodeConflict = replacedConflict
+	return response
 }
 
 func (d *Downloader) uninstallModNow(modId string) types.AssetUninstallResponse {
@@ -525,7 +740,7 @@ func (d *Downloader) uninstallMapNow(mapId string) types.AssetUninstallResponse 
 		return d.uninstallError(types.AssetTypeMap, mapId, types.UninstallErrorFilesystem, "Failed to remove map data files", err, "map_id", mapId)
 	}
 	tilePath := paths.JoinLocalPath(d.getMapTilePath(), mapConfig.Code+".pmtiles")
-	if err := os.Remove(tilePath); err != nil {
+	if err := os.Remove(tilePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return d.uninstallError(types.AssetTypeMap, mapId, types.UninstallErrorFilesystem, "Failed to remove map tile files", err, "map_id", mapId)
 	}
 	os.Remove(paths.JoinLocalPath(d.getMapThumbnailPath(), mapConfig.Code+".svg")) // Doesn't matter if this fails, thumbnail is optional and may not exist
@@ -536,44 +751,45 @@ func (d *Downloader) uninstallMapNow(mapId string) types.AssetUninstallResponse 
 	return d.uninstallSuccess(types.AssetTypeMap, mapId, "Map uninstalled successfully", "map_id", mapId)
 }
 
-// InstallAsset handles installation for all supported asset types.
-func (d *Downloader) InstallAsset(assetType types.AssetType, assetID string, version string) types.AssetInstallResponse {
-	if !types.IsValidAssetType(assetType) {
+// InstallAsset handles installation for all supported asset types using a structured request.
+func (d *Downloader) InstallAsset(req types.InstallAssetRequest) types.AssetInstallResponse {
+	if !types.IsValidAssetType(req.AssetType) {
 		return d.installError(
-			assetType,
-			assetID,
-			version,
+			req.AssetType,
+			req.AssetID,
+			req.Version,
 			types.ConfigData{},
 			types.InstallErrorInvalidAssetType,
 			"Invalid asset type",
 			nil,
-			"asset_type", assetType, "asset_id", assetID, "version", version,
+			"asset_type", req.AssetType, "asset_id", req.AssetID, "version", req.Version,
 		)
 	}
 
-	key := d.operationKey(operationActionInstall, assetType, assetID, version)
-	assetKey := downloadQueueKey{assetType: assetType, assetID: assetID}
+	replaceOnConflict := req.Map != nil && req.Map.ReplaceOnConflict
+	key := d.operationKey(operationActionInstall, req.AssetType, req.AssetID, req.Version)
+	assetKey := downloadQueueKey{assetType: req.AssetType, assetID: req.AssetID}
 	opCtx, cancel := context.WithCancel(context.Background())
 	result := d.enqueueOperation(operationActionInstall, assetKey, key, func() operationResult {
 		defer cancel()
-		switch assetType {
+		switch req.AssetType {
 		case types.AssetTypeMap:
-			return operationResult{assetInstallResponse: d.installMapNow(opCtx, assetID, version)}
+			return operationResult{assetInstallResponse: d.installMapNow(opCtx, req.AssetID, req.Version, replaceOnConflict)}
 		case types.AssetTypeMod:
-			return operationResult{assetInstallResponse: d.installModNow(opCtx, assetID, version)}
+			return operationResult{assetInstallResponse: d.installModNow(opCtx, req.AssetID, req.Version)}
 		default:
 			return operationResult{assetInstallResponse: d.installError(
-				assetType,
-				assetID,
-				version,
+				req.AssetType,
+				req.AssetID,
+				req.Version,
 				types.ConfigData{},
 				types.InstallErrorInvalidAssetType,
 				"Invalid asset type",
 				nil,
-				"asset_type", assetType, "asset_id", assetID, "version", version,
+				"asset_type", req.AssetType, "asset_id", req.AssetID, "version", req.Version,
 			)}
 		}
-	}, d.supersededOperationResult(operationActionInstall, assetType, assetID, version), cancel)
+	}, d.supersededOperationResult(operationActionInstall, req.AssetType, req.AssetID, req.Version), cancel)
 	return result.assetInstallResponse
 }
 
@@ -586,6 +802,7 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 			modId,
 			version,
 			types.ConfigData{},
+			nil,
 			fmt.Sprintf("%s already installed at requested version. No action taken.", assetTypeLabels[types.AssetTypeMod]),
 			"asset_type", types.AssetTypeMod,
 			"asset_id", modId,
@@ -593,15 +810,7 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 		)
 	}
 	if !d.Config.GetConfig().Validation.IsValid() {
-		return d.installError(
-			types.AssetTypeMod,
-			modId,
-			version,
-			types.ConfigData{},
-			types.InstallErrorInvalidConfig,
-			"Cannot install mod because app config paths are not properly configured. Please set valid paths in the config before installing mods.",
-			nil,
-		)
+		return d.installConfigError(types.AssetTypeMod, modId, version)
 	}
 	modInfo, err := d.Registry.GetMod(modId)
 	if err != nil {
@@ -639,7 +848,7 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 	// Pass in context to the download function so that it can be cancelled if the operation is no longer needed
 	downloadResp := d.downloadTempZip(ctx, versionInfo.DownloadURL, modId)
 	if downloadResp.Status == types.ResponseWarn {
-		return d.installWarn(types.AssetTypeMod, modId, version, types.ConfigData{}, downloadResp.Message, "mod_id", modId, "version", version)
+		return d.installWarn(types.AssetTypeMod, modId, version, types.ConfigData{}, nil, downloadResp.Message, "mod_id", modId, "version", version)
 	}
 	if downloadResp.Status != types.ResponseSuccess {
 		os.Remove(downloadResp.Path)
@@ -659,7 +868,7 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 		return d.installError(types.AssetTypeMod, modId, version, types.ConfigData{}, extractResp.ErrorType, "Failed to extract mod zip: "+extractResp.Message, nil, "mod_id", modId, "version", version)
 	}
 	os.Remove(downloadResp.Path)
-	d.Registry.AddInstalledMod(modId, version)
+	d.Registry.AddInstalledMod(modId, version, false)
 	if err := d.Registry.WriteInstalledToDisk(); err != nil {
 		d.Logger.Warn("Failed to persist installed state after installing mod", "error", err)
 	}
@@ -668,7 +877,7 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 }
 
 // installMapNow handles the installation of a map given its ID and version, including downloading, extracting, validating files, and updating the registry.
-func (d *Downloader) installMapNow(ctx context.Context, mapId string, version string) types.AssetInstallResponse {
+func (d *Downloader) installMapNow(ctx context.Context, mapId string, version string, replaceOnConflict bool) types.AssetInstallResponse {
 	d.Logger.Info("InstallMap started", "map_id", mapId, "version", version)
 	if state, installed := d.getInstalledState(types.AssetTypeMap, mapId); installed && state.version == version {
 		return d.installWarn(
@@ -676,6 +885,7 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 			mapId,
 			version,
 			state.mapConfig,
+			nil,
 			fmt.Sprintf("%s already installed at requested version. No action taken.", assetTypeLabels[types.AssetTypeMap]),
 			"asset_type", types.AssetTypeMap,
 			"asset_id", mapId,
@@ -683,7 +893,7 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 		)
 	}
 	if !d.Config.GetConfig().Validation.IsValid() {
-		return d.installError(types.AssetTypeMap, mapId, version, types.ConfigData{}, types.InstallErrorInvalidConfig, "Invalid configuration", nil, "map_id", mapId, "version", version)
+		return d.installConfigError(types.AssetTypeMap, mapId, version)
 	}
 	mapInfo, err := d.Registry.GetMap(mapId)
 	if err != nil {
@@ -721,7 +931,7 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 	// Pass in context to the download function so that it can be cancelled if the operation is no longer needed
 	downloadResp := d.downloadTempZip(ctx, versionInfo.DownloadURL, mapId)
 	if downloadResp.Status == types.ResponseWarn {
-		return d.installWarn(types.AssetTypeMap, mapId, version, types.ConfigData{}, downloadResp.Message, "map_id", mapId, "version", version)
+		return d.installWarn(types.AssetTypeMap, mapId, version, types.ConfigData{}, nil, downloadResp.Message, "map_id", mapId, "version", version)
 	}
 	if downloadResp.Status != types.ResponseSuccess {
 		os.Remove(downloadResp.Path)
@@ -733,6 +943,28 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 		return d.installError(types.AssetTypeMap, mapId, version, types.ConfigData{}, types.InstallErrorChecksumFailed, "SHA-256 integrity check failed", err, "map_id", mapId, "version", version)
 	}
 
+	cfg, configErrType, configErr := files.ValidateMapArchive(downloadResp.Path)
+	if configErr != nil {
+		os.Remove(downloadResp.Path)
+		return d.installError(types.AssetTypeMap, mapId, version, types.ConfigData{}, configErrType, "Failed to inspect map archive", configErr, "map_id", mapId, "version", version)
+	}
+
+	_, conflictResp, handled := d.resolveMapInstallConflict(
+		mapId,
+		version,
+		cfg,
+		replaceOnConflict,
+		true,
+		"Map code conflict detected. Confirm replacement to continue.",
+		"Failed to remove conflicting installed map before install",
+		"map_id", mapId,
+		"version", version,
+	)
+	if handled {
+		os.Remove(downloadResp.Path)
+		return conflictResp
+	}
+
 	d.Logger.Info("Extracting map", "map_id", mapId, "version", version, "temp_path", downloadResp.Path)
 	// No context is passed here (for cancellation)
 	extractResp := d.handleMapExtract(downloadResp.Path, mapId, version)
@@ -741,7 +973,7 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 		return d.installError(types.AssetTypeMap, mapId, version, types.ConfigData{}, extractResp.ErrorType, "Failed to extract map zip: "+extractResp.Message, nil, "map_id", mapId, "version", version)
 	}
 	os.Remove(downloadResp.Path)
-	d.Registry.AddInstalledMap(mapId, version, extractResp.Config)
+	d.Registry.AddInstalledMap(mapId, version, false, extractResp.Config)
 	if err := d.Registry.WriteInstalledToDisk(); err != nil {
 		d.Logger.Warn("Failed to persist installed state after installing map", "error", err)
 	}
@@ -867,17 +1099,12 @@ func (d *Downloader) getVanillaMapCodes() []string {
 	return cityCodes
 }
 
-// Used by handleMapExtract to check for vanilla/duplicate map codes
-func (d *Downloader) isMapCodeTaken(code string) bool {
-	return slices.Contains(d.getVanillaMapCodes(), code) || slices.Contains(d.Registry.GetInstalledMapCodes(), code)
-}
-
 // handleModExtract processes the downloaded mod zip file, extracts it to the appropriate location, and returns a success or error message.
 func (d *Downloader) handleModExtract(filePath string, modId string, version string) types.AssetInstallResponse {
 	return extractMod(d, filePath, modId, version)
 }
 
-// handleMapExtract processes the downloaded map zip file, validates required files, extracts them to the appropriate locations, and returns the map config or an error message.
+// handleMapExtract processes map zip files and extracts the contract-specific files for local or downloaded assets.
 func (d *Downloader) handleMapExtract(filePath string, mapId string, version string) types.AssetInstallResponse {
 	return extractMap(d, filePath, mapId, version)
 }

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"railyard/internal/config"
+	"railyard/internal/constants"
 	"railyard/internal/logger"
 	"railyard/internal/registry"
 	"railyard/internal/testutil"
@@ -482,7 +483,11 @@ func TestCancelDuringExtractRemovesInstalledFiles(t *testing.T) {
 
 	installDone := make(chan types.AssetInstallResponse, 1)
 	go func() {
-		installDone <- d.InstallAsset(types.AssetTypeMap, "map-a", "1.0.0")
+		installDone <- d.InstallAsset(types.InstallAssetRequest{
+			AssetType: types.AssetTypeMap,
+			AssetID:   "map-a",
+			Version:   "1.0.0",
+		})
 	}()
 
 	select {
@@ -593,7 +598,7 @@ func TestInstallMapForExistingIsNoOp(t *testing.T) {
 		Creator:     "tester",
 		Version:     "1.0.0",
 	}
-	reg.AddInstalledMap("map-a", "1.0.0", expectedConfig)
+	reg.AddInstalledMap("map-a", "1.0.0", false, expectedConfig)
 
 	d := &Downloader{
 		Registry: reg,
@@ -602,7 +607,11 @@ func TestInstallMapForExistingIsNoOp(t *testing.T) {
 	}
 
 	// Validate that no-op response is returned at invocation time
-	response := d.InstallAsset(types.AssetTypeMap, "map-a", "1.0.0")
+	response := d.InstallAsset(types.InstallAssetRequest{
+		AssetType: types.AssetTypeMap,
+		AssetID:   "map-a",
+		Version:   "1.0.0",
+	})
 	require.Equal(t, types.ResponseWarn, response.Status)
 	require.Contains(t, response.Message, "already installed at requested version")
 	require.Equal(t, expectedConfig, response.Config)
@@ -633,12 +642,16 @@ func TestInstallModPreservesNoOpThroughStateMutation(t *testing.T) {
 	responseCh := make(chan types.AssetInstallResponse, 1)
 	// Enqueue an install operation for mod-a
 	go func() {
-		responseCh <- d.InstallAsset(types.AssetTypeMod, "mod-a", "1.0.0")
+		responseCh <- d.InstallAsset(types.InstallAssetRequest{
+			AssetType: types.AssetTypeMod,
+			AssetID:   "mod-a",
+			Version:   "1.0.0",
+		})
 	}()
 
 	waitForPendingOperation(t, d, downloadQueueKey{assetType: types.AssetTypeMod, assetID: "mod-a"})
 	// Mutate registry state to make it appear as though mod-a is already installed while the install operation is still pending
-	reg.AddInstalledMod("mod-a", "1.0.0")
+	reg.AddInstalledMod("mod-a", "1.0.0", false)
 	close(releaseBlocker)
 
 	// Validate that no-op response is returned at execution time
@@ -738,7 +751,11 @@ func TestInstallAssetError(t *testing.T) {
 				defer cleanup()
 			}
 
-			response := d.InstallAsset(tc.assetType, tc.assetID, tc.version)
+			response := d.InstallAsset(types.InstallAssetRequest{
+				AssetType: tc.assetType,
+				AssetID:   tc.assetID,
+				Version:   tc.version,
+			})
 			require.Equal(t, tc.expectedStatus, response.Status)
 			require.Equal(t, tc.expectedErrorCode, response.ErrorType)
 		})
@@ -795,7 +812,11 @@ func TestInstallAssetSuccess(t *testing.T) {
 			cleanup := registrytest.MockRegistryServer(t, reg, tc.fixtures)
 			defer cleanup()
 
-			response := d.InstallAsset(tc.assetType, tc.assetID, tc.version)
+			response := d.InstallAsset(types.InstallAssetRequest{
+				AssetType: tc.assetType,
+				AssetID:   tc.assetID,
+				Version:   tc.version,
+			})
 			require.Equal(t, types.ResponseSuccess, response.Status, response.Message)
 			require.Equal(t, types.DownloaderErrorType(""), response.ErrorType)
 			if tc.expectMapConf {
@@ -805,6 +826,145 @@ func TestInstallAssetSuccess(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInstallMapWritesDownloadedContractFiles(t *testing.T) {
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	reg := registry.NewRegistry(testutil.TestLogSink{}, cfg)
+	configureDownloaderConfig(t, cfg)
+
+	d := &Downloader{
+		Registry: reg,
+		Config:   cfg,
+		Logger:   logger.LoggerAtPath(""),
+	}
+	d.tempPath = t.TempDir()
+	d.mapTilePath = t.TempDir()
+
+	cleanup := registrytest.MockRegistryServer(t, reg, []registrytest.UpdateFixture{
+		{AssetID: "map-a", AssetType: types.AssetTypeMap, Versions: []string{"1.0.0"}, MapCode: "AAA"},
+	})
+	defer cleanup()
+
+	resp := d.InstallAsset(types.InstallAssetRequest{
+		AssetType: types.AssetTypeMap,
+		AssetID:   "map-a",
+		Version:   "1.0.0",
+	})
+	require.Equal(t, types.ResponseSuccess, resp.Status, resp.Message)
+
+	mapDir := filepath.Join(d.getMapDataPath(), "AAA")
+	requiredDownloadedFiles := []string{
+		"config.json",
+		"buildings_index.json.gz",
+		"demand_data.json.gz",
+		"roads.geojson.gz",
+		"runways_taxiways.geojson.gz",
+		constants.RailyardAssetMarker,
+	}
+	for _, name := range requiredDownloadedFiles {
+		_, err := os.Stat(filepath.Join(mapDir, name))
+		require.NoError(t, err, "expected downloaded map file %s", name)
+	}
+
+	_, err := os.Stat(filepath.Join(mapDir, "config.json.gz"))
+	require.True(t, os.IsNotExist(err), "downloaded map should not write config.json.gz")
+	_, err = os.Stat(filepath.Join(d.getMapTilePath(), "AAA.pmtiles"))
+	require.NoError(t, err, "downloaded map should write pmtiles")
+	_, err = os.Stat(filepath.Join(d.getMapThumbnailPath(), "AAA.svg"))
+	require.NoError(t, err, "downloaded map should write thumbnail when present")
+}
+
+func TestImportMapWritesLocalContractFiles(t *testing.T) {
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	reg := registry.NewRegistry(testutil.TestLogSink{}, cfg)
+	configureDownloaderConfig(t, cfg)
+
+	d := &Downloader{
+		Registry: reg,
+		Config:   cfg,
+		Logger:   logger.LoggerAtPath(""),
+	}
+	d.tempPath = t.TempDir()
+	d.mapTilePath = t.TempDir()
+
+	zipPath := filepath.Join(t.TempDir(), "local-map.zip")
+	require.NoError(t, os.WriteFile(zipPath, registrytest.MockMapZip(t, "AAA"), 0o644))
+
+	resp := d.ImportAsset(types.AssetTypeMap, zipPath, false)
+	require.Equal(t, types.ResponseSuccess, resp.Status, resp.Message)
+
+	mapDir := filepath.Join(d.getMapDataPath(), "AAA")
+	requiredLocalFiles := []string{
+		"config.json",
+		"buildings_index.json.gz",
+		"demand_data.json.gz",
+		"roads.geojson.gz",
+		"runways_taxiways.geojson.gz",
+		constants.RailyardAssetMarker,
+	}
+	for _, name := range requiredLocalFiles {
+		_, err := os.Stat(filepath.Join(mapDir, name))
+		require.NoError(t, err, "expected local map file %s", name)
+	}
+
+	_, err := os.Stat(filepath.Join(d.getMapTilePath(), "AAA.pmtiles"))
+	require.NoError(t, err, "local map should write pmtiles")
+	_, err = os.Stat(filepath.Join(d.getMapThumbnailPath(), "AAA.svg"))
+	require.NoError(t, err, "local map should write thumbnail when present")
+}
+
+func TestImportAssetWarnsOnLocalToLocalConflict(t *testing.T) {
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	reg := registry.NewRegistry(testutil.TestLogSink{}, cfg)
+	configureDownloaderConfig(t, cfg)
+
+	d := &Downloader{
+		Registry: reg,
+		Config:   cfg,
+		Logger:   logger.LoggerAtPath(""),
+	}
+	d.tempPath = t.TempDir()
+	d.mapTilePath = t.TempDir()
+
+	localID := "AAA"
+	reg.AddInstalledMap(localID, "1.0.0", true, types.ConfigData{
+		Code:    "AAA",
+		Version: "1.0.0",
+		Name:    "Local AAA",
+	})
+
+	zipPath := filepath.Join(t.TempDir(), "local-map.zip")
+	require.NoError(t, os.WriteFile(zipPath, registrytest.MockMapZip(t, "AAA"), 0o644))
+
+	resp := d.ImportAsset(types.AssetTypeMap, zipPath, false)
+	require.Equal(t, types.ResponseWarn, resp.Status)
+	require.NotNil(t, resp.MapCodeConflict)
+	require.Equal(t, localID, resp.MapCodeConflict.ExistingAssetID)
+	require.True(t, resp.MapCodeConflict.ExistingIsLocal)
+	require.Equal(t, "AAA", resp.MapCodeConflict.CityCode)
+}
+
+func TestImportAssetRejectsNonUppercaseMapCode(t *testing.T) {
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	reg := registry.NewRegistry(testutil.TestLogSink{}, cfg)
+	configureDownloaderConfig(t, cfg)
+
+	d := &Downloader{
+		Registry: reg,
+		Config:   cfg,
+		Logger:   logger.LoggerAtPath(""),
+	}
+	d.tempPath = t.TempDir()
+	d.mapTilePath = t.TempDir()
+
+	zipPath := filepath.Join(t.TempDir(), "local-map-invalid-code.zip")
+	require.NoError(t, os.WriteFile(zipPath, registrytest.MockMapZip(t, "dca"), 0o644))
+
+	resp := d.ImportAsset(types.AssetTypeMap, zipPath, false)
+	require.Equal(t, types.ResponseError, resp.Status)
+	require.Equal(t, types.InstallErrorInvalidMapCode, resp.ErrorType)
+	require.Contains(t, resp.Message, "invalid map code")
 }
 
 func TestIsValidOperationAction(t *testing.T) {

--- a/internal/downloader/extractor.go
+++ b/internal/downloader/extractor.go
@@ -153,82 +153,46 @@ func extractMod(d *Downloader, filePath string, modId string, version string) ty
 	return d.installSuccess(types.AssetTypeMod, modId, version, types.ConfigData{}, "Mod extracted successfully", "file_path", filePath, "assetId", modId)
 }
 
-// extractMap processes the downloaded map zip file, validates required files, extracts them to the appropriate locations.
+// extractMap processes map zip files for downloaded/local installs and writes only the expected city-data artifacts.
 func extractMap(d *Downloader, filePath string, mapId string, version string) types.AssetInstallResponse {
-	configData := types.ConfigData{}
+	configData, errorType, inspectErr := files.ValidateMapArchive(filePath)
+	if inspectErr != nil {
+		return d.installError(types.AssetTypeMap, mapId, version, configData, errorType, "Failed map archive inspection", inspectErr, "file_path", filePath)
+	}
+
 	reader, err := zip.OpenReader(filePath)
 	if err != nil {
 		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidArchive, "Failed to open zip file", err, "file_path", filePath)
 	}
 	defer reader.Close()
 
-	filesFound := map[string]types.FileFoundStruct{
-		"config":     {Found: false, FileObject: nil, Required: true},
-		"demandData": {Found: false, FileObject: nil, Required: true},
-		"roads":      {Found: false, FileObject: nil, Required: true},
-		"runways":    {Found: false, FileObject: nil, Required: true},
-		"buildings":  {Found: false, FileObject: nil, Required: true},
-		"tiles":      {Found: false, FileObject: nil, Required: true},
-		"oceanDepth": {Found: false, FileObject: nil, Required: false},
-		"thumbnail":  {Found: false, FileObject: nil, Required: false},
-	}
-
-	for _, file := range reader.File {
-		switch file.Name {
-		case "config.json":
-			filesFound["config"] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		case "demand_data.json":
-			filesFound["demandData"] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		case "roads.geojson":
-			filesFound["roads"] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		case "runways_taxiways.geojson":
-			filesFound["runways"] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		case "buildings_index.json":
-			filesFound["buildings"] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		case "ocean_depth_index.json":
-			filesFound["oceanDepth"] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
-		}
-		if path.Ext(file.Name) == ".pmtiles" {
-			filesFound["tiles"] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		}
-		if path.Ext(file.Name) == ".svg" {
-			filesFound["thumbnail"] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
-		}
-	}
-
-	if !requiredFilesPresent(filesFound) {
-		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidArchive, "Zip file is missing one or more required files", nil, "file_path", filePath)
-	}
+	filesFound := files.BuildMapArchiveFileIndex(reader.File)
 
 	filesCount := 0
-	for key, fileStruct := range filesFound {
-		if fileStruct.Found && key != "config" {
+	for _, fileStruct := range filesFound {
+		if fileStruct.Found {
+			filesCount++
+		}
+	}
+	if configData.ThumbnailBbox != nil {
+		if fileStruct, ok := filesFound[files.MapArchiveKeyThumbnail]; !ok || !fileStruct.Found {
 			filesCount++
 		}
 	}
 
-	configReader, err := filesFound["config"].FileObject.Open()
-	if err != nil {
-		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidManifest, "Failed to read config file", err, "file_path", filePath)
-	}
-	defer configReader.Close()
-
-	configBytes, err := io.ReadAll(configReader)
-	if err != nil {
-		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidManifest, "Failed to read config file", err, "file_path", filePath)
-	}
-
-	configData, err = files.ParseJSON[types.ConfigData](configBytes, "config")
-	if err != nil {
-		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidManifest, "Failed to parse config file", err, "file_path", filePath)
-	}
-
-	if configData.ThumbnailBbox != nil && !filesFound["thumbnail"].Found {
-		filesCount++
-	}
-
-	if d.isMapCodeTaken(configData.Code) {
-		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorMapCodeConflict, "Cannot install map because its code matches a vanilla map included with the game or an already installed map.", nil, "map_code", configData.Code)
+	if conflict, hasConflict := d.FindMapCodeConflict(mapId, configData.Code, true); hasConflict {
+		return d.installError(
+			types.AssetTypeMap,
+			mapId,
+			version,
+			configData,
+			types.InstallErrorMapCodeConflict,
+			"Cannot install map because its code matches a vanilla map included with the game or an already installed map.",
+			nil,
+			"map_code", conflict.CityCode,
+			"conflicting_asset_id", conflict.ExistingAssetID,
+			"conflicting_is_local", conflict.ExistingIsLocal,
+		)
 	}
 
 	// Create necessary directories first
@@ -236,11 +200,9 @@ func extractMap(d *Downloader, filePath string, mapId string, version string) ty
 	if err := os.MkdirAll(destFolder, os.ModePerm); err != nil {
 		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorFilesystem, "Failed to create destination folder", err, "destination", destFolder)
 	}
-
-	if err := os.MkdirAll(d.mapTilePath, os.ModePerm); err != nil {
-		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorFilesystem, "Failed to create tiles directory", err, "tiles_path", d.mapTilePath)
+	if err := os.MkdirAll(d.getMapTilePath(), os.ModePerm); err != nil {
+		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorFilesystem, "Failed to create tiles directory", err, "tiles_path", d.getMapTilePath())
 	}
-
 	if err := os.MkdirAll(d.getMapThumbnailPath(), os.ModePerm); err != nil {
 		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorFilesystem, "Failed to create thumbnail directory", err, "thumbnail_path", d.getMapThumbnailPath())
 	}
@@ -249,12 +211,13 @@ func extractMap(d *Downloader, filePath string, mapId string, version string) ty
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(filesFound))
 
-	extractCount := 0
+	// Use atomic counter to track progress across routines
+	var extractCount atomic.Int64
 	if d.OnExtractProgress != nil {
-		d.OnExtractProgress(configData.Code, int64(extractCount), int64(filesCount))
+		d.OnExtractProgress(configData.Code, 0, int64(filesCount))
 	}
 	for key, fileStruct := range filesFound {
-		if !fileStruct.Found || key == "config" {
+		if !fileStruct.Found {
 			continue
 		}
 
@@ -269,27 +232,26 @@ func extractMap(d *Downloader, filePath string, mapId string, version string) ty
 			}
 			defer srcFile.Close()
 
+			outputFileName := path.Base(fileStruct.FileObject.Name)
+			destinationPath := paths.JoinLocalPath(destFolder, outputFileName+".gz")
+			shouldArchive := true
+
 			switch key {
-			case "tiles":
-				extractFileMap(paths.JoinLocalPath(d.mapTilePath, configData.Code+".pmtiles"), srcFile, errChan, false)
-				if d.OnExtractProgress != nil {
-					extractCount++
-					d.OnExtractProgress(configData.Code, int64(extractCount), int64(filesCount))
-				}
+			// Extract out config.json for future bootstrapping from installed state, in particular for local maps
+			case files.MapArchiveKeyConfig:
+				destinationPath = paths.JoinLocalPath(destFolder, files.MapConfigFileName)
+				shouldArchive = false
+			case files.MapArchiveKeyTiles:
+				destinationPath = paths.JoinLocalPath(d.getMapTilePath(), configData.Code+files.MapTileFileExt)
+				shouldArchive = false
+			case files.MapArchiveKeyThumbnail:
+				destinationPath = paths.JoinLocalPath(d.getMapThumbnailPath(), configData.Code+files.MapThumbnailFileExt)
+				shouldArchive = false
+			}
 
-			case "thumbnail":
-				extractFileMap(paths.JoinLocalPath(d.getMapThumbnailPath(), configData.Code+".svg"), srcFile, errChan, false)
-				if d.OnExtractProgress != nil {
-					extractCount++
-					d.OnExtractProgress(configData.Code, int64(extractCount), int64(filesCount))
-				}
-
-			default:
-				extractFileMap(paths.JoinLocalPath(destFolder, path.Base(fileStruct.FileObject.Name)+".gz"), srcFile, errChan, true)
-				if d.OnExtractProgress != nil {
-					extractCount++
-					d.OnExtractProgress(configData.Code, int64(extractCount), int64(filesCount))
-				}
+			extractFileMap(destinationPath, srcFile, errChan, shouldArchive)
+			if d.OnExtractProgress != nil {
+				d.OnExtractProgress(configData.Code, extractCount.Add(1), int64(filesCount))
 			}
 		}(key, fileStruct)
 	}
@@ -301,20 +263,19 @@ func extractMap(d *Downloader, filePath string, mapId string, version string) ty
 		err := <-errChan
 		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorExtractFailed, "Failed to extract file", err, "file_path", filePath)
 	}
-
-	if !filesFound["thumbnail"].Found {
+	if fileStruct, ok := filesFound[files.MapArchiveKeyThumbnail]; (!ok || !fileStruct.Found) && configData.ThumbnailBbox != nil {
 		srv, port, srvErr := utils.StartTempPMTilesServer()
 		if srvErr != nil {
-			return d.installWarn(types.AssetTypeMap, mapId, version, configData, "Failed to start PMTiles server for thumbnail generation, but map was extracted successfully.", "file_path", filePath, "map_code", configData.Code)
+			return d.installWarn(types.AssetTypeMap, mapId, version, configData, nil, "Failed to start PMTiles server for thumbnail generation, but map was extracted successfully.", "file_path", filePath, "map_code", configData.Code)
 		}
 		defer srv.Close()
 
 		thumbnailData, err := utils.GenerateThumbnail(configData.Code, configData, port)
 		if err != nil {
-			return d.installWarn(types.AssetTypeMap, mapId, version, configData, "Failed to generate thumbnail, but map was extracted successfully. You can try generating the thumbnail later from the map details page.", "file_path", filePath, "map_code", configData.Code)
+			return d.installWarn(types.AssetTypeMap, mapId, version, configData, nil, "Failed to generate thumbnail, but map was extracted successfully. You can try generating the thumbnail later from the map details page.", "file_path", filePath, "map_code", configData.Code)
 		}
 
-		thumbnailPath := paths.JoinLocalPath(d.getMapThumbnailPath(), configData.Code+".svg")
+		thumbnailPath := paths.JoinLocalPath(d.getMapThumbnailPath(), configData.Code+files.MapThumbnailFileExt)
 		if err := files.WriteFilesAtomically([]files.AtomicFileWrite{
 			{
 				Path:  thumbnailPath,
@@ -323,11 +284,10 @@ func extractMap(d *Downloader, filePath string, mapId string, version string) ty
 				Perm:  0o644,
 			},
 		}); err != nil {
-			return d.installWarn(types.AssetTypeMap, mapId, version, configData, "Failed to save generated thumbnail, but map was extracted successfully. You can try generating the thumbnail later from the map details page.", "file_path", filePath, "map_code", configData.Code, "thumbnail_path", thumbnailPath)
+			return d.installWarn(types.AssetTypeMap, mapId, version, configData, nil, "Failed to save generated thumbnail, but map was extracted successfully. You can try generating the thumbnail later from the map details page.", "file_path", filePath, "map_code", configData.Code, "thumbnail_path", thumbnailPath)
 		}
-		extractCount++
 		if d.OnExtractProgress != nil {
-			d.OnExtractProgress(configData.Code, int64(extractCount), int64(filesCount))
+			d.OnExtractProgress(configData.Code, extractCount.Add(1), int64(filesCount))
 		}
 	}
 

--- a/internal/files/map_validation.go
+++ b/internal/files/map_validation.go
@@ -1,0 +1,186 @@
+package files
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"railyard/internal/paths"
+	"railyard/internal/types"
+)
+
+const (
+	MapConfigFileName     = "config.json"
+	MapDemandFileName     = "demand_data.json"
+	MapRoadsFileName      = "roads.geojson"
+	MapRunwaysFileName    = "runways_taxiways.geojson"
+	MapBuildingsFileName  = "buildings_index.json"
+	MapOceanDepthFileName = "ocean_depth_index.json"
+
+	MapTileFileExt      = ".pmtiles"
+	MapThumbnailFileExt = ".svg"
+
+	MapArchiveKeyConfig     = "config"
+	MapArchiveKeyDemandData = "demandData"
+	MapArchiveKeyRoads      = "roads"
+	MapArchiveKeyRunways    = "runways"
+	MapArchiveKeyBuildings  = "buildings"
+	MapArchiveKeyTiles      = "tiles"
+	MapArchiveKeyThumbnail  = "thumbnail"
+	MapArchiveKeyOceanDepth = "oceanDepth"
+)
+
+// BuildMapArchiveFileIndex builds an index of expected map archive files for validation, returning a map of file keys to their presence and file objects in the archive
+func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundStruct {
+	filesFound := map[string]types.FileFoundStruct{
+		MapArchiveKeyConfig:     {Found: false, FileObject: nil, Required: true},
+		MapArchiveKeyDemandData: {Found: false, FileObject: nil, Required: true},
+		MapArchiveKeyRoads:      {Found: false, FileObject: nil, Required: true},
+		MapArchiveKeyRunways:    {Found: false, FileObject: nil, Required: true},
+		MapArchiveKeyBuildings:  {Found: false, FileObject: nil, Required: true},
+		MapArchiveKeyTiles:      {Found: false, FileObject: nil, Required: true},
+		MapArchiveKeyThumbnail:  {Found: false, FileObject: nil, Required: false},
+		MapArchiveKeyOceanDepth: {Found: false, FileObject: nil, Required: false},
+	}
+
+	for _, file := range zipFiles {
+		switch file.Name {
+		case MapConfigFileName:
+			filesFound[MapArchiveKeyConfig] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		case MapDemandFileName:
+			filesFound[MapArchiveKeyDemandData] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		case MapRoadsFileName:
+			filesFound[MapArchiveKeyRoads] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		case MapRunwaysFileName:
+			filesFound[MapArchiveKeyRunways] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		case MapBuildingsFileName:
+			filesFound[MapArchiveKeyBuildings] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		case MapOceanDepthFileName:
+			filesFound[MapArchiveKeyOceanDepth] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
+		}
+		if path.Ext(file.Name) == MapTileFileExt {
+			filesFound[MapArchiveKeyTiles] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		}
+		if path.Ext(file.Name) == MapThumbnailFileExt {
+			filesFound[MapArchiveKeyThumbnail] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
+		}
+	}
+
+	return filesFound
+}
+
+// ValidateMapArchive validates required map archive files and parses config.json.
+func ValidateMapArchive(filePath string) (types.ConfigData, types.DownloaderErrorType, error) {
+	configData := types.ConfigData{}
+	reader, err := zip.OpenReader(filePath)
+	if err != nil {
+		return configData, types.InstallErrorInvalidArchive, err
+	}
+	defer reader.Close()
+
+	filesFound := BuildMapArchiveFileIndex(reader.File)
+
+	if !requiredFilesPresent(filesFound) {
+		return configData, types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{"map archive is missing one or more required files"}}
+	}
+
+	configReader, err := filesFound[MapArchiveKeyConfig].FileObject.Open()
+	if err != nil {
+		return configData, types.InstallErrorInvalidManifest, err
+	}
+	defer configReader.Close()
+
+	configBytes, err := io.ReadAll(configReader)
+	if err != nil {
+		return configData, types.InstallErrorInvalidManifest, err
+	}
+
+	configData, err = ParseJSON[types.ConfigData](configBytes, "config")
+	if err != nil {
+		return configData, types.InstallErrorInvalidManifest, err
+	}
+	if !types.LocalMapCodePattern.MatchString(configData.Code) {
+		return configData, types.InstallErrorInvalidMapCode, fmt.Errorf("invalid map code %q in config.json: must match ^[A-Z]{2,4}$", configData.Code)
+	}
+
+	return configData, "", nil
+}
+
+func readInstalledMapConfig(mapInstallRoot string, cityCode string) (types.ConfigData, types.DownloaderErrorType, error) {
+	configData := types.ConfigData{}
+	plainPath := paths.JoinLocalPath(mapInstallRoot, cityCode, MapConfigFileName)
+	file, err := os.Open(plainPath)
+	if err != nil {
+		return configData, types.InstallErrorInvalidManifest, fmt.Errorf("failed to open installed map config: %w", err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return configData, types.InstallErrorInvalidManifest, fmt.Errorf("failed to read installed map config payload: %w", err)
+	}
+	configData, err = ParseJSON[types.ConfigData](data, "installed map config")
+	if err != nil {
+		return configData, types.InstallErrorInvalidManifest, fmt.Errorf("failed to parse installed map config: %w", err)
+	}
+	if !types.LocalMapCodePattern.MatchString(configData.Code) {
+		return configData, types.InstallErrorInvalidMapCode, fmt.Errorf("invalid map code %q in installed map config: must match ^[A-Z]{2,4}$", configData.Code)
+	}
+
+	return configData, "", nil
+}
+
+// ValidateInstalledMapData validates installed map files under a city-code folder.
+// For local maps (isLocal=true), config.json is required and parsed.
+// For downloaded maps (isLocal=false), only the compressed city-data files are required.
+func ValidateInstalledMapData(mapInstallRoot string, cityCode string, isLocal bool) (types.ConfigData, types.DownloaderErrorType, error) {
+	if isLocal {
+		configPath := paths.JoinLocalPath(mapInstallRoot, cityCode, MapConfigFileName)
+		if _, err := os.Stat(configPath); err != nil {
+			if os.IsNotExist(err) {
+				return types.ConfigData{}, types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{fmt.Sprintf("missing installed map file: %s", configPath)}}
+			}
+			return types.ConfigData{}, types.InstallErrorFilesystem, fmt.Errorf("failed to stat installed map file %q: %w", configPath, err)
+		}
+	}
+
+	if errorType, err := validateRequiredInstalledMapFiles(mapInstallRoot, cityCode); err != nil {
+		return types.ConfigData{}, errorType, err
+	}
+
+	if !isLocal {
+		return types.ConfigData{}, "", nil
+	}
+
+	return readInstalledMapConfig(mapInstallRoot, cityCode)
+}
+
+func requiredFilesPresent(filesFound map[string]types.FileFoundStruct) bool {
+	for _, fileStruct := range filesFound {
+		if fileStruct.Required && !fileStruct.Found {
+			return false
+		}
+	}
+	return true
+}
+
+func validateRequiredInstalledMapFiles(mapInstallRoot string, cityCode string) (types.DownloaderErrorType, error) {
+	requiredPaths := []string{
+		paths.JoinLocalPath(mapInstallRoot, cityCode, MapDemandFileName+".gz"),
+		paths.JoinLocalPath(mapInstallRoot, cityCode, MapRoadsFileName+".gz"),
+		paths.JoinLocalPath(mapInstallRoot, cityCode, MapRunwaysFileName+".gz"),
+		paths.JoinLocalPath(mapInstallRoot, cityCode, MapBuildingsFileName+".gz"),
+	}
+
+	for _, filePath := range requiredPaths {
+		if _, err := os.Stat(filePath); err != nil {
+			if os.IsNotExist(err) {
+				return types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{fmt.Sprintf("missing installed map file: %s", filePath)}}
+			}
+			return types.InstallErrorFilesystem, fmt.Errorf("failed to stat installed map file %q: %w", filePath, err)
+		}
+	}
+	return "", nil
+}

--- a/internal/files/map_validation_test.go
+++ b/internal/files/map_validation_test.go
@@ -1,0 +1,261 @@
+package files
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"railyard/internal/paths"
+	"railyard/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMapArchive(t *testing.T) {
+	requiredFiles := func(configCode string) map[string][]byte {
+		return map[string][]byte{
+			MapConfigFileName:    mustMapConfigJSON(t, configCode),
+			MapDemandFileName:    []byte("{}"),
+			MapRoadsFileName:     []byte("{}"),
+			MapRunwaysFileName:   []byte("{}"),
+			MapBuildingsFileName: []byte("{}"),
+			"AAA.pmtiles":        []byte("tiles"),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		files       map[string][]byte
+		wantErrType types.DownloaderErrorType
+		wantErr     bool
+		wantCode    string
+	}{
+		{
+			name:        "valid archive",
+			files:       requiredFiles("AAA"),
+			wantErrType: "",
+			wantErr:     false,
+			wantCode:    "AAA",
+		},
+		{
+			name: "missing required file",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				delete(f, MapRoadsFileName)
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "invalid config json",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f[MapConfigFileName] = []byte("{invalid")
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidManifest,
+			wantErr:     true,
+		},
+		{
+			name:        "invalid map code",
+			files:       requiredFiles("dca"),
+			wantErrType: types.InstallErrorInvalidMapCode,
+			wantErr:     true,
+		},
+		{
+			name: "missing tile file",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				delete(f, "AAA.pmtiles")
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zipPath := writeZipArchive(t, tt.files)
+			config, errType, err := ValidateMapArchive(zipPath)
+			require.Equal(t, tt.wantErrType, errType)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCode, config.Code)
+		})
+	}
+}
+
+func TestValidateInstalledMapDataLocal(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, mapRoot, cityCode string)
+		wantErrType types.DownloaderErrorType
+		wantErr     bool
+		wantCode    string
+	}{
+		{
+			name: "valid local installed map data",
+			setup: func(t *testing.T, mapRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+			},
+			wantErrType: "",
+			wantErr:     false,
+			wantCode:    "AAA",
+		},
+		{
+			name: "missing config file",
+			setup: func(t *testing.T, mapRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+				configPath := paths.JoinLocalPath(mapRoot, cityCode, MapConfigFileName)
+				require.NoError(t, os.Remove(configPath))
+			},
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "missing required gz file",
+			setup: func(t *testing.T, mapRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+				roadsPath := paths.JoinLocalPath(mapRoot, cityCode, MapRoadsFileName+".gz")
+				require.NoError(t, os.Remove(roadsPath))
+			},
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "invalid installed config json",
+			setup: func(t *testing.T, mapRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+				configPath := paths.JoinLocalPath(mapRoot, cityCode, MapConfigFileName)
+				require.NoError(t, os.WriteFile(configPath, []byte("{invalid"), 0o644))
+			},
+			wantErrType: types.InstallErrorInvalidManifest,
+			wantErr:     true,
+		},
+		{
+			name: "invalid installed config map code",
+			setup: func(t *testing.T, mapRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "aaa")
+			},
+			wantErrType: types.InstallErrorInvalidMapCode,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapRoot := t.TempDir()
+			cityCode := "AAA"
+			tt.setup(t, mapRoot, cityCode)
+
+			config, errType, err := ValidateInstalledMapData(mapRoot, cityCode, true)
+			require.Equal(t, tt.wantErrType, errType)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCode, config.Code)
+		})
+	}
+}
+
+func TestValidateInstalledMapDataDownloaded(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, mapRoot, cityCode string)
+		wantErrType types.DownloaderErrorType
+		wantErr     bool
+	}{
+		{
+			name: "valid downloaded installed map data",
+			setup: func(t *testing.T, mapRoot, cityCode string) {
+				writeInstalledDownloadedMapFixture(t, mapRoot, cityCode)
+			},
+			wantErrType: "",
+			wantErr:     false,
+		},
+		{
+			name: "missing required file",
+			setup: func(t *testing.T, mapRoot, cityCode string) {
+				writeInstalledDownloadedMapFixture(t, mapRoot, cityCode)
+				demandPath := paths.JoinLocalPath(mapRoot, cityCode, MapDemandFileName+".gz")
+				require.NoError(t, os.Remove(demandPath))
+			},
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapRoot := t.TempDir()
+			cityCode := "AAA"
+			tt.setup(t, mapRoot, cityCode)
+
+			_, errType, err := ValidateInstalledMapData(mapRoot, cityCode, false)
+			require.Equal(t, tt.wantErrType, errType)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func mustMapConfigJSON(t *testing.T, code string) []byte {
+	t.Helper()
+	cfg := types.ConfigData{
+		Code:    code,
+		Name:    "Test Map",
+		Version: "1.0.0",
+	}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	return data
+}
+
+func writeZipArchive(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	zipPath := filepath.Join(t.TempDir(), "map.zip")
+	file, err := os.Create(zipPath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	zipWriter := zip.NewWriter(file)
+	for name, content := range files {
+		entry, createErr := zipWriter.Create(name)
+		require.NoError(t, createErr)
+		_, writeErr := entry.Write(content)
+		require.NoError(t, writeErr)
+	}
+	require.NoError(t, zipWriter.Close())
+	return zipPath
+}
+
+func writeInstalledDownloadedMapFixture(t *testing.T, mapRoot, cityCode string) {
+	t.Helper()
+	cityPath := paths.JoinLocalPath(mapRoot, cityCode)
+	require.NoError(t, os.MkdirAll(cityPath, 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapDemandFileName+".gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapRoadsFileName+".gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapRunwaysFileName+".gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapBuildingsFileName+".gz"), []byte("{}"), 0o644))
+}
+
+func writeInstalledLocalMapFixture(t *testing.T, mapRoot, cityCode, configCode string) {
+	t.Helper()
+	writeInstalledDownloadedMapFixture(t, mapRoot, cityCode)
+	configPath := paths.JoinLocalPath(mapRoot, cityCode, MapConfigFileName)
+	require.NoError(t, os.WriteFile(configPath, mustMapConfigJSON(t, configCode), 0o644))
+}

--- a/internal/profiles/profiles_sync.go
+++ b/internal/profiles/profiles_sync.go
@@ -155,7 +155,11 @@ func (s *UserProfiles) buildMapSyncArgs(profile types.UserProfile, isStale func(
 			getVersionsFn:  s.Registry.GetVersions,
 		},
 		install: func(assetID string, version string) types.AssetInstallResponse {
-			return s.Downloader.InstallAsset(types.AssetTypeMap, assetID, version)
+			return s.Downloader.InstallAsset(types.InstallAssetRequest{
+				AssetType: types.AssetTypeMap,
+				AssetID:   assetID,
+				Version:   version,
+			})
 		},
 		uninstall: func(assetID string) types.AssetUninstallResponse {
 			return s.Downloader.UninstallAsset(types.AssetTypeMap, assetID)
@@ -181,7 +185,11 @@ func (s *UserProfiles) buildModSyncArgs(profile types.UserProfile, isStale func(
 			getVersionsFn:  s.Registry.GetVersions,
 		},
 		install: func(assetID string, version string) types.AssetInstallResponse {
-			return s.Downloader.InstallAsset(types.AssetTypeMod, assetID, version)
+			return s.Downloader.InstallAsset(types.InstallAssetRequest{
+				AssetType: types.AssetTypeMod,
+				AssetID:   assetID,
+				Version:   version,
+			})
 		},
 		uninstall: func(assetID string) types.AssetUninstallResponse {
 			return s.Downloader.UninstallAsset(types.AssetTypeMod, assetID)

--- a/internal/profiles/profiles_sync_test.go
+++ b/internal/profiles/profiles_sync_test.go
@@ -344,10 +344,10 @@ func TestSyncSubscriptions(t *testing.T) {
 			svc, cfg, reg := loadedUserProfilesServiceWithDependencies(t, tc.state)
 			configureConfig(t, cfg)
 			for _, mod := range tc.initialMods {
-				reg.AddInstalledMod(mod.ID, mod.Version)
+				reg.AddInstalledMod(mod.ID, mod.Version, false)
 			}
 			for _, m := range tc.initialMaps {
-				reg.AddInstalledMap(m.ID, m.Version, m.MapConfig)
+				reg.AddInstalledMap(m.ID, m.Version, false, m.MapConfig)
 			}
 			var cleanup func()
 			if tc.prepare != nil {

--- a/internal/profiles/profiles_update_test.go
+++ b/internal/profiles/profiles_update_test.go
@@ -51,7 +51,7 @@ func TestUpdateSubscriptionsForceSyncPersistsStateAndSyncs(t *testing.T) {
 
 	svc, cfg, reg := loadedUserProfilesServiceWithDependencies(t, state)
 	cfg.Cfg.MetroMakerDataPath = t.TempDir()
-	reg.AddInstalledMod("mod-a", "2.0.0")
+	reg.AddInstalledMod("mod-a", "2.0.0", false)
 	materializeInstalledAssets(t, cfg, []types.InstalledModInfo{{ID: "mod-a", Version: "2.0.0"}}, nil)
 
 	req := types.UpdateSubscriptionsRequest{
@@ -383,7 +383,7 @@ func TestUpdateSubscriptionsToLatest(t *testing.T) {
 			setup: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
 				t.Helper()
 				configureConfig(t, cfg)
-				reg.AddInstalledMod("mod-missing", "1.0.0")
+				reg.AddInstalledMod("mod-missing", "1.0.0", false)
 				// Previously installed mod is now missing from registry (causing a lookup warning)
 				return mockRegistry(t, reg, []registryFixture{
 					{

--- a/internal/registry/bootstrap.go
+++ b/internal/registry/bootstrap.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"railyard/internal/constants"
 	"railyard/internal/files"
@@ -79,28 +78,117 @@ func (r *Registry) bootstrapInstalledMods(subscriptions types.Subscriptions, mod
 func (r *Registry) bootstrapInstalledMaps(subscriptions types.Subscriptions, mapInstallRoot string) []types.InstalledMapInfo {
 	r.logger.Info("Bootstrapping installed maps from subscriptions", "subscriptions", subscriptions.Maps)
 
-	installedMaps := make([]types.InstalledMapInfo, 0, len(subscriptions.Maps))
+	installedMaps := make([]types.InstalledMapInfo, 0, len(subscriptions.Maps)+len(subscriptions.LocalMaps))
+	installedMapById := make(map[string]types.InstalledMapInfo, len(r.installedMaps))
+	for _, installed := range r.installedMaps {
+		installedMapById[installed.ID] = installed
+	}
 
 	for mapID, version := range subscriptions.Maps {
-		manifest, err := r.GetMap(mapID)
-		// Map version is not stored in the manifest, so we only rely on the file's presence to determine if the map is installed.
-		if err != nil {
-			r.logger.Warn("Skipping subscribed map during installed-state bootstrap: missing manifest", "map_id", mapID, "error", err)
-			continue
+		if installedMap, ok := r.bootstrapMapSubscription(mapID, version, mapInstallRoot, false, installedMapById); ok {
+			installedMaps = append(installedMaps, installedMap)
 		}
-		cityCode := strings.TrimSpace(manifest.CityCode)
-		if cityCode == "" {
-			r.logger.Warn("Skipping subscribed map during installed-state bootstrap: missing city_code", "map_id", mapID)
-			continue
-		}
-		if !r.hasAssetMarker(types.AssetTypeMap, mapID, mapInstallRoot, cityCode) {
-			continue
-		}
+	}
 
-		installedMaps = append(installedMaps, installedMapInfoFromManifest(mapID, version, manifest))
+	for localMapID, version := range subscriptions.LocalMaps {
+		if installedMap, ok := r.bootstrapMapSubscription(localMapID, version, mapInstallRoot, true, installedMapById); ok {
+			installedMaps = append(installedMaps, installedMap)
+		}
 	}
 
 	return installedMaps
+}
+
+func (r *Registry) bootstrapMapSubscription(
+	mapID string,
+	version string,
+	mapInstallRoot string,
+	isLocal bool,
+	installedMapByID map[string]types.InstalledMapInfo,
+) (types.InstalledMapInfo, bool) {
+	var manifest *types.MapManifest
+	var localConfig *types.ConfigData
+	cityCode := mapID
+
+	if isLocal {
+		// Local maps require config to be present on disk since fields are not available from remote manifest
+		cfg, ok := r.validateMapData(mapID, mapInstallRoot, cityCode, true)
+		if !ok {
+			return types.InstalledMapInfo{}, false
+		}
+		localConfig = &cfg
+	} else {
+		if resolvedManifest, err := r.GetMap(mapID); err == nil {
+			manifest = resolvedManifest
+			cityCode = manifest.CityCode
+		} else {
+			installed, ok := installedMapByID[mapID]
+			if !ok || installed.MapConfig.Code == "" {
+				r.logger.Warn("Skipping subscribed map during installed-state bootstrap: missing manifest and no installed fallback", "map_id", mapID, "error", err)
+				return types.InstalledMapInfo{}, false
+			}
+			cityCode = installed.MapConfig.Code
+		}
+		if _, ok := r.validateMapData(mapID, mapInstallRoot, cityCode, false); !ok {
+			return types.InstalledMapInfo{}, false
+		}
+	}
+
+	config, ok := r.resolveConfig(installedMapByID[mapID], localConfig, manifest, version, cityCode)
+	if !ok {
+		r.logger.Warn("Skipping subscribed map during installed-state bootstrap: invalid config", "map_id", mapID, "map_code", cityCode, "is_local", isLocal)
+		return types.InstalledMapInfo{}, false
+	}
+	return types.InstalledMapInfo{ID: mapID, Version: version, IsLocal: isLocal, MapConfig: config}, true
+}
+
+func (r *Registry) resolveConfig(
+	installed types.InstalledMapInfo,
+	localConfig *types.ConfigData,
+	manifest *types.MapManifest,
+	version string,
+	cityCode string,
+) (types.ConfigData, bool) {
+	var config types.ConfigData
+	switch {
+	case installed.MapConfig.Code != "":
+		config = installed.MapConfig
+	case localConfig != nil:
+		config = *localConfig
+	case manifest != nil:
+		config = mapConfigFromManifest(manifest, version)
+	default:
+		return types.ConfigData{}, false
+	}
+	config.Code = cityCode
+	config.Version = version
+	// Recover country from manifest if the config was tampered
+	if config.Country == nil && manifest != nil {
+		config.Country = &manifest.Country
+	}
+	return config, true
+}
+
+func (r *Registry) validateMapData(
+	assetID string,
+	mapInstallRoot string,
+	cityCode string,
+	isLocal bool,
+) (types.ConfigData, bool) {
+	if !r.hasAssetMarker(types.AssetTypeMap, assetID, mapInstallRoot, cityCode) {
+		return types.ConfigData{}, false
+	}
+	configFromDisk, errorType, validationErr := files.ValidateInstalledMapData(mapInstallRoot, cityCode, isLocal)
+	if validationErr != nil {
+		r.logger.Warn("Skipping subscribed map during installed-state bootstrap: missing downloaded map data files", "map_id", assetID,
+			"map_code", cityCode,
+			"error_type", errorType,
+			"error", validationErr,
+			"is_local", isLocal)
+		return types.ConfigData{}, false
+	}
+
+	return configFromDisk, true
 }
 
 // modManifestVersionMatches checks if the manifest.json in the given mod path exists and has a version field matching the expected version (from profile state)

--- a/internal/registry/installed.go
+++ b/internal/registry/installed.go
@@ -59,18 +59,20 @@ func (r *Registry) getInstalledMapsFromDisk() ([]types.InstalledMapInfo, error) 
 }
 
 // AddInstalledMod adds a mod to the in-memory list of installed mods. Remember to call WriteInstalledToDisk() to persist changes.
-func (r *Registry) AddInstalledMod(modID string, version string) {
+func (r *Registry) AddInstalledMod(modID string, version string, isLocal bool) {
 	r.installedMods = append(r.installedMods, types.InstalledModInfo{
 		ID:      modID,
 		Version: version,
+		IsLocal: isLocal,
 	})
 }
 
 // AddInstalledMap adds a map to the in-memory list of installed maps. Remember to call WriteInstalledToDisk() to persist changes.
-func (r *Registry) AddInstalledMap(mapID string, version string, config types.ConfigData) {
+func (r *Registry) AddInstalledMap(mapID string, version string, isLocal bool, config types.ConfigData) {
 	r.installedMaps = append(r.installedMaps, types.InstalledMapInfo{
 		ID:        mapID,
 		Version:   version,
+		IsLocal:   isLocal,
 		MapConfig: config,
 	})
 }
@@ -111,6 +113,18 @@ func (r *Registry) GetInstalledModsResponse() types.InstalledModsResponse {
 // GetInstalledMaps returns the locally installed maps.
 func (r *Registry) GetInstalledMaps() []types.InstalledMapInfo {
 	return r.installedMaps
+}
+
+// GetRemoteInstalledMaps returns installed maps excluding local imports.
+func (r *Registry) GetRemoteInstalledMaps() []types.InstalledMapInfo {
+	remote := make([]types.InstalledMapInfo, 0, len(r.installedMaps))
+	for _, item := range r.installedMaps {
+		if item.IsLocal {
+			continue
+		}
+		remote = append(remote, item)
+	}
+	return remote
 }
 
 // GetInstalledMapsResponse returns installed maps with status metadata.

--- a/internal/registry/installed_manifest_helpers.go
+++ b/internal/registry/installed_manifest_helpers.go
@@ -27,6 +27,7 @@ func installedMapInfoFromManifest(mapID string, version string, manifest *types.
 	return types.InstalledMapInfo{
 		ID:        mapID,
 		Version:   version,
+		IsLocal:   false,
 		MapConfig: mapConfigFromManifest(manifest, version),
 	}
 }
@@ -38,5 +39,6 @@ func installedModInfoFromManifest(modID string, version string, manifest *types.
 	return types.InstalledModInfo{
 		ID:      modID,
 		Version: version,
+		IsLocal: false,
 	}
 }

--- a/internal/registry/installed_test.go
+++ b/internal/registry/installed_test.go
@@ -16,6 +16,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func writeInstalledMapFiles(t *testing.T, mapInstallRoot string, tilesRoot string, code string, config types.ConfigData) {
+	t.Helper()
+	mapDir := paths.JoinLocalPath(mapInstallRoot, code)
+	require.NoError(t, os.MkdirAll(mapDir, 0o755))
+	require.NoError(t, os.MkdirAll(tilesRoot, 0o755))
+
+	require.NoError(t, files.WriteJSON(paths.JoinLocalPath(mapDir, "config.json"), "installed map config", config))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapDir, "demand_data.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapDir, "roads.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapDir, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapDir, "buildings_index.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(tilesRoot, code+".pmtiles"), []byte("tiles"), 0o644))
+}
+
 func TestWriteInstalledToDiskPersistsMapsAndMods(t *testing.T) {
 	testutil.NewHarness(t)
 	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
@@ -189,6 +203,15 @@ func TestBootstrapInstalledStateFromProfileSuccessOnEmptyState(t *testing.T) {
 	mapPath := paths.JoinLocalPath(cfg.Cfg.MetroMakerDataPath, "cities", "data", "AAA")
 	require.NoError(t, os.MkdirAll(mapPath, 0o755))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, constants.RailyardAssetMarker), []byte(""), 0o644)) // Add asset marker
+	writeInstalledMapFiles(t, cfg.Cfg.GetMapsFolderPath(), paths.TilesPath(), "AAA", types.ConfigData{
+		Code:        "AAA",
+		Name:        "Map A",
+		Description: "Map Description",
+		Population:  123456,
+		Creator:     "Author A",
+		Country:     &country,
+		Version:     "2.0.0",
+	})
 
 	profile := types.DefaultProfile()
 	profile.Subscriptions.Mods["mod-a"] = "1.0.0"
@@ -237,4 +260,371 @@ func TestBootstrapInstalledStateFromProfileSuccessOnEmptyState(t *testing.T) {
 	mapsOnDisk, err := files.ReadJSON[[]types.InstalledMapInfo](paths.InstalledMapsPath(), "installed maps file", files.JSONReadOptions{})
 	require.NoError(t, err)
 	require.Equal(t, reg.GetInstalledMaps(), mapsOnDisk)
+}
+
+func TestBootstrapInstalledStateFromProfilePreservesExistingRemoteMapWhenManifestMissing(t *testing.T) {
+	testutil.NewHarness(t)
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	testutil.SetValidConfigPaths(t, &cfg.Cfg)
+	reg := NewRegistry(testutil.TestLogSink{}, cfg)
+	reg.installedMaps = []types.InstalledMapInfo{
+		{
+			ID:      "missing-map",
+			Version: "1.0.0",
+			IsLocal: false,
+			MapConfig: types.ConfigData{
+				Code:    "MIS",
+				Name:    "Missing",
+				Version: "1.0.0",
+				Country: func() *string { value := "US"; return &value }(),
+			},
+		},
+	}
+
+	require.NoError(t, os.MkdirAll(paths.RegistryRepoPath(), 0o755))
+	reg.maps = []types.MapManifest{}
+	mapPath := paths.JoinLocalPath(cfg.Cfg.GetMapsFolderPath(), "MIS")
+	require.NoError(t, os.MkdirAll(mapPath, 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, constants.RailyardAssetMarker), []byte(""), 0o644))
+	writeInstalledMapFiles(t, cfg.Cfg.GetMapsFolderPath(), paths.TilesPath(), "MIS", types.ConfigData{
+		Code:    "MIS",
+		Name:    "Missing",
+		Version: "1.0.0",
+		Country: func() *string { value := "US"; return &value }(),
+	})
+
+	profile := types.DefaultProfile()
+	profile.Subscriptions.Maps["missing-map"] = "1.0.0"
+
+	require.NoError(t, reg.BootstrapInstalledStateFromProfile(profile))
+	require.Len(t, reg.GetInstalledMaps(), 1)
+	require.Equal(t, "missing-map", reg.GetInstalledMaps()[0].ID)
+	require.Equal(t, "MIS", reg.GetInstalledMaps()[0].MapConfig.Code)
+}
+
+func TestBootstrapInstalledStateFromProfileHydratesLocalMapConfigFromDisk(t *testing.T) {
+	testutil.NewHarness(t)
+	registrytest.WriteFixture(t, registrytest.RepositoryFixture{})
+
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	testutil.SetValidConfigPaths(t, &cfg.Cfg)
+	reg := NewRegistry(testutil.TestLogSink{}, cfg)
+	require.NoError(t, reg.fetchFromDisk())
+
+	country := "JP"
+	cityCode := "KCZ"
+	pitch := 35.0
+	configData := types.ConfigData{
+		Code:        cityCode,
+		Name:        "Kochi",
+		Description: "Local imported map",
+		Population:  340000,
+		Creator:     "suscat",
+		Country:     &country,
+		Version:     "0.9.0",
+		InitialViewState: struct {
+			Latitude  float64  `json:"latitude"`
+			Longitude float64  `json:"longitude"`
+			Zoom      float64  `json:"zoom"`
+			Pitch     *float64 `json:"pitch,omitempty"`
+			Bearing   float64  `json:"bearing"`
+		}{
+			Latitude:  33.5597,
+			Longitude: 133.5311,
+			Zoom:      11.5,
+			Pitch:     &pitch,
+			Bearing:   12,
+		},
+	}
+	mapPath := paths.JoinLocalPath(cfg.Cfg.GetMapsFolderPath(), cityCode)
+	require.NoError(t, os.MkdirAll(mapPath, 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, constants.RailyardAssetMarker), []byte(""), 0o644))
+	writeInstalledMapFiles(t, cfg.Cfg.GetMapsFolderPath(), paths.TilesPath(), cityCode, configData)
+	localMapID := cityCode
+	reg.installedMaps = []types.InstalledMapInfo{
+		{
+			ID:        localMapID,
+			Version:   "1.0.0",
+			IsLocal:   true,
+			MapConfig: configData,
+		},
+	}
+
+	profile := types.DefaultProfile()
+	profile.Subscriptions.LocalMaps[localMapID] = "1.2.3"
+
+	require.NoError(t, reg.BootstrapInstalledStateFromProfile(profile))
+
+	installedMaps := reg.GetInstalledMaps()
+	require.Len(t, installedMaps, 1)
+	require.Equal(t, localMapID, installedMaps[0].ID)
+	require.True(t, installedMaps[0].IsLocal)
+	require.Equal(t, "1.2.3", installedMaps[0].Version)
+	require.Equal(t, "1.2.3", installedMaps[0].MapConfig.Version)
+	require.Equal(t, cityCode, installedMaps[0].MapConfig.Code)
+	require.Equal(t, configData.Name, installedMaps[0].MapConfig.Name)
+	require.Equal(t, configData.Description, installedMaps[0].MapConfig.Description)
+	require.Equal(t, configData.Population, installedMaps[0].MapConfig.Population)
+	require.Equal(t, configData.Creator, installedMaps[0].MapConfig.Creator)
+	require.Equal(t, configData.Country, installedMaps[0].MapConfig.Country)
+	require.Equal(t, configData.InitialViewState, installedMaps[0].MapConfig.InitialViewState)
+}
+
+func TestBootstrapInstalledStateFromProfileKeepsRemoteMapWhenDownloadedDataFilesExist(t *testing.T) {
+	testutil.NewHarness(t)
+	country := "IT"
+	registrytest.WriteFixture(t, registrytest.RepositoryFixture{
+		Maps: []types.MapManifest{
+			{
+				ID:          "map-a",
+				CityCode:    "AAA",
+				Name:        "Map A",
+				Description: "Map Description",
+				Author:      "Author A",
+				Country:     country,
+				Population:  123456,
+			},
+		},
+	})
+
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	testutil.SetValidConfigPaths(t, &cfg.Cfg)
+	reg := NewRegistry(testutil.TestLogSink{}, cfg)
+	require.NoError(t, reg.fetchFromDisk())
+
+	mapPath := paths.JoinLocalPath(cfg.Cfg.MetroMakerDataPath, "cities", "data", "AAA")
+	require.NoError(t, os.MkdirAll(mapPath, 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, constants.RailyardAssetMarker), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "buildings_index.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+
+	profile := types.DefaultProfile()
+	profile.Subscriptions.Maps["map-a"] = "2.0.0"
+
+	require.NoError(t, reg.BootstrapInstalledStateFromProfile(profile))
+	require.Len(t, reg.GetInstalledMaps(), 1)
+	require.Equal(t, "map-a", reg.GetInstalledMaps()[0].ID)
+	require.Equal(t, "2.0.0", reg.GetInstalledMaps()[0].Version)
+}
+
+func TestBootstrapInstalledStateFromProfilePreservesExistingRemoteMapConfigAndBackfillsCountry(t *testing.T) {
+	testutil.NewHarness(t)
+	country := "IT"
+	registrytest.WriteFixture(t, registrytest.RepositoryFixture{
+		Maps: []types.MapManifest{
+			{
+				ID:          "map-a",
+				CityCode:    "AAA",
+				Name:        "Registry Name",
+				Description: "Registry Description",
+				Author:      "Registry Author",
+				Country:     country,
+				Population:  123456,
+			},
+		},
+	})
+
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	testutil.SetValidConfigPaths(t, &cfg.Cfg)
+	reg := NewRegistry(testutil.TestLogSink{}, cfg)
+	require.NoError(t, reg.fetchFromDisk())
+
+	mapPath := paths.JoinLocalPath(cfg.Cfg.GetMapsFolderPath(), "AAA")
+	require.NoError(t, os.MkdirAll(mapPath, 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, constants.RailyardAssetMarker), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "buildings_index.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+
+	reg.installedMaps = []types.InstalledMapInfo{
+		{
+			ID:      "map-a",
+			Version: "1.0.0",
+			IsLocal: false,
+			MapConfig: types.ConfigData{
+				Code:        "AAA",
+				Name:        "Existing Name",
+				Description: "Existing Description",
+				Population:  654321,
+				Creator:     "Existing Author",
+				Version:     "1.0.0",
+			},
+		},
+	}
+
+	profile := types.DefaultProfile()
+	profile.Subscriptions.Maps["map-a"] = "2.0.0"
+
+	require.NoError(t, reg.BootstrapInstalledStateFromProfile(profile))
+	require.Len(t, reg.GetInstalledMaps(), 1)
+	mapInfo := reg.GetInstalledMaps()[0]
+	require.Equal(t, "map-a", mapInfo.ID)
+	require.False(t, mapInfo.IsLocal)
+	require.Equal(t, "2.0.0", mapInfo.Version)
+	require.Equal(t, "AAA", mapInfo.MapConfig.Code)
+	require.Equal(t, "2.0.0", mapInfo.MapConfig.Version)
+	require.Equal(t, "Existing Name", mapInfo.MapConfig.Name)
+	require.Equal(t, "Existing Description", mapInfo.MapConfig.Description)
+	require.Equal(t, 654321, mapInfo.MapConfig.Population)
+	require.Equal(t, "Existing Author", mapInfo.MapConfig.Creator)
+	require.NotNil(t, mapInfo.MapConfig.Country)
+	require.Equal(t, country, *mapInfo.MapConfig.Country)
+}
+
+func TestBootstrapInstalledStateFromProfileKeepsLocalMap(t *testing.T) {
+	testutil.NewHarness(t)
+	registrytest.WriteFixture(t, registrytest.RepositoryFixture{})
+
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	testutil.SetValidConfigPaths(t, &cfg.Cfg)
+	reg := NewRegistry(testutil.TestLogSink{}, cfg)
+	require.NoError(t, reg.fetchFromDisk())
+
+	cityCode := "KCZ"
+	mapPath := paths.JoinLocalPath(cfg.Cfg.GetMapsFolderPath(), cityCode)
+	require.NoError(t, os.MkdirAll(mapPath, 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, constants.RailyardAssetMarker), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "buildings_index.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+	country := "JP"
+	require.NoError(t, files.WriteJSON(paths.JoinLocalPath(mapPath, "config.json"), "installed map config", types.ConfigData{
+		Code:    cityCode,
+		Name:    "Kochi",
+		Version: "0.0.1",
+		Country: &country,
+	}))
+
+	localMapID := cityCode
+	profile := types.DefaultProfile()
+	profile.Subscriptions.LocalMaps[localMapID] = "1.2.3"
+
+	require.NoError(t, reg.BootstrapInstalledStateFromProfile(profile))
+	installedMaps := reg.GetInstalledMaps()
+	require.Len(t, installedMaps, 1)
+	require.Equal(t, localMapID, installedMaps[0].ID)
+	require.True(t, installedMaps[0].IsLocal)
+	require.Equal(t, cityCode, installedMaps[0].MapConfig.Code)
+	require.Equal(t, "1.2.3", installedMaps[0].MapConfig.Version)
+}
+
+func TestBootstrapInstalledStateFromProfilePrefersExistingInstalledConfigForLocalMap(t *testing.T) {
+	testutil.NewHarness(t)
+	registrytest.WriteFixture(t, registrytest.RepositoryFixture{})
+
+	cfg := config.NewConfig(testutil.TestLogSink{})
+	testutil.SetValidConfigPaths(t, &cfg.Cfg)
+	reg := NewRegistry(testutil.TestLogSink{}, cfg)
+	require.NoError(t, reg.fetchFromDisk())
+
+	cityCode := "KCZ"
+	mapPath := paths.JoinLocalPath(cfg.Cfg.GetMapsFolderPath(), cityCode)
+	require.NoError(t, os.MkdirAll(mapPath, 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, constants.RailyardAssetMarker), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "buildings_index.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+
+	diskCountry := "JP"
+	require.NoError(t, files.WriteJSON(paths.JoinLocalPath(mapPath, "config.json"), "installed map config", types.ConfigData{
+		Code:        cityCode,
+		Name:        "Disk Name",
+		Description: "Disk Description",
+		Population:  100,
+		Creator:     "Disk Author",
+		Version:     "0.0.1",
+		Country:     &diskCountry,
+	}))
+
+	existingCountry := "US"
+	reg.installedMaps = []types.InstalledMapInfo{
+		{
+			ID:      cityCode,
+			Version: "1.0.0",
+			IsLocal: true,
+			MapConfig: types.ConfigData{
+				Code:        cityCode,
+				Name:        "Existing Name",
+				Description: "Existing Description",
+				Population:  999,
+				Creator:     "Existing Author",
+				Version:     "1.0.0",
+				Country:     &existingCountry,
+			},
+		},
+	}
+
+	profile := types.DefaultProfile()
+	profile.Subscriptions.LocalMaps[cityCode] = "1.2.3"
+
+	require.NoError(t, reg.BootstrapInstalledStateFromProfile(profile))
+
+	installedMaps := reg.GetInstalledMaps()
+	require.Len(t, installedMaps, 1)
+	require.Equal(t, cityCode, installedMaps[0].ID)
+	require.True(t, installedMaps[0].IsLocal)
+	require.Equal(t, "Existing Name", installedMaps[0].MapConfig.Name)
+	require.Equal(t, "Existing Description", installedMaps[0].MapConfig.Description)
+	require.Equal(t, 999, installedMaps[0].MapConfig.Population)
+	require.Equal(t, "Existing Author", installedMaps[0].MapConfig.Creator)
+	require.NotNil(t, installedMaps[0].MapConfig.Country)
+	require.Equal(t, existingCountry, *installedMaps[0].MapConfig.Country)
+	require.Equal(t, cityCode, installedMaps[0].MapConfig.Code)
+	require.Equal(t, "1.2.3", installedMaps[0].MapConfig.Version)
+}
+
+func TestInstalledStatePersistsMutations(t *testing.T) {
+	testutil.NewHarness(t)
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+
+	reg.AddInstalledMod("mod-a", "1.0.0", true)
+	reg.AddInstalledMod("mod-b", "2.0.0", false)
+	reg.AddInstalledMap("map-a", "1.0.0", true, types.ConfigData{Code: "AAA"})
+	reg.AddInstalledMap("map-b", "2.0.0", false, types.ConfigData{Code: "BBB"})
+
+	require.Len(t, reg.GetInstalledMods(), 2)
+	require.Len(t, reg.GetInstalledMaps(), 2)
+	require.ElementsMatch(t, []string{"AAA", "BBB"}, reg.GetInstalledMapCodes())
+
+	modsResp := reg.GetInstalledModsResponse()
+	require.Equal(t, types.ResponseSuccess, modsResp.Status)
+	require.Len(t, modsResp.Mods, 2)
+
+	mapsResp := reg.GetInstalledMapsResponse()
+	require.Equal(t, types.ResponseSuccess, mapsResp.Status)
+	require.Len(t, mapsResp.Maps, 2)
+
+	reg.RemoveInstalledMod("mod-a")
+	reg.RemoveInstalledMap("map-a")
+	require.Equal(t, []types.InstalledModInfo{
+		{ID: "mod-b", Version: "2.0.0", IsLocal: false},
+	}, reg.GetInstalledMods())
+	require.Equal(t, []types.InstalledMapInfo{
+		{ID: "map-b", Version: "2.0.0", IsLocal: false, MapConfig: types.ConfigData{Code: "BBB"}},
+	}, reg.GetInstalledMaps())
+}
+
+func TestGetRemoteInstalledMaps(t *testing.T) {
+	testutil.NewHarness(t)
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+
+	reg.AddInstalledMap("map-remote", "1.0.0", false, types.ConfigData{Code: "AAA"})
+	reg.AddInstalledMap("map-local", "1.2.0", true, types.ConfigData{Code: "BBB"})
+
+	remote := reg.GetRemoteInstalledMaps()
+	require.Equal(t, []types.InstalledMapInfo{
+		{
+			ID:      "map-remote",
+			Version: "1.0.0",
+			IsLocal: false,
+			MapConfig: types.ConfigData{
+				Code: "AAA",
+			},
+		},
+	}, remote)
 }

--- a/internal/types/app_types.go
+++ b/internal/types/app_types.go
@@ -47,6 +47,11 @@ type SandboxStatusResponse struct {
 	Installed bool `json:"installed"`
 }
 
+type ImportAssetDialogResponse struct {
+	GenericResponse
+	Path string `json:"path"`
+}
+
 type GameRunningResponse struct {
 	GenericResponse
 	Running bool `json:"running"`

--- a/internal/types/common.go
+++ b/internal/types/common.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"io"
+	"regexp"
 	"strings"
 	"time"
 
@@ -30,11 +31,24 @@ type DownloadTempResponse struct {
 	Path string `json:"path,omitempty"`
 }
 
+type AssetConflict struct {
+	ExistingAssetID   string    `json:"existingAssetId"`
+	ExistingAssetType AssetType `json:"existingAssetType"`
+	ExistingVersion   string    `json:"existingVersion"`
+	ExistingIsLocal   bool      `json:"existingIsLocal"`
+}
+
+type MapCodeConflict struct {
+	AssetConflict
+	CityCode string `json:"cityCode"`
+}
+
 type DownloaderErrorType string
 
 const (
 	InstallErrorInvalidAssetType   DownloaderErrorType = "install_invalid_asset_type"
 	InstallErrorInvalidConfig      DownloaderErrorType = "install_invalid_config"
+	InstallErrorInvalidMapCode     DownloaderErrorType = "install_invalid_map_code"
 	InstallErrorRegistryLookup     DownloaderErrorType = "install_registry_lookup_failed"
 	InstallErrorVersionLookup      DownloaderErrorType = "install_version_lookup_failed"
 	InstallErrorVersionNotFound    DownloaderErrorType = "install_version_not_found"
@@ -67,11 +81,27 @@ func AutoPurgeDownloadErrors(err DownloaderErrorType) bool {
 
 type AssetInstallResponse struct {
 	GenericResponse
-	AssetType AssetType           `json:"assetType"`
-	AssetID   string              `json:"assetId"`
-	Version   string              `json:"version"`
-	Config    ConfigData          `json:"config,omitempty"`
-	ErrorType DownloaderErrorType `json:"errorType,omitempty"`
+	AssetType       AssetType           `json:"assetType"`
+	AssetID         string              `json:"assetId"`
+	Version         string              `json:"version"`
+	Config          ConfigData          `json:"config,omitempty"`
+	ErrorType       DownloaderErrorType `json:"errorType,omitempty"`
+	MapCodeConflict *MapCodeConflict    `json:"mapCodeConflict,omitempty"`
+}
+
+type MapInstallOptions struct {
+	ReplaceOnConflict bool `json:"replaceOnConflict"`
+}
+
+// Reserved for future mod-specific install options.
+type ModInstallOptions struct{}
+
+type InstallAssetRequest struct {
+	AssetType AssetType          `json:"assetType"`
+	AssetID   string             `json:"assetId"`
+	Version   string             `json:"version"`
+	Map       *MapInstallOptions `json:"map,omitempty"`
+	Mod       *ModInstallOptions `json:"mod,omitempty"`
 }
 
 type AssetUninstallResponse struct {
@@ -111,6 +141,8 @@ const (
 	AssetTypeMap AssetType = "map"
 	AssetTypeMod AssetType = "mod"
 )
+
+var LocalMapCodePattern = regexp.MustCompile(`^[A-Z]{2,4}$`)
 
 func IsValidAssetType(assetType AssetType) bool {
 	switch assetType {

--- a/internal/types/common_test.go
+++ b/internal/types/common_test.go
@@ -89,3 +89,23 @@ func TestProgressReader(t *testing.T) {
 	require.Equal(t, int64(len(payload)), lastReceived)
 	require.Equal(t, int64(len(payload)), lastTotal)
 }
+
+func TestLocalMapCodePattern(t *testing.T) {
+	require.True(t, LocalMapCodePattern.MatchString("AB"))
+	require.True(t, LocalMapCodePattern.MatchString("ABC"))
+	require.True(t, LocalMapCodePattern.MatchString("ABCD"))
+	require.False(t, LocalMapCodePattern.MatchString("A"))
+	require.False(t, LocalMapCodePattern.MatchString("ABCDE"))
+	require.False(t, LocalMapCodePattern.MatchString("AbC"))
+	require.False(t, LocalMapCodePattern.MatchString("abc"))
+	require.False(t, LocalMapCodePattern.MatchString("AB1"))
+	require.False(t, LocalMapCodePattern.MatchString(" AB"))
+	require.False(t, LocalMapCodePattern.MatchString("AB "))
+}
+
+func TestNormalizeSemver(t *testing.T) {
+	require.Equal(t, "v1.2.3", NormalizeSemver("1.2.3"))
+	require.Equal(t, "v1.2.3", NormalizeSemver("v1.2.3"))
+	require.Equal(t, "v1.2.3", NormalizeSemver(" 1.2.3 "))
+	require.Equal(t, "", NormalizeSemver("   "))
+}

--- a/internal/types/profile_types.go
+++ b/internal/types/profile_types.go
@@ -61,8 +61,9 @@ type Favorites struct {
 
 // Subscriptions represents the maps/mods and their respective versions that a user is subscribed to.
 type Subscriptions struct {
-	Maps map[string]string `json:"maps"`
-	Mods map[string]string `json:"mods"`
+	Maps      map[string]string `json:"maps"`
+	LocalMaps map[string]string `json:"localMaps"`
+	Mods      map[string]string `json:"mods"`
 }
 
 type SubscriptionAction string
@@ -84,13 +85,22 @@ func IsValidSubscriptionAction(action SubscriptionAction) bool {
 type SubscriptionUpdateItem struct {
 	Version Version   `json:"version"`
 	Type    AssetType `json:"type"`
+	IsLocal bool      `json:"isLocal,omitempty"`
 }
 
 type UpdateSubscriptionsRequest struct {
-	ProfileID string                            `json:"profileId"`
-	Assets    map[string]SubscriptionUpdateItem `json:"assets"`
-	Action    SubscriptionAction                `json:"action"`
-	ForceSync bool                              `json:"forceSync"`
+	ProfileID         string                            `json:"profileId"`
+	Assets            map[string]SubscriptionUpdateItem `json:"assets"`
+	Action            SubscriptionAction                `json:"action"`
+	ForceSync         bool                              `json:"forceSync"`
+	ReplaceOnConflict bool                              `json:"replaceOnConflict"`
+}
+
+type ImportAssetRequest struct {
+	ProfileID         string    `json:"profileId"`
+	AssetType         AssetType `json:"assetType"`
+	ZipPath           string    `json:"zipPath"`
+	ReplaceOnConflict bool      `json:"replaceOnConflict"`
 }
 
 type UpdateSubscriptionsToLatestRequest struct {
@@ -105,6 +115,7 @@ const (
 	UpdateSubscriptions UpdateSubscriptionRequestType = "update_subscriptions"
 	LatestCheck         UpdateSubscriptionRequestType = "latest_check"
 	LatestApply         UpdateSubscriptionRequestType = "latest_apply"
+	ImportAsset         UpdateSubscriptionRequestType = "import_asset"
 )
 
 type SubscriptionOperation struct {
@@ -175,6 +186,7 @@ type UpdateSubscriptionsResult struct {
 	Persisted      bool                          `json:"persisted"`      // whether the updated profile state was persisted to disk (if applicable)
 	Operations     []SubscriptionOperation       `json:"operations"`     // the list of subscription operations that were performed (if any)
 	Errors         []UserProfilesError           `json:"errors"`         // errors that were encountered during the subscription update process
+	Conflicts      []MapCodeConflict             `json:"conflicts"`      // map code conflicts that require explicit confirmation to replace
 }
 
 type SyncSubscriptionsResult struct {
@@ -231,8 +243,9 @@ func defaultFavorites() Favorites {
 
 func defaultSubscriptions() Subscriptions {
 	return Subscriptions{
-		Maps: map[string]string{},
-		Mods: map[string]string{},
+		Maps:      map[string]string{},
+		LocalMaps: map[string]string{},
+		Mods:      map[string]string{},
 	}
 }
 
@@ -346,6 +359,9 @@ func ValidateState(s UserProfilesState) (UserProfilesState, error) {
 		// Collections must be present (non-nil).
 		if p.Subscriptions.Maps == nil || p.Subscriptions.Mods == nil {
 			return UserProfilesState{}, fmt.Errorf("%w: profiles[%q] subscriptions maps/mods must be present", ErrMalformedProfile, key)
+		}
+		if p.Subscriptions.LocalMaps == nil {
+			p.Subscriptions.LocalMaps = map[string]string{}
 		}
 		if p.Favorites.Authors == nil || p.Favorites.Maps == nil || p.Favorites.Mods == nil {
 			return UserProfilesState{}, fmt.Errorf("%w: profiles[%q] favorites authors/maps/mods must be present", ErrMalformedProfile, key)

--- a/internal/types/profile_types_test.go
+++ b/internal/types/profile_types_test.go
@@ -181,3 +181,9 @@ func TestValidateStateRejectsInvalidProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidSubscriptionAction(t *testing.T) {
+	require.True(t, IsValidSubscriptionAction(SubscriptionActionSubscribe))
+	require.True(t, IsValidSubscriptionAction(SubscriptionActionUnsubscribe))
+	require.False(t, IsValidSubscriptionAction(SubscriptionAction("invalid")))
+}

--- a/internal/types/registry_types.go
+++ b/internal/types/registry_types.go
@@ -40,6 +40,7 @@ type ModsResponse struct {
 type InstalledModInfo struct {
 	ID      string `json:"id"`
 	Version string `json:"version"`
+	IsLocal bool   `json:"isLocal"` // Unused for now
 }
 
 type InstalledModsResponse struct {
@@ -51,6 +52,7 @@ type InstalledModsResponse struct {
 type InstalledMapInfo struct {
 	ID        string     `json:"id"`
 	Version   string     `json:"version"`
+	IsLocal   bool       `json:"isLocal"` // Indicates whether or not the map was installed from a local file rather than downloaded via the registry
 	MapConfig ConfigData `json:"config"`
 }
 


### PR DESCRIPTION
This PR does a lot of things
 - Add ImportAsset (to complement InstallAsset)
 - Central map validation into map_validation.go (since now both installMap/importMap will use it)
 - Update bootstrapping to account for imported assets
 - Lots of tests