### PR TITLE
[Backend] Move file dialogs to a separate file

### DIFF
--- a/app.go
+++ b/app.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -52,47 +51,6 @@ type App struct {
 	startupReady  bool
 
 	deepLinks deepLinkQueue
-}
-
-func (a *App) OpenInFileExplorer(targetPath string) types.GenericResponse {
-	a.Logger.Info("Spawning file explorer", "path", targetPath)
-	trimmedPath := strings.TrimSpace(targetPath)
-	if trimmedPath == "" {
-		a.Logger.Warn("Invalid path provided to OpenInFileExplorer", "path", targetPath)
-		return types.ErrorResponse("invalid path")
-	}
-	cleanedPath := paths.NormalizeLocalPath(trimmedPath)
-	if cleanedPath == "" {
-		a.Logger.Warn("Invalid path provided to OpenInFileExplorer", "path", targetPath)
-		return types.ErrorResponse("invalid path")
-	}
-
-	info, err := os.Stat(cleanedPath)
-	if err != nil {
-		a.Logger.Warn("Failed to stat path in OpenInFileExplorer", "path", cleanedPath, "error", err)
-		return types.ErrorResponse(fmt.Sprintf("failed to resolve path: %v", err))
-	}
-	if !info.IsDir() {
-		cleanedPath = filepath.Dir(cleanedPath)
-	}
-
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "windows":
-		cmd = exec.Command("explorer", cleanedPath)
-	case "darwin":
-		cmd = exec.Command("open", cleanedPath)
-	default:
-		cmd = exec.Command("xdg-open", cleanedPath)
-	}
-
-	if err := cmd.Start(); err != nil {
-		a.Logger.Warn("Failed to open path in file explorer", "path", cleanedPath, "error", err)
-		return types.ErrorResponse(fmt.Sprintf("failed to open path in file explorer: %v", err))
-	}
-
-	a.Logger.Info("File explorer opened successfully", "path", cleanedPath)
-	return types.SuccessResponse("opened in file explorer")
 }
 
 // NewApp creates a new App application struct

--- a/app_dialog.go
+++ b/app_dialog.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"railyard/internal/dialog"
+	"railyard/internal/types"
+)
+
+func (a *App) OpenInFileExplorer(targetPath string) types.GenericResponse {
+	return dialog.OpenInFileExplorer(targetPath)
+}
+
+func (a *App) OpenImportAssetDialog(assetType types.AssetType) types.ImportAssetDialogResponse {
+	return dialog.OpenImportAssetDialog(a.ctx, assetType)
+}

--- a/internal/dialog/explorer.go
+++ b/internal/dialog/explorer.go
@@ -1,0 +1,82 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"railyard/internal/paths"
+	"railyard/internal/types"
+
+	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+func OpenInFileExplorer(targetPath string) types.GenericResponse {
+	trimmedPath := strings.TrimSpace(targetPath)
+	if trimmedPath == "" {
+		return types.ErrorResponse("invalid path")
+	}
+	cleanedPath := paths.NormalizeLocalPath(trimmedPath)
+	if cleanedPath == "" {
+		return types.ErrorResponse("invalid path")
+	}
+
+	info, err := os.Stat(cleanedPath)
+	if err != nil {
+		return types.ErrorResponse(fmt.Sprintf("failed to resolve path: %v", err))
+	}
+	if !info.IsDir() {
+		cleanedPath = filepath.Dir(cleanedPath)
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("explorer", cleanedPath)
+	case "darwin":
+		cmd = exec.Command("open", cleanedPath)
+	default:
+		cmd = exec.Command("xdg-open", cleanedPath)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return types.ErrorResponse(fmt.Sprintf("failed to open path in file explorer: %v", err))
+	}
+	return types.SuccessResponse("opened in file explorer")
+}
+
+func OpenImportAssetArchive(ctx context.Context) (string, error) {
+	return wruntime.OpenFileDialog(ctx, wruntime.OpenDialogOptions{
+		Title: "Import Map Archive",
+		Filters: []wruntime.FileFilter{
+			{
+				DisplayName: "ZIP Archives",
+				Pattern:     "*.zip",
+			},
+		},
+	})
+}
+
+func OpenImportAssetDialog(ctx context.Context, assetType types.AssetType) types.ImportAssetDialogResponse {
+	selectedPath, err := OpenImportAssetArchive(ctx)
+	if err != nil {
+		return types.ImportAssetDialogResponse{
+			GenericResponse: types.ErrorResponse(fmt.Sprintf("Failed to open import dialog: %v", err)),
+			Path:            "",
+		}
+	}
+	if selectedPath == "" {
+		return types.ImportAssetDialogResponse{
+			GenericResponse: types.WarnResponse("Import cancelled"),
+			Path:            "",
+		}
+	}
+	return types.ImportAssetDialogResponse{
+		GenericResponse: types.SuccessResponse("Asset archive selected"),
+		Path:            selectedPath,
+	}
+}

--- a/internal/types/app_types.go
+++ b/internal/types/app_types.go
@@ -47,6 +47,11 @@ type SandboxStatusResponse struct {
 	Installed bool `json:"installed"`
 }
 
+type ImportAssetDialogResponse struct {
+	GenericResponse
+	Path string `json:"path"`
+}
+
 type GameRunningResponse struct {
 	GenericResponse
 	Running bool `json:"running"`


### PR DESCRIPTION
This PR moves file dialog functions out of app.go and into explorer.go + adds a new function for importing zips