### PR TITLE
[Backend] Enforce PMTiles present for validate install

### DIFF
--- a/internal/files/map_validation.go
+++ b/internal/files/map_validation.go
@@ -137,7 +137,7 @@ func readInstalledMapConfig(mapInstallRoot string, cityCode string) (types.Confi
 // ValidateInstalledMapData validates installed map files under a city-code folder.
 // For local maps (isLocal=true), config.json is required and parsed.
 // For downloaded maps (isLocal=false), only the compressed city-data files are required.
-func ValidateInstalledMapData(mapInstallRoot string, cityCode string, isLocal bool) (types.ConfigData, types.DownloaderErrorType, error) {
+func ValidateInstalledMapData(mapInstallRoot string, mapTilesRoot string, cityCode string, isLocal bool) (types.ConfigData, types.DownloaderErrorType, error) {
 	if isLocal {
 		configPath := paths.JoinLocalPath(mapInstallRoot, cityCode, MapConfigFileName)
 		if _, err := os.Stat(configPath); err != nil {
@@ -148,7 +148,7 @@ func ValidateInstalledMapData(mapInstallRoot string, cityCode string, isLocal bo
 		}
 	}
 
-	if errorType, err := validateRequiredInstalledMapFiles(mapInstallRoot, cityCode); err != nil {
+	if errorType, err := validateRequiredInstalledMapFiles(mapInstallRoot, mapTilesRoot, cityCode); err != nil {
 		return types.ConfigData{}, errorType, err
 	}
 
@@ -168,12 +168,13 @@ func requiredFilesPresent(filesFound map[string]types.FileFoundStruct) bool {
 	return true
 }
 
-func validateRequiredInstalledMapFiles(mapInstallRoot string, cityCode string) (types.DownloaderErrorType, error) {
+func validateRequiredInstalledMapFiles(mapInstallRoot string, mapTilesRoot string, cityCode string) (types.DownloaderErrorType, error) {
 	requiredPaths := []string{
 		paths.JoinLocalPath(mapInstallRoot, cityCode, MapDemandFileName+".gz"),
 		paths.JoinLocalPath(mapInstallRoot, cityCode, MapRoadsFileName+".gz"),
 		paths.JoinLocalPath(mapInstallRoot, cityCode, MapRunwaysFileName+".gz"),
 		paths.JoinLocalPath(mapInstallRoot, cityCode, MapBuildingsFileName+".gz"),
+		paths.JoinLocalPath(mapTilesRoot, cityCode+MapTileFileExt),
 	}
 
 	for _, filePath := range requiredPaths {

--- a/internal/files/map_validation_test.go
+++ b/internal/files/map_validation_test.go
@@ -96,15 +96,15 @@ func TestValidateMapArchive(t *testing.T) {
 func TestValidateInstalledMapDataLocal(t *testing.T) {
 	tests := []struct {
 		name        string
-		setup       func(t *testing.T, mapRoot, cityCode string)
+		setup       func(t *testing.T, mapRoot, tilesRoot, cityCode string)
 		wantErrType types.DownloaderErrorType
 		wantErr     bool
 		wantCode    string
 	}{
 		{
 			name: "valid local installed map data",
-			setup: func(t *testing.T, mapRoot, cityCode string) {
-				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, tilesRoot, cityCode, "AAA")
 			},
 			wantErrType: "",
 			wantErr:     false,
@@ -112,8 +112,8 @@ func TestValidateInstalledMapDataLocal(t *testing.T) {
 		},
 		{
 			name: "missing config file",
-			setup: func(t *testing.T, mapRoot, cityCode string) {
-				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, tilesRoot, cityCode, "AAA")
 				configPath := paths.JoinLocalPath(mapRoot, cityCode, MapConfigFileName)
 				require.NoError(t, os.Remove(configPath))
 			},
@@ -122,8 +122,8 @@ func TestValidateInstalledMapDataLocal(t *testing.T) {
 		},
 		{
 			name: "missing required gz file",
-			setup: func(t *testing.T, mapRoot, cityCode string) {
-				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, tilesRoot, cityCode, "AAA")
 				roadsPath := paths.JoinLocalPath(mapRoot, cityCode, MapRoadsFileName+".gz")
 				require.NoError(t, os.Remove(roadsPath))
 			},
@@ -131,9 +131,19 @@ func TestValidateInstalledMapDataLocal(t *testing.T) {
 			wantErr:     true,
 		},
 		{
+			name: "missing tile file",
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, tilesRoot, cityCode, "AAA")
+				tilePath := paths.JoinLocalPath(tilesRoot, cityCode+MapTileFileExt)
+				require.NoError(t, os.Remove(tilePath))
+			},
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
 			name: "invalid installed config json",
-			setup: func(t *testing.T, mapRoot, cityCode string) {
-				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "AAA")
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, tilesRoot, cityCode, "AAA")
 				configPath := paths.JoinLocalPath(mapRoot, cityCode, MapConfigFileName)
 				require.NoError(t, os.WriteFile(configPath, []byte("{invalid"), 0o644))
 			},
@@ -142,8 +152,8 @@ func TestValidateInstalledMapDataLocal(t *testing.T) {
 		},
 		{
 			name: "invalid installed config map code",
-			setup: func(t *testing.T, mapRoot, cityCode string) {
-				writeInstalledLocalMapFixture(t, mapRoot, cityCode, "aaa")
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledLocalMapFixture(t, mapRoot, tilesRoot, cityCode, "aaa")
 			},
 			wantErrType: types.InstallErrorInvalidMapCode,
 			wantErr:     true,
@@ -153,10 +163,11 @@ func TestValidateInstalledMapDataLocal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mapRoot := t.TempDir()
+			tilesRoot := t.TempDir()
 			cityCode := "AAA"
-			tt.setup(t, mapRoot, cityCode)
+			tt.setup(t, mapRoot, tilesRoot, cityCode)
 
-			config, errType, err := ValidateInstalledMapData(mapRoot, cityCode, true)
+			config, errType, err := ValidateInstalledMapData(mapRoot, tilesRoot, cityCode, true)
 			require.Equal(t, tt.wantErrType, errType)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -172,24 +183,34 @@ func TestValidateInstalledMapDataLocal(t *testing.T) {
 func TestValidateInstalledMapDataDownloaded(t *testing.T) {
 	tests := []struct {
 		name        string
-		setup       func(t *testing.T, mapRoot, cityCode string)
+		setup       func(t *testing.T, mapRoot, tilesRoot, cityCode string)
 		wantErrType types.DownloaderErrorType
 		wantErr     bool
 	}{
 		{
 			name: "valid downloaded installed map data",
-			setup: func(t *testing.T, mapRoot, cityCode string) {
-				writeInstalledDownloadedMapFixture(t, mapRoot, cityCode)
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledDownloadedMapFixture(t, mapRoot, tilesRoot, cityCode)
 			},
 			wantErrType: "",
 			wantErr:     false,
 		},
 		{
 			name: "missing required file",
-			setup: func(t *testing.T, mapRoot, cityCode string) {
-				writeInstalledDownloadedMapFixture(t, mapRoot, cityCode)
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledDownloadedMapFixture(t, mapRoot, tilesRoot, cityCode)
 				demandPath := paths.JoinLocalPath(mapRoot, cityCode, MapDemandFileName+".gz")
 				require.NoError(t, os.Remove(demandPath))
+			},
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "missing tile file",
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledDownloadedMapFixture(t, mapRoot, tilesRoot, cityCode)
+				tilePath := paths.JoinLocalPath(tilesRoot, cityCode+MapTileFileExt)
+				require.NoError(t, os.Remove(tilePath))
 			},
 			wantErrType: types.InstallErrorInvalidArchive,
 			wantErr:     true,
@@ -199,10 +220,11 @@ func TestValidateInstalledMapDataDownloaded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mapRoot := t.TempDir()
+			tilesRoot := t.TempDir()
 			cityCode := "AAA"
-			tt.setup(t, mapRoot, cityCode)
+			tt.setup(t, mapRoot, tilesRoot, cityCode)
 
-			_, errType, err := ValidateInstalledMapData(mapRoot, cityCode, false)
+			_, errType, err := ValidateInstalledMapData(mapRoot, tilesRoot, cityCode, false)
 			require.Equal(t, tt.wantErrType, errType)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -243,19 +265,21 @@ func writeZipArchive(t *testing.T, files map[string][]byte) string {
 	return zipPath
 }
 
-func writeInstalledDownloadedMapFixture(t *testing.T, mapRoot, cityCode string) {
+func writeInstalledDownloadedMapFixture(t *testing.T, mapRoot, tilesRoot, cityCode string) {
 	t.Helper()
 	cityPath := paths.JoinLocalPath(mapRoot, cityCode)
 	require.NoError(t, os.MkdirAll(cityPath, 0o755))
+	require.NoError(t, os.MkdirAll(tilesRoot, 0o755))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapDemandFileName+".gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapRoadsFileName+".gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapRunwaysFileName+".gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(cityPath, MapBuildingsFileName+".gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(tilesRoot, cityCode+MapTileFileExt), []byte("tiles"), 0o644))
 }
 
-func writeInstalledLocalMapFixture(t *testing.T, mapRoot, cityCode, configCode string) {
+func writeInstalledLocalMapFixture(t *testing.T, mapRoot, tilesRoot, cityCode, configCode string) {
 	t.Helper()
-	writeInstalledDownloadedMapFixture(t, mapRoot, cityCode)
+	writeInstalledDownloadedMapFixture(t, mapRoot, tilesRoot, cityCode)
 	configPath := paths.JoinLocalPath(mapRoot, cityCode, MapConfigFileName)
 	require.NoError(t, os.WriteFile(configPath, mustMapConfigJSON(t, configCode), 0o644))
 }

--- a/internal/registry/bootstrap.go
+++ b/internal/registry/bootstrap.go
@@ -180,7 +180,7 @@ func (r *Registry) validateMapData(
 	if !r.hasAssetMarker(types.AssetTypeMap, assetID, mapInstallRoot, cityCode) {
 		return types.ConfigData{}, false
 	}
-	configFromDisk, errorType, validationErr := files.ValidateInstalledMapData(mapInstallRoot, cityCode, isLocal)
+	configFromDisk, errorType, validationErr := files.ValidateInstalledMapData(mapInstallRoot, paths.TilesPath(), cityCode, isLocal)
 	if validationErr != nil {
 		r.logger.Warn("Skipping subscribed map during installed-state bootstrap: missing downloaded map data files", "map_id", assetID,
 			"map_code", cityCode,

--- a/internal/registry/installed_test.go
+++ b/internal/registry/installed_test.go
@@ -399,6 +399,8 @@ func TestBootstrapInstalledStateFromProfileKeepsRemoteMapWhenDownloadedDataFiles
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(paths.TilesPath(), 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(paths.TilesPath(), "AAA.pmtiles"), []byte("tiles"), 0o644))
 
 	profile := types.DefaultProfile()
 	profile.Subscriptions.Maps["map-a"] = "2.0.0"
@@ -438,6 +440,8 @@ func TestBootstrapInstalledStateFromProfilePreservesExistingRemoteMapConfigAndBa
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(paths.TilesPath(), 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(paths.TilesPath(), "AAA.pmtiles"), []byte("tiles"), 0o644))
 
 	reg.installedMaps = []types.InstalledMapInfo{
 		{
@@ -491,6 +495,8 @@ func TestBootstrapInstalledStateFromProfileKeepsLocalMap(t *testing.T) {
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(paths.TilesPath(), 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(paths.TilesPath(), cityCode+".pmtiles"), []byte("tiles"), 0o644))
 	country := "JP"
 	require.NoError(t, files.WriteJSON(paths.JoinLocalPath(mapPath, "config.json"), "installed map config", types.ConfigData{
 		Code:    cityCode,
@@ -529,6 +535,8 @@ func TestBootstrapInstalledStateFromProfilePrefersExistingInstalledConfigForLoca
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "demand_data.json.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "roads.geojson.gz"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapPath, "runways_taxiways.geojson.gz"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(paths.TilesPath(), 0o755))
+	require.NoError(t, os.WriteFile(paths.JoinLocalPath(paths.TilesPath(), cityCode+".pmtiles"), []byte("tiles"), 0o644))
 
 	diskCountry := "JP"
 	require.NoError(t, files.WriteJSON(paths.JoinLocalPath(mapPath, "config.json"), "installed map config", types.ConfigData{


### PR DESCRIPTION
Simple change. On bootstrap/installed state validation we should make sure that PMTiles is present; otherwise users can't load the map in properly.