### PR TITLE
[Backend] Fix bootstrap/swap behavior for locally installed maps

### DIFF
--- a/app.go
+++ b/app.go
@@ -268,6 +268,13 @@ func (a *App) bootstrapInstalledState(activeProfile types.UserProfile) {
 	if err != nil {
 		// This should not be blocking as we are already in an error state
 		a.Logger.Error("Failed to bootstrap installed asset state on startup", err, "profile_id", activeProfile.ID)
+		return
+	}
+
+	// Reconcile local map subscriptions after bootstrap to remove any entries that can no longer be fulfilled with the current installed state.
+	reconcileResult := a.Profiles.ReconcileLocalMapSubscriptions(activeProfile.ID)
+	if reconcileResult.Status == types.ResponseError {
+		return
 	}
 }
 

--- a/internal/profiles/profiles_state.go
+++ b/internal/profiles/profiles_state.go
@@ -610,6 +610,36 @@ func (s *UserProfiles) SwapProfile(req types.SwapProfileRequest) types.UserProfi
 	}
 
 	// Otherwise, if the target archive is not fresh, we will need to run a new subscriptions sync to ensure that the profile is up to date post-swap
+	// First we need to bootstrap the registry state from the target profile
+	if err := s.Registry.BootstrapInstalledStateFromProfile(swappedProfile); err != nil {
+		s.Logger.Error("Active profile changed, but failed to bootstrap installed state", err, "profile_id", targetProfile.ID)
+		return profileStateErrorResult(
+			"Active profile changed, but failed to bootstrap installed state",
+			swappedProfile,
+			userProfilesError(
+				req.ProfileID,
+				"",
+				"",
+				types.ErrorSyncFailed,
+				"",
+				"Active profile changed, but failed to bootstrap installed state: "+err.Error(),
+			),
+		)
+	}
+
+	// After bootstrapping the registry state from the profile, we should attempt to reconcile any local map subscriptions that may be out of sync due to the profile swap before running a full sync to update any remaining subscriptions
+	reconcileResult := s.ReconcileLocalMapSubscriptions(targetProfile.ID)
+	if reconcileResult.Status == types.ResponseError {
+		return types.UserProfileResult{
+			GenericResponse: types.ErrorResponse("Active profile changed, but failed to reconcile local map subscriptions"),
+			Profile:         swappedProfile,
+			Errors:          reconcileResult.Errors,
+		}
+	}
+	if reconcileResult.Profile.ID != "" {
+		swappedProfile = reconcileResult.Profile
+	}
+
 	syncResult := s.SyncSubscriptions(targetProfile.ID, false, false)
 	if syncResult.Status == types.ResponseError {
 		return types.UserProfileResult{
@@ -618,11 +648,13 @@ func (s *UserProfiles) SwapProfile(req types.SwapProfileRequest) types.UserProfi
 			Errors:          syncResult.Errors,
 		}
 	}
-	if syncResult.Status == types.ResponseWarn {
+	if syncResult.Status == types.ResponseWarn || reconcileResult.Status == types.ResponseWarn {
+		warnErrors := append([]types.UserProfilesError{}, reconcileResult.Errors...)
+		warnErrors = append(warnErrors, syncResult.Errors...)
 		return types.UserProfileResult{
-			GenericResponse: types.WarnResponse("Profile swapped with subscription sync warnings"),
+			GenericResponse: types.WarnResponse("Profile swapped with reconciliation or sync warnings"),
 			Profile:         swappedProfile,
-			Errors:          syncResult.Errors,
+			Errors:          warnErrors,
 		}
 	}
 

--- a/internal/profiles/profiles_state_management_test.go
+++ b/internal/profiles/profiles_state_management_test.go
@@ -222,6 +222,69 @@ func TestSwapProfileForceWithoutArchiveSwapsAndSyncs(t *testing.T) {
 	require.Equal(t, target.ID, activeAfter.Profile.ID)
 }
 
+func TestReconcileLocalMapSubscriptionsRemovesUnrecoverableEntries(t *testing.T) {
+	testutil.NewHarness(t)
+
+	state := types.InitialProfilesState()
+	active := state.Profiles[state.ActiveProfileID]
+	active.Subscriptions.LocalMaps["local-map-a"] = "1.0.0"
+	state.Profiles[active.ID] = active
+
+	svc := loadedUserProfilesService(t, state)
+	result := svc.ReconcileLocalMapSubscriptions(active.ID)
+	require.Equal(t, types.ResponseWarn, result.Status)
+	require.Len(t, result.Operations, 1)
+	require.Equal(t, "local-map-a", result.Operations[0].AssetID)
+	require.Equal(t, types.SubscriptionActionUnsubscribe, result.Operations[0].Action)
+	require.True(t, findProfileErrorType(result.Errors, types.ErrorArchiveMissing))
+	require.NotContains(t, result.Profile.Subscriptions.LocalMaps, "local-map-a")
+
+	persisted, err := ReadUserProfilesState()
+	require.NoError(t, err)
+	require.NotContains(t, persisted.Profiles[active.ID].Subscriptions.LocalMaps, "local-map-a")
+}
+
+func TestReconcileLocalMapSubscriptionsKeepsRecoverableEntries(t *testing.T) {
+	testutil.NewHarness(t)
+
+	state := types.InitialProfilesState()
+	active := state.Profiles[state.ActiveProfileID]
+	active.Subscriptions.LocalMaps["local-map-a"] = "1.0.0"
+	state.Profiles[active.ID] = active
+
+	svc, _, reg := loadedUserProfilesServiceWithDependencies(t, state)
+	reg.AddInstalledMap("local-map-a", "1.0.0", true, types.ConfigData{Code: "LMA"})
+
+	result := svc.ReconcileLocalMapSubscriptions(active.ID)
+	require.Equal(t, types.ResponseSuccess, result.Status)
+	require.Empty(t, result.Operations)
+	require.Contains(t, result.Profile.Subscriptions.LocalMaps, "local-map-a")
+}
+
+func TestSwapProfileForceWithoutArchiveReconcilesStaleLocalSubscriptions(t *testing.T) {
+	testutil.NewHarness(t)
+
+	state := types.InitialProfilesState()
+	target := newTestUserProfile("profile_0", "Target")
+	target.Subscriptions.LocalMaps["local-map-a"] = "1.0.0"
+	state.Profiles[target.ID] = target
+	svc := loadedUserProfilesService(t, state)
+
+	result := svc.SwapProfile(types.SwapProfileRequest{
+		ProfileID: target.ID,
+		ForceSwap: true,
+	})
+	require.Equal(t, types.ResponseWarn, result.Status)
+	require.Equal(t, target.ID, result.Profile.ID)
+	require.True(t, findProfileErrorType(result.Errors, types.ErrorArchiveMissing))
+	require.NotContains(t, result.Profile.Subscriptions.LocalMaps, "local-map-a")
+
+	activeAfter := svc.GetActiveProfile()
+	require.Equal(t, types.ResponseSuccess, activeAfter.Status)
+	require.Equal(t, target.ID, activeAfter.Profile.ID)
+	require.NotContains(t, activeAfter.Profile.Subscriptions.LocalMaps, "local-map-a")
+}
+
 func TestSwapProfileUsesFreshArchiveRestorePath(t *testing.T) {
 	testutil.NewHarness(t)
 

--- a/internal/profiles/profiles_update.go
+++ b/internal/profiles/profiles_update.go
@@ -217,6 +217,100 @@ func (s *UserProfiles) resolveLatestUpdatesForProfile(
 
 // ===== Registry Helpers ===== //
 
+// ReconcileLocalMapSubscriptions removes local-map subscriptions that are no longer recoverable from installed state.
+// Primarily used after bootstrap/swap fallback paths where local maps cannot be restored from archive.
+func (s *UserProfiles) ReconcileLocalMapSubscriptions(profileID string) types.UpdateSubscriptionsResult {
+	s.logRequest("ReconcileLocalMapSubscriptions", "profile_id", profileID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stateCopy, profile, profileErr := s.resolveProfileFromCopy(profileID)
+	if profileErr != nil {
+		s.Logger.Error("Profile not found", profileErr, "profile_id", profileID)
+		return profileNotFoundUpdateResult(profileErr, types.UpdateSubscriptions, "profile not found")
+	}
+
+	// Compile a list of currently installed local maps to determine which local map subscriptions are still recoverable (if any)
+	currentLocalMapIDs := make(map[string]struct{})
+	for _, installedMap := range s.Registry.GetInstalledMaps() {
+		if !installedMap.IsLocal {
+			continue
+		}
+		currentLocalMapIDs[installedMap.ID] = struct{}{}
+	}
+
+	cloneProfileSubscriptions(&profile)
+	assetsToRemove := make(map[string]types.SubscriptionUpdateItem)
+	for localMapID := range profile.Subscriptions.LocalMaps {
+		if _, exists := currentLocalMapIDs[localMapID]; exists {
+			continue
+		}
+		// Append unrecoverable local map subscription to removal list
+		assetsToRemove[localMapID] = types.SubscriptionUpdateItem{
+			Type:    types.AssetTypeMap,
+			IsLocal: true,
+		}
+	}
+
+	if len(assetsToRemove) == 0 {
+		s.Logger.Info("Local map subscription reconciliation completed with no removals", "profile_id", profileID)
+		result := updateResultBase(types.UpdateSubscriptions, types.ResponseSuccess, "Local map subscriptions reconciled")
+		result.Profile = profile
+		return result
+	}
+
+	// Apply mutations to remove unrecoverable local map subscriptions from the profile state so that it no longer erroneously references missing installed data
+	operations := make([]types.SubscriptionOperation, 0, len(assetsToRemove))
+	for assetID, item := range assetsToRemove {
+		operation, opErr := applySubscriptionMutation(&profile, types.SubscriptionActionUnsubscribe, strings.TrimSpace(assetID), item)
+		if opErr != nil {
+			s.Logger.Error("Failed to reconcile local map subscription", *opErr, "asset_id", assetID, "profile_id", profileID)
+			result := updateResultBase(types.UpdateSubscriptions, types.ResponseError, "Failed to reconcile local map subscriptions")
+			result.Profile = profile
+			result.Errors = []types.UserProfilesError{*opErr}
+			return result
+		}
+		operations = appendOperation(operations, operation)
+	}
+
+	if err := s.commitProfileMutation(&stateCopy, profileID, profile, true); err != nil {
+		persistErr := updateSubscriptionError(
+			profileID,
+			"",
+			types.AssetTypeMap,
+			types.ErrorPersistFailed,
+			fmt.Errorf("failed to persist reconciled local map subscriptions: %w", err),
+		)
+		result := updateResultBase(types.UpdateSubscriptions, types.ResponseError, "Failed to persist local map subscription reconciliation")
+		result.Profile = profile
+		result.Operations = operations
+		result.Errors = []types.UserProfilesError{persistErr}
+		return result
+	}
+
+	result := updateResultBase(
+		types.UpdateSubscriptions,
+		types.ResponseWarn,
+		fmt.Sprintf("Removed %d unrecoverable local map subscription(s)", len(operations)),
+	)
+	result.Applied = true
+	result.Profile = profile
+	result.Persisted = true
+	result.Operations = operations
+	for _, operation := range operations {
+		result.Errors = append(result.Errors, userProfilesError(
+			profileID,
+			operation.AssetID,
+			types.AssetTypeMap,
+			types.ErrorArchiveMissing,
+			"",
+			fmt.Sprintf("Removed local map subscription %q because installed data is unavailable", operation.AssetID),
+		))
+	}
+	return result
+}
+
 func (s *UserProfiles) resolveLatestSubscriptionUpdates(
 	profileID string,
 	profile types.UserProfile,

--- a/internal/registry/bootstrap.go
+++ b/internal/registry/bootstrap.go
@@ -186,7 +186,9 @@ func (r *Registry) validateMapData(
 			"is_local", isLocal)
 		return types.ConfigData{}, false
 	}
-
+	// TODO: Enforce map config version equality against the subscribed version during bootstrap validation.
+	// We should fail bootstrap for map entries where config.version does not match the target subscription version.
+	// This must be delayed until widespread adoption of 0.2.0 because older installs may will not have config present on disk.
 	return configFromDisk, true
 }
 


### PR DESCRIPTION
Currently subscriptions for locally installed maps can be orphaned on bootstrap and/or profile swap if they are not present in the installed state / archives as they are not checked on sync subscriptions.

This PR fixes this by adding a local map reconciliation step to both, removing any local map entries that are not found in the installed state when profile swaps (with failures) or bootstrap occurs