### PR TITLE
[Frontend] Show contributor tags + tooltips

### DIFF
--- a/frontend/src/components/library/LibraryList.tsx
+++ b/frontend/src/components/library/LibraryList.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { Link } from 'wouter';
 
 import { AppDialog } from '@/components/dialogs/AppDialog';
+import { AuthorName } from '@/components/shared/AuthorName';
 import { GalleryImage } from '@/components/shared/GalleryImage';
 import { SortableHeaderCell } from '@/components/shared/SortableHeaderCell';
 import { Badge } from '@/components/ui/badge';
@@ -378,8 +379,13 @@ function LibraryListRow({
                 {entry.item.name}
               </Link>
             )}
-            <p className="mt-0.5 truncate text-xs text-muted-foreground">
-              by {entry.item.author.author_alias}
+            <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground min-w-0">
+              <span className="shrink-0">by</span>
+              <AuthorName
+                name={entry.item.author.author_alias}
+                contributorTier={entry.item.author.contributor_tier}
+                size="sm"
+              />
             </p>
           </div>
 

--- a/frontend/src/components/project/ProjectHeader.tsx
+++ b/frontend/src/components/project/ProjectHeader.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
 import { AppDialog } from '@/components/dialogs/AppDialog';
+import { AuthorName } from '@/components/shared/AuthorName';
 import { GalleryImage } from '@/components/shared/GalleryImage';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -476,13 +477,16 @@ export function ProjectHeader({
                 </div>
               )}
               <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-                by{' '}
+                <span className="shrink-0">by</span>
                 <Button
                   variant="link"
                   className="h-auto p-0 text-sm font-normal text-muted-foreground hover:text-foreground gap-1"
                   onClick={() => BrowserOpenURL(authorAttributionLink)}
                 >
-                  {authorAlias}
+                  <AuthorName
+                    name={authorAlias}
+                    contributorTier={item.author.contributor_tier}
+                  />
                   <ExternalLink className="h-3 w-3" />
                 </Button>
               </p>

--- a/frontend/src/components/shared/AuthorName.tsx
+++ b/frontend/src/components/shared/AuthorName.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@/lib/utils';
+
+import {
+  ContributorTierIcon,
+  type ContributorTierIconSize,
+} from './ContributorTierIcon';
+
+interface AuthorNameProps {
+  name: string;
+  contributorTier?: string;
+  size?: ContributorTierIconSize;
+  className?: string;
+}
+
+export function AuthorName({
+  name,
+  contributorTier,
+  size = 'default',
+  className,
+}: AuthorNameProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex min-w-0 max-w-full items-center gap-1',
+        className,
+      )}
+    >
+      <span className="min-w-0 truncate">{name}</span>
+      <ContributorTierIcon tier={contributorTier} size={size} />
+    </span>
+  );
+}

--- a/frontend/src/components/shared/ContributorTierIcon.tsx
+++ b/frontend/src/components/shared/ContributorTierIcon.tsx
@@ -1,0 +1,53 @@
+import type { CSSProperties } from 'react';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { getContributorTierStyle } from '@/lib/contributor-tier';
+
+export type ContributorTierIconSize = 'sm' | 'default';
+
+interface ContributorTierIconProps {
+  tier: string | undefined;
+  size?: ContributorTierIconSize;
+}
+
+const ICON_SIZE: Record<ContributorTierIconSize, string> = {
+  sm: 'size-3',
+  default: 'size-3.5',
+};
+
+export function ContributorTierIcon({
+  tier,
+  size = 'default',
+}: ContributorTierIconProps) {
+  const style = getContributorTierStyle(tier);
+  if (!style) return null;
+
+  const Icon = style.icon;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex shrink-0 items-center justify-center">
+            <Icon className={ICON_SIZE[size]} style={{ color: style.color }} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          className="border-transparent text-white"
+          style={
+            {
+              '--surface-raised': style.color,
+            } as CSSProperties
+          }
+        >
+          {style.label}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/shared/ItemCard.tsx
+++ b/frontend/src/components/shared/ItemCard.tsx
@@ -12,6 +12,7 @@ import type { SearchViewMode } from '@/lib/search-view-mode';
 import { cn } from '@/lib/utils';
 
 import type { types } from '../../../wailsjs/go/models';
+import { AuthorName } from './AuthorName';
 import { GalleryImage } from './GalleryImage';
 
 const TYPE_PILL_CLASS =
@@ -20,7 +21,8 @@ const CARD_IMAGE_CLASS =
   'h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]';
 const CARD_TITLE_CLASS =
   'font-semibold text-sm leading-snug text-foreground truncate';
-const CARD_AUTHOR_CLASS = 'text-xs text-muted-foreground mt-0.5 truncate';
+const CARD_AUTHOR_CLASS =
+  'flex items-center gap-1 text-xs text-muted-foreground mt-0.5 min-w-0';
 const CARD_ARTICLE_BASE =
   'group relative bg-card border border-border rounded-lg overflow-hidden cursor-pointer transition-all duration-150 hover:border-foreground/20 hover:shadow-sm';
 
@@ -392,7 +394,12 @@ export const ItemCard = memo(function ItemCard({
                 <div className="min-w-0 flex-1">
                   <h3 className={CARD_TITLE_CLASS}>{item.name}</h3>
                   <p className={CARD_AUTHOR_CLASS}>
-                    by {item.author.author_alias}
+                    <span className="shrink-0">by</span>
+                    <AuthorName
+                      name={item.author.author_alias}
+                      contributorTier={item.author.contributor_tier}
+                      size="sm"
+                    />
                   </p>
                 </div>
                 {presentation.isMap && (
@@ -480,8 +487,12 @@ export const ItemCard = memo(function ItemCard({
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0 flex-1">
                 <h3 className={CARD_TITLE_CLASS}>{item.name}</h3>
-                <p className="text-[11px] text-muted-foreground mt-0.5 truncate">
-                  by {item.author.author_alias}
+                <p className="flex items-center gap-1 text-[11px] text-muted-foreground mt-0.5 min-w-0">
+                  <span className="shrink-0">by</span>
+                  <AuthorName
+                    name={item.author.author_alias}
+                    contributorTier={item.author.contributor_tier}
+                  />
                 </p>
               </div>
               {presentation.isMap && (
@@ -563,7 +574,14 @@ export const ItemCard = memo(function ItemCard({
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0 flex-1">
               <h3 className={CARD_TITLE_CLASS}>{item.name}</h3>
-              <p className={CARD_AUTHOR_CLASS}>by {item.author.author_alias}</p>
+              <p className={CARD_AUTHOR_CLASS}>
+                <span className="shrink-0">by</span>
+                <AuthorName
+                  name={item.author.author_alias}
+                  contributorTier={item.author.contributor_tier}
+                  size="sm"
+                />
+              </p>
             </div>
             {presentation.isMap && (
               <MapLocationMeta

--- a/frontend/src/lib/contributor-tier.ts
+++ b/frontend/src/lib/contributor-tier.ts
@@ -1,0 +1,36 @@
+import type { LucideIcon } from 'lucide-react';
+import { CodeXml, Heart, UsersRound } from 'lucide-react';
+
+export type ContributorTier =
+  | 'developer'
+  | 'engineer'
+  | 'conductor'
+  | 'executive'
+  | 'collaborator';
+
+export interface ContributorTierStyle {
+  label: string;
+  color: string;
+  icon: LucideIcon;
+}
+
+export const CONTRIBUTOR_TIER_STYLES: Record<
+  ContributorTier,
+  ContributorTierStyle
+> = {
+  developer: { label: 'Developer', color: '#5296D5', icon: CodeXml },
+  engineer: { label: 'Engineer', color: '#D65745', icon: Heart },
+  conductor: { label: 'Conductor', color: '#9F2757', icon: Heart },
+  executive: { label: 'Executive', color: '#D8833B', icon: Heart },
+  collaborator: { label: 'Collaborator', color: '#925CB1', icon: UsersRound },
+};
+
+export function getContributorTierStyle(
+  tier: string | undefined,
+): ContributorTierStyle | null {
+  if (!tier) return null;
+  return (
+    (CONTRIBUTOR_TIER_STYLES as Record<string, ContributorTierStyle>)[tier] ??
+    null
+  );
+}


### PR DESCRIPTION
Let's add this to the app to say thanks to our contributors/supporters

Matches the website change and uses:

Heart/CodeXml/Users-Round for Supporters/Developers/Contributors, respectively
<img width="1848" height="396" alt="image" src="https://github.com/user-attachments/assets/e3acc8bf-e62c-4b4a-8537-8b6f6475bbbb" />
<img width="833" height="314" alt="image" src="https://github.com/user-attachments/assets/0a10a6bd-3131-43c2-acbe-3816f7df1685" />
<img width="426" height="584" alt="image" src="https://github.com/user-attachments/assets/ae41054b-c85c-4f79-b33e-8ae60524beca" />

