### PR TITLE
[Backend] More bug fixes

### DIFF
--- a/.github/workflows/railyard-release.yml
+++ b/.github/workflows/railyard-release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build macOS (universal)
         run: |
-          echo -e $VERSION > internal/constants/version.txt
+          printf '%s' "$VERSION" > internal/constants/version.txt
           wails build -platform darwin/universal
           cd build/bin
           ditto -c -k --sequesterRsrc --keepParent railyard.app railyard-${VERSION}-macos-universal.zip
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build Linux (amd64 current)
         run: |
-          echo -e $VERSION > internal/constants/version.txt
+          printf '%s' "$VERSION" > internal/constants/version.txt
           cp build/linux/org.SBM.Railyard.yml .
           flatpak-builder --force-clean --repo="./out" build/build-linux org.SBM.Railyard.yml
           mkdir -p build/bin

--- a/railyard/app.go
+++ b/railyard/app.go
@@ -505,6 +505,8 @@ func (a *App) LaunchGame() types.GenericResponse {
 		}
 	}
 
+	a.Logger.Info("Executing launch command", "cmd", cmd.Path, "args", cmd.Args, "dir", cmd.Dir)
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return types.ErrorResponse(fmt.Sprintf("failed to create stdout pipe: %v", err))
@@ -684,15 +686,15 @@ func (a *App) startPMTilesServer() (int, error) {
 		return -1, err
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
 
 	a.Logger.Info(fmt.Sprintf("Starting PMTiles server on port %d", port))
 
 	channel := make(chan error, 1)
 
-	go func(l *logger.AppLogger, port int, errorChan chan error) {
+	go func(l *logger.AppLogger, port int, errorChan chan error, ln net.Listener) {
 		pmtilesServer, err := pmtiles.NewServerWithBucket(pmtiles.NewFileBucket(path.Join(paths.AppDataRoot(), "tiles")), "", log.New(l.Writer, "pmtiles: ", log.Default().Flags()), 128, "")
 		if err != nil {
+			ln.Close()
 			l.Error("Failed to create PMTiles server", err)
 			errorChan <- err
 			return
@@ -739,13 +741,11 @@ func (a *App) startPMTilesServer() (int, error) {
 			statusCode := pmtilesServer.ServeHTTP(w, r)
 			l.Info("Handled PMTiles request", "path", r.URL.Path, "status", statusCode)
 		})
+		srv := &http.Server{Handler: mux}
+		a.pmtilesServer = srv
 		errorChan <- nil
-		a.pmtilesServer = &http.Server{
-			Addr:    fmt.Sprintf(":%d", port),
-			Handler: mux,
-		}
-		l.Error("PMTiles error: ", a.pmtilesServer.ListenAndServe())
-	}(a.Logger, port, channel)
+		l.Error("PMTiles error: ", srv.Serve(ln))
+	}(a.Logger, port, channel, listener)
 	return port, <-channel
 }
 

--- a/railyard/internal/constants/mod_template.js
+++ b/railyard/internal/constants/mod_template.js
@@ -24,63 +24,62 @@ function generateTabs(places) {
   return tabs;
 }
 
-config.places.forEach(async place => {
-    let newPlace = {
-        code: place.code,
-        name: place.name,
-        population: place.population,
-        description: place.description,
-        mapImageUrl: "http://127.0.0.1:" + config.port + "/thumbnails/" + place.code + ".svg"
-    };
-    if (place.initialViewState) {
-        newPlace.initialViewState = place.initialViewState;
-    } else {
-        newPlace.initialViewState = {
-            longitude: (place.bbox[0] + place.bbox[2]) / 2,
-            latitude: (place.bbox[1] + place.bbox[3]) / 2,
-            zoom: 12,
-            bearing: 0,
+(async () => {
+    await Promise.all(config.places.map(async place => {
+        let newPlace = {
+            code: place.code,
+            name: place.name,
+            population: place.population,
+            description: place.description,
+            mapImageUrl: "http://127.0.0.1:" + config.port + "/thumbnails/" + place.code + ".svg"
         };
-    }
-    window.SubwayBuilderAPI.registerCity(newPlace);
-    window.SubwayBuilderAPI.map.setDefaultLayerVisibility(place.code, {
-        oceanFoundations: false,
-        trackElevations: false
-    });
-    // 3. Fix layer schemas for custom tiles
-    window.SubwayBuilderAPI.map.setLayerOverride({
-        layerId: 'parks-large',
-        sourceLayer: 'landuse',
-        filter: ['==', ['get', 'kind'], 'park'],
-    });
+        if (place.initialViewState) {
+            newPlace.initialViewState = place.initialViewState;
+        } else {
+            newPlace.initialViewState = {
+                longitude: (place.bbox[0] + place.bbox[2]) / 2,
+                latitude: (place.bbox[1] + place.bbox[3]) / 2,
+                zoom: 12,
+                bearing: 0,
+            };
+        }
+        await window.SubwayBuilderAPI.registerCity(newPlace);
+        window.SubwayBuilderAPI.map.setDefaultLayerVisibility(place.code, {
+            oceanFoundations: false,
+            trackElevations: false
+        });
+        // Fix layer schemas for custom tiles
+        window.SubwayBuilderAPI.map.setLayerOverride({
+            layerId: 'parks-large',
+            sourceLayer: 'landuse',
+            filter: ['==', ['get', 'kind'], 'park'],
+        });
+        window.SubwayBuilderAPI.map.setLayerOverride({
+            layerId: 'airports',
+            sourceLayer: 'landuse',
+            filter: ['==', ['get', 'kind'], 'aerodrome'],
+        });
+        window.SubwayBuilderAPI.map.setTileURLOverride({
+            cityCode: place.code,
+            tilesUrl: "http://127.0.0.1:" + config.port + "/" + place.code + "/{z}/{x}/{y}.mvt",
+            foundationTilesUrl: "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+            maxZoom: config.tileZoomLevel
+        });
+        window.SubwayBuilderAPI.cities.setCityDataFiles(place.code, { // auto appends .gz, is this intended? if it is then its fine if not then that has to be removed so we can manually set the .gz file extension
+            buildingsIndex: "/data/" + place.code + "/buildings_index.json",
+            demandData: "/data/" + place.code + "/demand_data.json", // drivingPaths supplied in demand_data.json.gz still aren't used
+            roads: "/data/" + place.code + "/roads.geojson",
+            runwaysTaxiways: "/data/" + place.code + "/runways_taxiways.geojson",
+        });
+    }));
 
-    window.SubwayBuilderAPI.map.setLayerOverride({
-        layerId: 'airports',
-        sourceLayer: 'landuse',
-        filter: ['==', ['get', 'kind'], 'aerodrome'],
+    const tabs = generateTabs(config.places);
+    Object.entries(tabs).forEach(([country, codes]) => {
+        window.SubwayBuilderAPI.cities.registerTab({
+            id: country,
+            label: getCountryName(country),
+            emoji: getFlagEmoji(country),
+            cityCodes: codes,
+        });
     });
-
-    window.SubwayBuilderAPI.map.setTileURLOverride({
-        cityCode: place.code,
-        tilesUrl: "http://127.0.0.1:" + config.port + "/" + place.code + "/{z}/{x}/{y}.mvt",
-        foundationTilesUrl: "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-        maxZoom: config.tileZoomLevel
-    });
-
-    window.SubwayBuilderAPI.cities.setCityDataFiles(place.code, { // auto appends .gz, is this intended? if it is then its fine if not then that has to be removed so we can manually set the .gz file extension
-        buildingsIndex: "/data/" + place.code + "/buildings_index.json",
-        demandData: "/data/" + place.code + "/demand_data.json", // drivingPaths supplied in demand_data.json.gz still aren't used
-        roads: "/data/" + place.code + "/roads.geojson",
-        runwaysTaxiways: "/data/" + place.code + "/runways_taxiways.geojson",
-    })
-})
-
-let tabs = generateTabs(config.places);
-Object.entries(tabs).forEach(([country, codes]) => {
-    window.SubwayBuilderAPI.cities.registerTab({
-      id: country,
-      label: getCountryName(country),
-      emoji: getFlagEmoji(country),
-      cityCodes: codes,
-    });
-});
+})();

--- a/railyard/internal/constants/mod_template.js
+++ b/railyard/internal/constants/mod_template.js
@@ -1,21 +1,29 @@
 const config = $CONFIG;
-function getFlagEmoji (countryCode) {
-	let codePoints = countryCode.toUpperCase().split('').map(char =>  127397 + char.charCodeAt());
-	return String.fromCodePoint(...codePoints);
+function getFlagEmoji(countryCode) {
+  let codePoints = countryCode
+    .toUpperCase()
+    .split("")
+    .map((char) => 127397 + char.charCodeAt());
+  return String.fromCodePoint(...codePoints);
 }
 
 function getCountryName(countryCode) {
-    const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
-    return regionNames.of(countryCode.toUpperCase());
+  const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
+  return regionNames.of(countryCode.toUpperCase());
 }
 
 function generateTabs(places) {
   let tabs = {};
-  places.forEach(place => {
-    if(place.country === undefined || place.country.toUpperCase() === "US" || place.country.toUpperCase() === "GB") { // don't make tabs for these, we will have to do these on an upcoming update
+  places.forEach((place) => {
+    if (
+      place.country === undefined ||
+      place.country.toUpperCase() === "US" ||
+      place.country.toUpperCase() === "GB"
+    ) {
+      // don't make tabs for these, we will have to do these on an upcoming update
       return;
     }
-    if(tabs.hasOwnProperty(place.country)) {
+    if (tabs.hasOwnProperty(place.country)) {
       tabs[place.country].push(place.code);
     } else {
       tabs[place.country] = [place.code];
@@ -25,61 +33,76 @@ function generateTabs(places) {
 }
 
 (async () => {
-    await Promise.all(config.places.map(async place => {
-        let newPlace = {
-            code: place.code,
-            name: place.name,
-            population: place.population,
-            description: place.description,
-            mapImageUrl: "http://127.0.0.1:" + config.port + "/thumbnails/" + place.code + ".svg"
+  await Promise.all(
+    config.places.map(async (place) => {
+      let newPlace = {
+        code: place.code,
+        name: place.name,
+        population: place.population,
+        description: place.description,
+        mapImageUrl:
+          "http://127.0.0.1:" +
+          config.port +
+          "/thumbnails/" +
+          place.code +
+          ".svg",
+      };
+      if (place.initialViewState) {
+        newPlace.initialViewState = place.initialViewState;
+      } else {
+        newPlace.initialViewState = {
+          longitude: (place.bbox[0] + place.bbox[2]) / 2,
+          latitude: (place.bbox[1] + place.bbox[3]) / 2,
+          zoom: 12,
+          bearing: 0,
         };
-        if (place.initialViewState) {
-            newPlace.initialViewState = place.initialViewState;
-        } else {
-            newPlace.initialViewState = {
-                longitude: (place.bbox[0] + place.bbox[2]) / 2,
-                latitude: (place.bbox[1] + place.bbox[3]) / 2,
-                zoom: 12,
-                bearing: 0,
-            };
-        }
-        await window.SubwayBuilderAPI.registerCity(newPlace);
-        window.SubwayBuilderAPI.map.setDefaultLayerVisibility(place.code, {
-            oceanFoundations: false,
-            trackElevations: false
-        });
-        // Fix layer schemas for custom tiles
-        window.SubwayBuilderAPI.map.setLayerOverride({
-            layerId: 'parks-large',
-            sourceLayer: 'landuse',
-            filter: ['==', ['get', 'kind'], 'park'],
-        });
-        window.SubwayBuilderAPI.map.setLayerOverride({
-            layerId: 'airports',
-            sourceLayer: 'landuse',
-            filter: ['==', ['get', 'kind'], 'aerodrome'],
-        });
-        window.SubwayBuilderAPI.map.setTileURLOverride({
-            cityCode: place.code,
-            tilesUrl: "http://127.0.0.1:" + config.port + "/" + place.code + "/{z}/{x}/{y}.mvt",
-            foundationTilesUrl: "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-            maxZoom: config.tileZoomLevel
-        });
-        window.SubwayBuilderAPI.cities.setCityDataFiles(place.code, { // auto appends .gz, is this intended? if it is then its fine if not then that has to be removed so we can manually set the .gz file extension
-            buildingsIndex: "/data/" + place.code + "/buildings_index.json",
-            demandData: "/data/" + place.code + "/demand_data.json", // drivingPaths supplied in demand_data.json.gz still aren't used
-            roads: "/data/" + place.code + "/roads.geojson",
-            runwaysTaxiways: "/data/" + place.code + "/runways_taxiways.geojson",
-        });
-    }));
+      }
+      await window.SubwayBuilderAPI.registerCity(newPlace);
+      window.SubwayBuilderAPI.map.setDefaultLayerVisibility(place.code, {
+        oceanFoundations: false,
+        trackElevations: false,
+      });
+      // Fix layer schemas for custom tiles
+      window.SubwayBuilderAPI.map.setLayerOverride({
+        layerId: "parks-large",
+        sourceLayer: "landuse",
+        filter: ["==", ["get", "kind"], "park"],
+      });
+      window.SubwayBuilderAPI.map.setLayerOverride({
+        layerId: "airports",
+        sourceLayer: "landuse",
+        filter: ["==", ["get", "kind"], "aerodrome"],
+      });
+      window.SubwayBuilderAPI.map.setTileURLOverride({
+        cityCode: place.code,
+        tilesUrl:
+          "http://127.0.0.1:" +
+          config.port +
+          "/" +
+          place.code +
+          "/{z}/{x}/{y}.mvt",
+        foundationTilesUrl:
+          "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+        maxZoom: config.tileZoomLevel,
+      });
+      window.SubwayBuilderAPI.cities.setCityDataFiles(place.code, {
+        // auto appends .gz, is this intended? if it is then its fine if not then that has to be removed so we can manually set the .gz file extension
+        buildingsIndex: "/data/" + place.code + "/buildings_index.json",
+        demandData: "/data/" + place.code + "/demand_data.json", // drivingPaths supplied in demand_data.json.gz still aren't used
+        roads: "/data/" + place.code + "/roads.geojson",
+        runwaysTaxiways: "/data/" + place.code + "/runways_taxiways.geojson",
+      });
+    }),
+  );
 
-    const tabs = generateTabs(config.places);
-    Object.entries(tabs).forEach(([country, codes]) => {
-        window.SubwayBuilderAPI.cities.registerTab({
-            id: country,
-            label: getCountryName(country),
-            emoji: getFlagEmoji(country),
-            cityCodes: codes,
-        });
+  const tabs = generateTabs(config.places);
+  Object.entries(tabs).forEach(([country, codes]) => {
+    console.log("Registering tab for country:", country, "with codes:", codes);
+    window.SubwayBuilderAPI.cities.registerTab({
+      id: country,
+      label: getCountryName(country),
+      emoji: getFlagEmoji(country),
+      cityCodes: codes,
     });
+  });
 })();

--- a/railyard/internal/files/map_validation.go
+++ b/railyard/internal/files/map_validation.go
@@ -104,7 +104,7 @@ func ValidateMapArchive(filePath string) (types.ConfigData, types.DownloaderErro
 		return configData, types.InstallErrorInvalidManifest, err
 	}
 	if !types.LocalMapCodePattern.MatchString(configData.Code) {
-		return configData, types.InstallErrorInvalidMapCode, fmt.Errorf("invalid map code %q in config.json: must match ^[A-Z]{2,4}$", configData.Code)
+		return configData, types.InstallErrorInvalidMapCode, fmt.Errorf("invalid map code %q in config.json: must be 2-4 chars, start with 2 uppercase letters, digits only as trailing suffix", configData.Code)
 	}
 
 	return configData, "", nil
@@ -128,7 +128,7 @@ func readInstalledMapConfig(mapInstallRoot string, cityCode string) (types.Confi
 		return configData, types.InstallErrorInvalidManifest, fmt.Errorf("failed to parse installed map config: %w", err)
 	}
 	if !types.LocalMapCodePattern.MatchString(configData.Code) {
-		return configData, types.InstallErrorInvalidMapCode, fmt.Errorf("invalid map code %q in installed map config: must match ^[A-Z]{2,4}$", configData.Code)
+		return configData, types.InstallErrorInvalidMapCode, fmt.Errorf("invalid map code %q in installed map config: must be 2-4 chars, start with 2 uppercase letters, digits only as trailing suffix", configData.Code)
 	}
 
 	return configData, "", nil

--- a/railyard/internal/types/common.go
+++ b/railyard/internal/types/common.go
@@ -177,7 +177,7 @@ const (
 	AssetTypeMod AssetType = "mod"
 )
 
-var LocalMapCodePattern = regexp.MustCompile(`^[A-Z]{2,4}$`)
+var LocalMapCodePattern = regexp.MustCompile(`^[A-Z]{2}([A-Z]{0,2}|[A-Z][0-9]|[0-9]{1,2})$`)
 
 func IsValidAssetType(assetType AssetType) bool {
 	switch assetType {

--- a/railyard/internal/types/common_test.go
+++ b/railyard/internal/types/common_test.go
@@ -91,14 +91,21 @@ func TestProgressReader(t *testing.T) {
 }
 
 func TestLocalMapCodePattern(t *testing.T) {
+	// Valid: 2-4 chars, first two uppercase alpha, digits only as trailing suffix
 	require.True(t, LocalMapCodePattern.MatchString("AB"))
 	require.True(t, LocalMapCodePattern.MatchString("ABC"))
 	require.True(t, LocalMapCodePattern.MatchString("ABCD"))
+	require.True(t, LocalMapCodePattern.MatchString("AB1"))
+	require.True(t, LocalMapCodePattern.MatchString("AB12"))
+	require.True(t, LocalMapCodePattern.MatchString("ABC1"))
+	// Invalid
 	require.False(t, LocalMapCodePattern.MatchString("A"))
 	require.False(t, LocalMapCodePattern.MatchString("ABCDE"))
 	require.False(t, LocalMapCodePattern.MatchString("AbC"))
 	require.False(t, LocalMapCodePattern.MatchString("abc"))
-	require.False(t, LocalMapCodePattern.MatchString("AB1"))
+	require.False(t, LocalMapCodePattern.MatchString("A1"))
+	require.False(t, LocalMapCodePattern.MatchString("A1B"))
+	require.False(t, LocalMapCodePattern.MatchString("AB1C"))
 	require.False(t, LocalMapCodePattern.MatchString(" AB"))
 	require.False(t, LocalMapCodePattern.MatchString("AB "))
 }

--- a/railyard/internal/updater/updater.go
+++ b/railyard/internal/updater/updater.go
@@ -179,8 +179,8 @@ func downloadAndRunInstaller(downloadURL string, ctx context.Context, downloadPr
 
 func VersionIsNewerThanInstalled(version string) bool {
 	installed := constants.RAILYARD_VERSION
-	installed = strings.TrimPrefix(installed, "v")
-	version = strings.TrimPrefix(version, "v")
+	installed = strings.TrimSpace(strings.TrimPrefix(installed, "v"))
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
 
 	newVersionIsRC := strings.Contains(version, "rc")
 	installedVersionIsRC := strings.Contains(installed, "rc")


### PR DESCRIPTION
- Fix updater for UNIX. There's a new line appended with echo-e that was not properly stripped. This caused version comparisons to fail (missing trimspace). Added the trimspace in and changed to printf

- Updated CityCode support to include alphanumeric with strict numeric suffix (max 2 digits, requires 2 alphabetic digits)

- Cities missing from the country tabs on first install of new city is now fixed. This was mostly due to our registerCity being async and the registertabs not awaiting it to complete. 