### PR TITLE
[Foundry] Add workflow to publish npm package for special demand schemas

### DIFF
--- a/.github/workflows/foundry-schemas-ci.yml
+++ b/.github/workflows/foundry-schemas-ci.yml
@@ -1,0 +1,94 @@
+name: Foundry Schemas CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "foundry/schemas/**"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/foundry-schemas-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "foundry/schemas/**"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/foundry-schemas-ci.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: foundry-schemas-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build And Test Foundry Schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm --dir foundry/schemas run build
+
+      - name: Test package
+        run: pnpm --dir foundry/schemas run test
+
+      - name: Verify packed contents
+        working-directory: foundry/schemas
+        shell: bash
+        run: |
+          npm pack --json --dry-run --cache .npm-cache > pack-result.json
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const [{ files }] = JSON.parse(fs.readFileSync('pack-result.json', 'utf8'));
+          const packedFiles = new Set(files.map((entry) => entry.path));
+          const expected = [
+            'dist/index.js',
+            'dist/index.d.ts',
+            'special_demand_type_definitions.schema.json',
+            'special_demand_types.schema.json',
+            'special_demand_points.schema.json',
+          ];
+
+          for (const file of expected) {
+            if (!packedFiles.has(file)) {
+              console.error(`Missing packed file: ${file}`);
+              process.exit(1);
+            }
+          }
+
+          const excluded = [
+            'special_demand_types.json',
+            'special_demand_points_izumo.json',
+            'special_demand_points_tsugaru.json',
+          ];
+
+          for (const file of excluded) {
+            if (packedFiles.has(file)) {
+              console.error(`Unexpected packed fixture: ${file}`);
+              process.exit(1);
+            }
+          }
+
+          console.log('Packed contents verified.');
+          NODE

--- a/.github/workflows/publish-special-demand-schemas.yml
+++ b/.github/workflows/publish-special-demand-schemas.yml
@@ -1,0 +1,55 @@
+name: Publish @subway-builder-modded/special-demand-schemas
+
+on:
+  push:
+    tags:
+      - "special-demand-schemas-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: "@subway-builder-modded"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#special-demand-schemas-v}"
+          package_version="$(node -p "require('./foundry/schemas/package.json').version")"
+
+          if [ "$tag_version" != "$package_version" ]; then
+            echo "Tag version ${tag_version} does not match package version ${package_version}."
+            exit 1
+          fi
+
+      - name: Build package
+        run: pnpm --filter @subway-builder-modded/special-demand-schemas run build
+
+      - name: Test package
+        run: pnpm --filter @subway-builder-modded/special-demand-schemas run test
+
+      - name: Publish package
+        run: pnpm --filter @subway-builder-modded/special-demand-schemas publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 # Ignore agentic files and directories
 .claude/
+.serena/
 
 # Ignore cache and temporary files
 .gocache/
 .pnpm-store/
 tmp/
+foundry/schemas/dist/
+foundry/schemas/.npm-cache/
 
 node_modules/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository is managed as a **pnpm workspace**. A single `pnpm install` from
 | `@subway-builder-modded/lifecycle-core` | `packages/lifecycle-core` | Shared lifecycle hooks |
 | `@subway-builder-modded/lifecycle-web` | `packages/lifecycle-web` | Web-specific lifecycle hooks |
 | `@subway-builder-modded/lifecycle-wails` | `packages/lifecycle-wails` | Wails-specific lifecycle hooks |
+| `@subway-builder-modded/special-demand-schemas` | `foundry/schemas` | Published special demand JSON schemas and validators |
 
 ### Root scripts
 

--- a/foundry/schemas/README.md
+++ b/foundry/schemas/README.md
@@ -1,48 +1,81 @@
-# Special Demand Schema
+# Special Demand Schemas
 
-JSON Schema definitions for the Subway Builder mod's special demand system. These schemas define how non-commute demand points (airports, schools, attractions, etc.) are classified, described, and linked to the simulation's demand data.
+This package contains the JSON Schema assets and runtime validators for the
+Subway Builder Modded special demand system.
 
-Owned by **Subway-Builder-Modded**. Published as an npm package via the railyard/foundry subproject.
+Package name: `@subway-builder-modded/special-demand-schemas`
 
-## Schema files
+Registry: GitHub Packages under the `@subway-builder-modded` scope
 
-### `special_demand_type_definitions.schema.json`
+## Install
 
-Defines the taxonomy of demand point types. Each type has a machine-readable id, a short code used as a point ID prefix, localized labels, a Lucide icon, and optional sub-types.
+Add an `.npmrc` entry for the organization scope:
 
-The schema encodes a governance model through custom annotations:
+```ini
+@subway-builder-modded:registry=https://npm.pkg.github.com
+```
 
-- **`x-template-locked: true`** — fields (id, code, label, description, icon) that are set by the org and must not be altered by mappers.
-- **`x-user-extensible: true`** — fields (sub_types, metadata) that mappers may add to or override for their region.
-- **`$defs/type_templates`** — a machine-readable contract listing all mandatory types with their locked field values. Application-level validators should verify that every template entry is present and that locked fields match exactly.
+Then install the package:
 
-New types are added only through versioned PRs to this schema. The current version defines 24 types across infrastructure, education, attractions, and several placeholder categories for community use.
+```bash
+pnpm add @subway-builder-modded/special-demand-schemas
+```
 
-### `special_demand_content.schema.json`
+## Published assets
 
-Per-map content file linking demand points to the type taxonomy. Each `SpecialDemandPoint` entry carries:
+The package publishes three schema files directly:
 
-- **point_id** — joins to `demand_data.json` (the simulation's spatial/demand output)
-- **type / sub_type** — references a type id from the definitions schema
-- **name** — localized display name
-- **pop_ids** — population group IDs assigned to this point (links content metadata to the demand simulation)
-- **sibling_point_ids** — other points representing the same real-world entity (e.g. multiple airport terminals)
+- `special_demand_type_definitions.schema.json`
+- `special_demand_types.schema.json`
+- `special_demand_points.schema.json`
 
-This schema is annotated `x-immutable: true` — its structure is not user-modifiable.
+It also exports a small validator API from the package root.
 
-### `special_demand_types.json` (not a schema)
+## Why there are two type schemas
 
-A generated instance of the type definitions schema, produced by `generate_types.py` from this repository's pipeline registries. Serves as the canonical type definitions file for the JP data pipeline and as a reference example for other regions.
+`special_demand_type_definitions.schema.json` is the authoritative contract for
+organization-owned type definitions. It includes the template-lock metadata and
+the canonical `type_templates` contract that application-level validators must
+enforce.
 
-## Generator scripts (JP-specific)
+`special_demand_types.schema.json` is the consumer-facing shape schema for type
+definition documents. It validates the document structure without carrying the
+full template-governance contract.
 
-These live in this directory but are specific to the subwaybuilder-jp-data pipeline:
+Use the authoritative schema and `validateSpecialDemandTypeDefinitions(...)`
+when you need to verify required template presence and locked field values.
 
-- **`generate_types.py`** — builds `special_demand_types.json` from `attraction_type_registry.py` and hardcoded infrastructure/education definitions. Sub-type metadata documents the classification methodology (MLIT field heuristics, manual assignment, etc.).
-- **`generate_content.py`** — builds per-bundle content files by joining phase_e points to phase_f demand data, resolving point IDs, pop_ids, and sibling relationships.
+## Runtime API
 
-## Example content files (JP-specific)
+The root package exports:
 
-- `special_demand_content_fukuoka.json` — 728 points, 7 types
-- `special_demand_content_izumo.json` — 400 points, 15 types
-- `special_demand_content_tsugaru.json` — 372 points, 15 types
+- `specialDemandTypeDefinitionsSchema`
+- `specialDemandTypesSchema`
+- `specialDemandPointsSchema`
+- `validateSpecialDemandTypeDefinitions(data)`
+- `validateSpecialDemandTypes(data)`
+- `validateSpecialDemandPoints(data)`
+- `validateSpecialDemandDataset({ typeDefinitions, points })`
+
+`validateSpecialDemandDataset(...)` adds the cross-document checks that JSON
+Schema alone cannot express:
+
+- required template entries are present in the type definitions document
+- template-locked fields still match the canonical template values
+- every point `type` exists in the supplied definitions document
+- every point `sub_type` exists under the selected parent type
+
+## Local fixtures
+
+These files stay in the repository as fixtures for tests and package
+verification. They are not published with the package:
+
+- `special_demand_types.json`
+- `special_demand_points_izumo.json`
+- `special_demand_points_tsugaru.json`
+
+## Notes
+
+`special_demand_points.schema.json` is the current per-map points schema. Older
+references to `special_demand_content.schema.json` should be treated as legacy
+terminology.

--- a/foundry/schemas/RELEASING.md
+++ b/foundry/schemas/RELEASING.md
@@ -1,0 +1,46 @@
+# Releasing `@subway-builder-modded/special-demand-schemas`
+
+Publishing is handled by the `publish-special-demand-schemas.yml` GitHub Actions
+workflow. The workflow publishes to GitHub Packages when a
+`special-demand-schemas-v*` tag is pushed.
+
+## Release steps
+
+1. Update the schema JSON files and validator code under `foundry/schemas/`.
+2. Bump `foundry/schemas/package.json` using semver.
+3. Verify the package locally from the repo root:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --dir foundry/schemas run build
+pnpm --dir foundry/schemas run test
+npm pack --json --dry-run --cache foundry/schemas/.npm-cache
+```
+
+4. Create and push the namespaced tag:
+
+```bash
+git tag special-demand-schemas-v<version>
+git push origin special-demand-schemas-v<version>
+```
+
+Example:
+
+```bash
+git tag special-demand-schemas-v0.1.0
+git push origin special-demand-schemas-v0.1.0
+```
+
+The workflow verifies that the tag version matches
+`foundry/schemas/package.json` before publishing.
+
+## Consumer setup
+
+Consumers need an `.npmrc` entry for the organization scope:
+
+```ini
+@subway-builder-modded:registry=https://npm.pkg.github.com
+```
+
+If the consuming environment needs authentication for package install, configure
+the appropriate GitHub Packages token for that scope.

--- a/foundry/schemas/package.json
+++ b/foundry/schemas/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@subway-builder-modded/special-demand-schemas",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./special_demand_type_definitions.schema.json": "./special_demand_type_definitions.schema.json",
+    "./special_demand_types.schema.json": "./special_demand_types.schema.json",
+    "./special_demand_points.schema.json": "./special_demand_points.schema.json"
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "special_demand_type_definitions.schema.json",
+    "special_demand_types.schema.json",
+    "special_demand_points.schema.json"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "pnpm run build && node --test --test-isolation=none tests/*.test.mjs",
+    "check": "pnpm run test"
+  },
+  "dependencies": {
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/foundry/schemas/package.json
+++ b/foundry/schemas/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "pnpm run build && node --test --test-isolation=none tests/*.test.mjs",
+    "test": "pnpm run build && node --test --experimental-test-isolation=none tests/*.test.mjs",
     "check": "pnpm run test"
   },
   "dependencies": {

--- a/foundry/schemas/special_demand_types.schema.json
+++ b/foundry/schemas/special_demand_types.schema.json
@@ -13,8 +13,8 @@
     },
     "version": {
       "type": "integer",
-      "const": 1,
-      "description": "Schema version. Increment on breaking changes."
+      "minimum": 1,
+      "description": "Schema version. Increment when the type definitions document changes."
     },
     "types": {
       "type": "array",

--- a/foundry/schemas/src/index.ts
+++ b/foundry/schemas/src/index.ts
@@ -1,0 +1,82 @@
+import { loadSchema } from "./load-schema.js";
+import {
+  createAjvValidator,
+  createValidationResult,
+  formatAjvErrors,
+  prefixErrors,
+  validatePointTypeReferences,
+  validateTemplateLocks,
+} from "./validators.js";
+
+export type { JsonObject } from "./load-schema.js";
+export type { ValidationIssue, ValidationResult } from "./validators.js";
+
+export interface SpecialDemandDatasetInput {
+  typeDefinitions: unknown;
+  points: unknown;
+}
+
+export const specialDemandTypeDefinitionsSchema = loadSchema(
+  "../special_demand_type_definitions.schema.json",
+);
+export const specialDemandTypesSchema = loadSchema(
+  "../special_demand_types.schema.json",
+);
+export const specialDemandPointsSchema = loadSchema(
+  "../special_demand_points.schema.json",
+);
+
+const validateTypeDefinitionsSchema = createAjvValidator(
+  specialDemandTypeDefinitionsSchema,
+);
+const validateTypesSchema = createAjvValidator(specialDemandTypesSchema);
+const validatePointsSchema = createAjvValidator(specialDemandPointsSchema);
+
+export function validateSpecialDemandTypeDefinitions(data: unknown) {
+  const errors = [
+    ...runAjvValidation(validateTypeDefinitionsSchema, data),
+    ...validateTemplateLocks(data, specialDemandTypeDefinitionsSchema),
+  ];
+
+  return createValidationResult(errors);
+}
+
+export function validateSpecialDemandTypes(data: unknown) {
+  return createValidationResult(runAjvValidation(validateTypesSchema, data));
+}
+
+export function validateSpecialDemandPoints(data: unknown) {
+  return createValidationResult(runAjvValidation(validatePointsSchema, data));
+}
+
+export function validateSpecialDemandDataset(
+  input: SpecialDemandDatasetInput,
+) {
+  const typeDefinitionResult = validateSpecialDemandTypeDefinitions(
+    input.typeDefinitions,
+  );
+  const pointsResult = validateSpecialDemandPoints(input.points);
+
+  const errors = [
+    ...prefixErrors("typeDefinitions", typeDefinitionResult.errors),
+    ...prefixErrors("points", pointsResult.errors),
+    ...prefixErrors(
+      "points",
+      validatePointTypeReferences(input.typeDefinitions, input.points),
+    ),
+  ];
+
+  return createValidationResult(errors);
+}
+
+function runAjvValidation(
+  validator: ReturnType<typeof createAjvValidator>,
+  data: unknown,
+) {
+  const valid = validator(data);
+  if (valid) {
+    return [];
+  }
+
+  return formatAjvErrors(validator.errors);
+}

--- a/foundry/schemas/src/load-schema.ts
+++ b/foundry/schemas/src/load-schema.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from "node:fs";
+
+export type JsonObject = Record<string, unknown>;
+
+export function loadSchema(relativePath: string): JsonObject {
+  return JSON.parse(
+    readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+  ) as JsonObject;
+}

--- a/foundry/schemas/src/validators.ts
+++ b/foundry/schemas/src/validators.ts
@@ -1,0 +1,198 @@
+import Ajv2020Import from "ajv/dist/2020.js";
+import type { ErrorObject } from "ajv";
+import addFormatsImport from "ajv-formats";
+
+import type { JsonObject } from "./load-schema.js";
+
+export interface ValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationIssue[];
+}
+
+type TemplateEntry = Record<string, unknown>;
+type AjvValidator = ((data: unknown) => boolean) & {
+  errors?: ErrorObject[] | null;
+};
+
+const Ajv2020 = Ajv2020Import as unknown as new (options?: {
+  allErrors?: boolean;
+  strict?: boolean;
+}) => {
+  compile: (schema: JsonObject) => AjvValidator;
+};
+
+const addFormats = addFormatsImport as unknown as (ajv: object) => void;
+
+export function createAjvValidator(schema: JsonObject) {
+  const ajv = new Ajv2020({
+    allErrors: true,
+    strict: false,
+  });
+
+  addFormats(ajv);
+
+  return ajv.compile(schema);
+}
+
+export function createValidationResult(errors: ValidationIssue[]): ValidationResult {
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function formatAjvErrors(errors: ErrorObject[] | null | undefined): ValidationIssue[] {
+  return (errors ?? []).map((error) => ({
+    path: error.instancePath || "/",
+    message: error.message ?? "Validation failed.",
+  }));
+}
+
+export function prefixErrors(
+  prefix: string,
+  errors: ValidationIssue[],
+): ValidationIssue[] {
+  return errors.map((error) => ({
+    path: prefixPath(prefix, error.path),
+    message: error.message,
+  }));
+}
+
+export function validateTemplateLocks(
+  data: unknown,
+  schema: JsonObject,
+): ValidationIssue[] {
+  if (!isRecord(data)) {
+    return [];
+  }
+
+  const templates = getTemplateEntries(schema);
+  if (templates.length === 0) {
+    return [];
+  }
+
+  const types = Array.isArray(data.types) ? data.types : [];
+  const typeMap = new Map<string, Record<string, unknown>>();
+
+  for (const entry of types) {
+    if (!isRecord(entry) || typeof entry.id !== "string") {
+      continue;
+    }
+
+    typeMap.set(entry.id, entry);
+  }
+
+  const errors: ValidationIssue[] = [];
+
+  for (const template of templates) {
+    const templateId = template.id;
+    if (typeof templateId !== "string") {
+      continue;
+    }
+
+    const actualType = typeMap.get(templateId);
+    if (!actualType) {
+      errors.push({
+        path: `/types/${templateId}`,
+        message: `Missing required template type "${templateId}".`,
+      });
+      continue;
+    }
+
+    for (const [field, expectedValue] of Object.entries(template)) {
+      if (actualType[field] !== expectedValue) {
+        errors.push({
+          path: `/types/${templateId}/${field}`,
+          message: `Template-locked field "${field}" must match "${String(expectedValue)}".`,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function validatePointTypeReferences(
+  typeDefinitions: unknown,
+  pointsDocument: unknown,
+): ValidationIssue[] {
+  if (!isRecord(typeDefinitions) || !isRecord(pointsDocument)) {
+    return [];
+  }
+
+  const types = Array.isArray(typeDefinitions.types) ? typeDefinitions.types : [];
+  const points = Array.isArray(pointsDocument.points) ? pointsDocument.points : [];
+
+  const typeMap = new Map<string, Set<string>>();
+
+  for (const typeEntry of types) {
+    if (!isRecord(typeEntry) || typeof typeEntry.id !== "string") {
+      continue;
+    }
+
+    const subTypes = new Set<string>();
+    if (Array.isArray(typeEntry.sub_types)) {
+      for (const subTypeEntry of typeEntry.sub_types) {
+        if (isRecord(subTypeEntry) && typeof subTypeEntry.id === "string") {
+          subTypes.add(subTypeEntry.id);
+        }
+      }
+    }
+
+    typeMap.set(typeEntry.id, subTypes);
+  }
+
+  const errors: ValidationIssue[] = [];
+
+  for (const [index, pointEntry] of points.entries()) {
+    if (!isRecord(pointEntry) || typeof pointEntry.type !== "string") {
+      continue;
+    }
+
+    const knownSubTypes = typeMap.get(pointEntry.type);
+    if (!knownSubTypes) {
+      errors.push({
+        path: `/points/${index}/type`,
+        message: `Unknown point type "${pointEntry.type}".`,
+      });
+      continue;
+    }
+
+    const subType = pointEntry.sub_type;
+    if (typeof subType === "string" && !knownSubTypes.has(subType)) {
+      errors.push({
+        path: `/points/${index}/sub_type`,
+        message: `Unknown sub_type "${subType}" for type "${pointEntry.type}".`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+function getTemplateEntries(schema: JsonObject): TemplateEntry[] {
+  const defs = isRecord(schema.$defs) ? schema.$defs : null;
+  const typeTemplates = defs && isRecord(defs.type_templates) ? defs.type_templates : null;
+  const defaultEntries = typeTemplates && Array.isArray(typeTemplates.default)
+    ? typeTemplates.default
+    : [];
+
+  return defaultEntries.filter(isRecord);
+}
+
+function prefixPath(prefix: string, path: string): string {
+  if (path === "/" || path.length === 0) {
+    return `/${prefix}`;
+  }
+
+  return `/${prefix}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/foundry/schemas/tests/validation.test.mjs
+++ b/foundry/schemas/tests/validation.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  specialDemandPointsSchema,
+  specialDemandTypeDefinitionsSchema,
+  specialDemandTypesSchema,
+  validateSpecialDemandDataset,
+  validateSpecialDemandPoints,
+  validateSpecialDemandTypeDefinitions,
+  validateSpecialDemandTypes,
+} from "../dist/index.js";
+
+import izumoPoints from "../special_demand_points_izumo.json" with { type: "json" };
+import tsugaruPoints from "../special_demand_points_tsugaru.json" with { type: "json" };
+import specialDemandTypes from "../special_demand_types.json" with { type: "json" };
+
+test("exports the parsed schema objects", () => {
+  assert.equal(
+    specialDemandTypeDefinitionsSchema.title,
+    "Special Demand Type Definitions",
+  );
+  assert.equal(
+    specialDemandTypesSchema.title,
+    "Special Demand Type Definitions",
+  );
+  assert.equal(specialDemandPointsSchema.title, "Special Demand Content");
+});
+
+test("validateSpecialDemandTypeDefinitions accepts the current type definitions fixture", () => {
+  const result = validateSpecialDemandTypeDefinitions(specialDemandTypes);
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test("validateSpecialDemandTypeDefinitions rejects template-locked changes", () => {
+  const mutated = structuredClone(specialDemandTypes);
+  mutated.types[0].icon = "train-front";
+
+  const result = validateSpecialDemandTypeDefinitions(mutated);
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.errors.map((error) => error.message).join("\n"),
+    /Template-locked field "icon"/,
+  );
+});
+
+test("validateSpecialDemandTypes accepts the current type definitions fixture structurally", () => {
+  const result = validateSpecialDemandTypes(specialDemandTypes);
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test("validateSpecialDemandPoints accepts the Izumo and Tsugaru fixtures", () => {
+  assert.equal(validateSpecialDemandPoints(izumoPoints).valid, true);
+  assert.equal(validateSpecialDemandPoints(tsugaruPoints).valid, true);
+});
+
+test("validateSpecialDemandDataset rejects unknown point types", () => {
+  const mutatedPoints = structuredClone(izumoPoints);
+  mutatedPoints.points[0].type = "unknown_type";
+
+  const result = validateSpecialDemandDataset({
+    typeDefinitions: specialDemandTypes,
+    points: mutatedPoints,
+  });
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.errors.map((error) => error.message).join("\n"),
+    /Unknown point type "unknown_type"/,
+  );
+});
+
+test("validateSpecialDemandDataset rejects unknown point sub-types", () => {
+  const mutatedPoints = structuredClone(izumoPoints);
+  mutatedPoints.points[0].sub_type = "not_a_real_sub_type";
+
+  const result = validateSpecialDemandDataset({
+    typeDefinitions: specialDemandTypes,
+    points: mutatedPoints,
+  });
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.errors.map((error) => error.message).join("\n"),
+    /Unknown sub_type "not_a_real_sub_type"/,
+  );
+});
+
+test("validateSpecialDemandDataset rejects missing required templates", () => {
+  const mutatedDefinitions = structuredClone(specialDemandTypes);
+  mutatedDefinitions.types = mutatedDefinitions.types.filter(
+    (entry) => entry.id !== "airport",
+  );
+
+  const result = validateSpecialDemandDataset({
+    typeDefinitions: mutatedDefinitions,
+    points: izumoPoints,
+  });
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.errors.map((error) => error.message).join("\n"),
+    /Missing required template type "airport"/,
+  );
+});

--- a/foundry/schemas/tsconfig.json
+++ b/foundry/schemas/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,22 @@ importers:
 
   .: {}
 
+  foundry/schemas:
+    dependencies:
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.18.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   foundry/scripts:
     dependencies:
       '@mapbox/sphericalmercator':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - website
   - railyard/frontend
+  - foundry/schemas
   - foundry/scripts
   - packages/*


### PR DESCRIPTION
This pr adds the code to publish Subway-Builder-Modded/special-demand-schemas package for use by downstream users.

Pretty straightforward PR with a lot of boilerplate.

New CI workflow to publish to Github npm and some new validation scripts using AJV (to be included in the package for use)