### PR TITLE
[Backend] Centralize integrity checks in the BE + Standardize UTC date reporting

### DIFF
--- a/packages/asset-listings-ui/src/components/project-version-row.tsx
+++ b/packages/asset-listings-ui/src/components/project-version-row.tsx
@@ -93,8 +93,8 @@ export function ProjectVersionRow({
 				)}
 			</div>
 
-			<div className="w-[7rem] shrink-0 hidden sm:block">
-				<span className="text-sm text-muted-foreground">
+			<div className="w-[11rem] shrink-0 hidden sm:block">
+				<span className="text-sm text-muted-foreground whitespace-nowrap tabular-nums">
 					{formatProjectVersionDate(date)}
 				</span>
 			</div>

--- a/packages/asset-listings-ui/src/components/sort-select.tsx
+++ b/packages/asset-listings-ui/src/components/sort-select.tsx
@@ -1,4 +1,11 @@
-import { cn } from '@subway-builder-modded/shared-ui';
+import {
+  cn,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@subway-builder-modded/shared-ui';
 import {
   ArrowDown,
   ArrowUp,
@@ -66,7 +73,9 @@ export function SortSelect({
   renderFieldControl,
 }: SortSelectProps) {
   const iconMap = fieldIcons ?? DEFAULT_FIELD_ICONS;
-  const textFieldsSet = new Set(textSortFields ?? ['name', 'author', 'country', 'city_code']);
+  const textFieldsSet = new Set(
+    textSortFields ?? ['name', 'author', 'country', 'city_code'],
+  );
 
   const currentFieldValid = fieldOptions.some((f) => f.field === value.field);
   const currentField = currentFieldValid
@@ -74,6 +83,7 @@ export function SortSelect({
     : (fieldOptions.find((opt) => Boolean(iconMap[opt.field]))?.field ??
       fieldOptions[0]?.field ??
       'name');
+  const currentOption = fieldOptions.find((opt) => opt.field === currentField);
   const isRandom = currentField === randomField;
 
   const handleFieldChange = (field: string) => {
@@ -86,7 +96,7 @@ export function SortSelect({
 
   const handleDirectionToggle = () => {
     onChange({
-      field: value.field,
+      field: currentField,
       direction: value.direction === 'asc' ? 'desc' : 'asc',
     });
   };
@@ -100,21 +110,27 @@ export function SortSelect({
           onFieldChange: handleFieldChange,
         })
       ) : (
-        <select
-          value={currentField}
-          onChange={(e) => handleFieldChange(e.target.value)}
-          className={cn(
-            'h-8 min-w-[8.5rem] border-0 bg-transparent px-3 text-xs font-semibold text-muted-foreground outline-none',
-            !isRandom && 'rounded-none border-r border-border/60',
-          )}
-          aria-label="Sort field"
-        >
-          {fieldOptions.map((opt) => (
-            <option key={opt.field} value={opt.field}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+        <Select value={currentField} onValueChange={handleFieldChange}>
+          <SelectTrigger
+            size="sm"
+            aria-label="Sort field"
+            className={cn(
+              'h-8 min-w-[8.5rem] rounded-none border-0 bg-transparent px-3 text-xs font-semibold text-muted-foreground shadow-none focus-visible:ring-0',
+              !isRandom && 'rounded-r-none border-r border-border/60',
+            )}
+          >
+            <SelectValue placeholder={currentOption?.label ?? currentField} />
+          </SelectTrigger>
+          <SelectContent align="start">
+            {fieldOptions.map((opt) => {
+              return (
+                <SelectItem key={opt.field} value={opt.field}>
+                  <span>{opt.label}</span>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
       )}
 
       {!isRandom && (
@@ -123,8 +139,8 @@ export function SortSelect({
           onClick={handleDirectionToggle}
           aria-label={
             value.direction === 'asc'
-              ? 'Sort ascending — click to sort descending'
-              : 'Sort descending — click to sort ascending'
+              ? 'Sort ascending - click to sort descending'
+              : 'Sort descending - click to sort ascending'
           }
           className={cn(
             'flex h-8 w-8 items-center justify-center',
@@ -132,7 +148,7 @@ export function SortSelect({
             'hover:bg-accent/45 hover:text-primary',
           )}
         >
-          {directionArrow(value.field, value.direction, textFieldsSet)}
+          {directionArrow(currentField, value.direction, textFieldsSet)}
         </button>
       )}
     </div>

--- a/packages/asset-listings-ui/src/index.ts
+++ b/packages/asset-listings-ui/src/index.ts
@@ -100,6 +100,7 @@ export {
 } from './types';
 export {
 	DEFAULT_PROJECT_VERSION_SORT,
+	formatDetailedProjectVersionDate,
 	formatProjectVersionDate,
 	sortProjectVersions,
 	toggleProjectVersionSort,

--- a/packages/asset-listings-ui/src/lib/project-versions.test.ts
+++ b/packages/asset-listings-ui/src/lib/project-versions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatDetailedProjectVersionDate,
   formatProjectVersionDate,
   parseProjectVersionDate,
   sortProjectVersions,
@@ -12,11 +13,17 @@ describe('project version dates', () => {
   });
 
   it('formats date-only values consistently in UTC', () => {
-    expect(formatProjectVersionDate('2026-04-14')).toBe('2026-04-14Z');
+    expect(formatProjectVersionDate('2026-04-14')).toBe('2026-04-14');
   });
 
-  it('formats timestamp values consistently in UTC', () => {
+  it('formats timestamp values as UTC calendar dates by default', () => {
     expect(formatProjectVersionDate('2026-04-14T03:51:46Z')).toBe(
+      '2026-04-14',
+    );
+  });
+
+  it('formats timestamp values with explicit UTC time detail when requested', () => {
+    expect(formatDetailedProjectVersionDate('2026-04-14T03:51:46Z')).toBe(
       '2026-04-14T03:51Z',
     );
   });

--- a/packages/asset-listings-ui/src/lib/project-versions.test.ts
+++ b/packages/asset-listings-ui/src/lib/project-versions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatProjectVersionDate,
+  parseProjectVersionDate,
+  sortProjectVersions,
+} from './project-versions';
+
+describe('project version dates', () => {
+  it('parses custom feed date-only values as UTC midnight', () => {
+    expect(parseProjectVersionDate('2026-04-14')).toBe(Date.UTC(2026, 3, 14));
+  });
+
+  it('formats date-only values consistently in UTC', () => {
+    expect(formatProjectVersionDate('2026-04-14')).toBe('2026-04-14Z');
+  });
+
+  it('formats timestamp values consistently in UTC', () => {
+    expect(formatProjectVersionDate('2026-04-14T03:51:46Z')).toBe(
+      '2026-04-14T03:51Z',
+    );
+  });
+
+  it('sorts version rows by parsed UTC dates', () => {
+    const rows = [
+      { version: '1.0.0', date: '2026-04-14', downloads: 0 },
+      { version: '1.1.0', date: '2026-04-15T03:51:46Z', downloads: 0 },
+    ];
+
+    expect(
+      sortProjectVersions(rows, { field: 'date', direction: 'desc' }).map(
+        (row) => row.version,
+      ),
+    ).toEqual(['1.1.0', '1.0.0']);
+  });
+});

--- a/packages/asset-listings-ui/src/lib/project-versions.ts
+++ b/packages/asset-listings-ui/src/lib/project-versions.ts
@@ -18,6 +18,7 @@ export interface ProjectVersionRowLike {
 
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+/** Formats UTC date parts into a compact display string. */
 function formatUTCDate(parts: {
   year: number;
   month: number;
@@ -29,13 +30,14 @@ function formatUTCDate(parts: {
   const month = String(parts.month).padStart(2, '0');
   const day = String(parts.day).padStart(2, '0');
   if (parts.hours === undefined || parts.minutes === undefined) {
-    return `${year}-${month}-${day} UTC`;
+    return `${year}-${month}-${day}Z`;
   }
   const hours = String(parts.hours).padStart(2, '0');
   const minutes = String(parts.minutes).padStart(2, '0');
-  return `${year}-${month}-${day} ${hours}:${minutes} UTC`;
+  return `${year}-${month}-${day}T${hours}:${minutes}Z`;
 }
 
+/** Parses project version dates as UTC timestamps. */
 export function parseProjectVersionDate(date: string): number | null {
   if (DATE_ONLY_PATTERN.test(date)) {
     const [year, month, day] = date.split('-').map(Number);
@@ -46,6 +48,7 @@ export function parseProjectVersionDate(date: string): number | null {
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
+/** Toggles project version sorting for the requested column. */
 export function toggleProjectVersionSort(
   previous: ProjectVersionSortState,
   field: ProjectVersionSortField,
@@ -60,6 +63,7 @@ export function toggleProjectVersionSort(
   return { field, direction: 'desc' };
 }
 
+/** Sorts project versions using parsed UTC dates when needed. */
 export function sortProjectVersions<T extends ProjectVersionRowLike>(
   versions: T[],
   sort: ProjectVersionSortState,
@@ -79,13 +83,14 @@ export function sortProjectVersions<T extends ProjectVersionRowLike>(
       comparison = compareVersion(left.version, right.version);
     }
 
-    return sort.direction === 'asc' ? comparison : -comparison;
+  return sort.direction === 'asc' ? comparison : -comparison;
   });
 }
 
+/** Formats project version dates for consistent UTC display. */
 export function formatProjectVersionDate(date: string): string {
   if (DATE_ONLY_PATTERN.test(date)) {
-    return `${date} UTC`;
+    return `${date}Z`;
   }
 
   const timestamp = parseProjectVersionDate(date);

--- a/packages/asset-listings-ui/src/lib/project-versions.ts
+++ b/packages/asset-listings-ui/src/lib/project-versions.ts
@@ -16,6 +16,36 @@ export interface ProjectVersionRowLike {
   downloads: number;
 }
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function formatUTCDate(parts: {
+  year: number;
+  month: number;
+  day: number;
+  hours?: number;
+  minutes?: number;
+}): string {
+  const year = String(parts.year).padStart(4, '0');
+  const month = String(parts.month).padStart(2, '0');
+  const day = String(parts.day).padStart(2, '0');
+  if (parts.hours === undefined || parts.minutes === undefined) {
+    return `${year}-${month}-${day} UTC`;
+  }
+  const hours = String(parts.hours).padStart(2, '0');
+  const minutes = String(parts.minutes).padStart(2, '0');
+  return `${year}-${month}-${day} ${hours}:${minutes} UTC`;
+}
+
+export function parseProjectVersionDate(date: string): number | null {
+  if (DATE_ONLY_PATTERN.test(date)) {
+    const [year, month, day] = date.split('-').map(Number);
+    return Date.UTC(year, month - 1, day);
+  }
+
+  const timestamp = Date.parse(date);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
 export function toggleProjectVersionSort(
   previous: ProjectVersionSortState,
   field: ProjectVersionSortField,
@@ -41,7 +71,8 @@ export function sortProjectVersions<T extends ProjectVersionRowLike>(
 
     if (sort.field === 'date') {
       comparison =
-        new Date(left.date).getTime() - new Date(right.date).getTime();
+        (parseProjectVersionDate(left.date) ?? 0) -
+        (parseProjectVersionDate(right.date) ?? 0);
     } else if (sort.field === 'downloads') {
       comparison = left.downloads - right.downloads;
     } else {
@@ -53,13 +84,19 @@ export function sortProjectVersions<T extends ProjectVersionRowLike>(
 }
 
 export function formatProjectVersionDate(date: string): string {
-  try {
-    return new Date(date).toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  } catch {
-    return date;
+  if (DATE_ONLY_PATTERN.test(date)) {
+    return `${date} UTC`;
   }
+
+  const timestamp = parseProjectVersionDate(date);
+  if (timestamp === null) return date;
+
+  const parsed = new Date(timestamp);
+  return formatUTCDate({
+    year: parsed.getUTCFullYear(),
+    month: parsed.getUTCMonth() + 1,
+    day: parsed.getUTCDate(),
+    hours: parsed.getUTCHours(),
+    minutes: parsed.getUTCMinutes(),
+  });
 }

--- a/packages/asset-listings-ui/src/lib/project-versions.ts
+++ b/packages/asset-listings-ui/src/lib/project-versions.ts
@@ -30,7 +30,7 @@ function formatUTCDate(parts: {
   const month = String(parts.month).padStart(2, '0');
   const day = String(parts.day).padStart(2, '0');
   if (parts.hours === undefined || parts.minutes === undefined) {
-    return `${year}-${month}-${day}Z`;
+    return `${year}-${month}-${day}`;
   }
   const hours = String(parts.hours).padStart(2, '0');
   const minutes = String(parts.minutes).padStart(2, '0');
@@ -83,16 +83,25 @@ export function sortProjectVersions<T extends ProjectVersionRowLike>(
       comparison = compareVersion(left.version, right.version);
     }
 
-  return sort.direction === 'asc' ? comparison : -comparison;
+    return sort.direction === 'asc' ? comparison : -comparison;
   });
 }
 
 /** Formats project version dates for consistent UTC display. */
 export function formatProjectVersionDate(date: string): string {
-  if (DATE_ONLY_PATTERN.test(date)) {
-    return `${date}Z`;
-  }
+  const timestamp = parseProjectVersionDate(date);
+  if (timestamp === null) return date;
 
+  const parsed = new Date(timestamp);
+  return formatUTCDate({
+    year: parsed.getUTCFullYear(),
+    month: parsed.getUTCMonth() + 1,
+    day: parsed.getUTCDate(),
+  });
+}
+
+/** Formats project version timestamps with explicit UTC time detail. */
+export function formatDetailedProjectVersionDate(date: string): string {
   const timestamp = parseProjectVersionDate(date);
   if (timestamp === null) return date;
 

--- a/railyard/frontend/src/pages/ChangelogPage.tsx
+++ b/railyard/frontend/src/pages/ChangelogPage.tsx
@@ -1,6 +1,7 @@
 import {
   EmptyState,
   ErrorBanner,
+  formatProjectVersionDate,
   MarkdownPanel,
 } from '@subway-builder-modded/asset-listings-ui';
 import {
@@ -322,15 +323,7 @@ export function ChangelogPage() {
 
   const formattedDate = useMemo(() => {
     if (!versionInfo?.date) return null;
-    try {
-      return new Date(versionInfo.date).toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      });
-    } catch {
-      return versionInfo.date;
-    }
+    return formatProjectVersionDate(versionInfo.date);
   }, [versionInfo?.date]);
 
   if (!item || !type) {

--- a/railyard/frontend/src/pages/ChangelogPage.tsx
+++ b/railyard/frontend/src/pages/ChangelogPage.tsx
@@ -1,6 +1,7 @@
 import {
   EmptyState,
   ErrorBanner,
+  formatDetailedProjectVersionDate,
   formatProjectVersionDate,
   MarkdownPanel,
 } from '@subway-builder-modded/asset-listings-ui';
@@ -326,6 +327,11 @@ export function ChangelogPage() {
     return formatProjectVersionDate(versionInfo.date);
   }, [versionInfo?.date]);
 
+  const formattedPublishedDate = useMemo(() => {
+    if (!versionInfo?.date) return null;
+    return formatDetailedProjectVersionDate(versionInfo.date);
+  }, [versionInfo?.date]);
+
   if (!item || !type) {
     return (
       <EmptyState
@@ -623,9 +629,9 @@ export function ChangelogPage() {
                       {versionInfo.downloads.toLocaleString()}
                     </MetaRow>
 
-                    {formattedDate && (
+                    {formattedPublishedDate && (
                       <MetaRow icon={Calendar} label="Published">
-                        {formattedDate}
+                        {formattedPublishedDate}
                       </MetaRow>
                     )}
                   </div>

--- a/railyard/frontend/src/pages/ChangelogPage.tsx
+++ b/railyard/frontend/src/pages/ChangelogPage.tsx
@@ -71,7 +71,7 @@ import { ComputeDependencyList } from '../../wailsjs/go/downloader/Downloader';
 import type { types } from '../../wailsjs/go/models';
 import {
   GetAssetDownloadCounts,
-  GetVersionsResponse,
+  GetInstallableVersionsResponse,
 } from '../../wailsjs/go/registry/Registry';
 import { BrowserOpenURL } from '../../wailsjs/runtime/runtime';
 
@@ -109,8 +109,6 @@ export function ChangelogPage() {
   const [, params] = useRoute('/project/:type/:id/changelog/:version');
   const mods = useRegistryStore((s) => s.mods);
   const maps = useRegistryStore((s) => s.maps);
-  const modIntegrity = useRegistryStore((s) => s.modIntegrity);
-  const mapIntegrity = useRegistryStore((s) => s.mapIntegrity);
 
   const routeType = params?.type;
   const type = routeType ? listingPathToAssetType(routeType) : undefined;
@@ -176,17 +174,10 @@ export function ChangelogPage() {
 
   useEffect(() => {
     if (!item || !type || !versionParam) return;
-    const source =
-      item.update.type === 'github' ? item.update.repo : item.update.url;
-    if (!source) {
-      setFetchError('No update source configured');
-      setLoading(false);
-      return;
-    }
     let cancelled = false;
     setLoading(true);
     setFetchError(null);
-    GetVersionsResponse(item.update.type, source)
+    GetInstallableVersionsResponse(type, item.id)
       .then(async (response) => {
         if (cancelled) return;
         if (response.status !== 'success') {
@@ -211,14 +202,7 @@ export function ChangelogPage() {
         } catch {}
 
         if (!cancelled) {
-          const integrity = type === 'mod' ? modIntegrity : mapIntegrity;
-          const completeVersions =
-            integrity && id ? integrity.listings[id]?.complete_versions : null;
-          const filtered = completeVersions
-            ? mergedVersions.filter((v) => completeVersions.includes(v.version))
-            : mergedVersions;
-
-          const found = filtered.find((v) => v.version === versionParam);
+          const found = mergedVersions.find((v) => v.version === versionParam);
           setVersionInfo(found ?? null);
           setLoading(false);
         }
@@ -232,14 +216,7 @@ export function ChangelogPage() {
     return () => {
       cancelled = true;
     };
-  }, [
-    type,
-    item?.id,
-    item?.update.type,
-    item?.update.repo,
-    item?.update.url,
-    versionParam,
-  ]);
+  }, [type, item?.id, versionParam]);
 
   useEffect(() => {
     setResolvedDeps(null);

--- a/railyard/frontend/src/pages/ProjectPage.tsx
+++ b/railyard/frontend/src/pages/ProjectPage.tsx
@@ -32,7 +32,7 @@ import { GetGameVersion } from '../../wailsjs/go/main/App';
 import type { types } from '../../wailsjs/go/models';
 import {
   GetAssetDownloadCounts,
-  GetVersionsResponse,
+  GetInstallableVersionsResponse,
 } from '../../wailsjs/go/registry/Registry';
 import { BrowserOpenURL } from '../../wailsjs/runtime/runtime';
 
@@ -40,8 +40,6 @@ export function ProjectPage() {
   const [, params] = useRoute('/project/:type/:id');
   const mods = useRegistryStore((s) => s.mods);
   const maps = useRegistryStore((s) => s.maps);
-  const mapIntegrity = useRegistryStore((s) => s.mapIntegrity);
-  const modIntegrity = useRegistryStore((s) => s.modIntegrity);
   const modDownloadTotals = useRegistryStore((s) => s.modDownloadTotals);
   const mapDownloadTotals = useRegistryStore((s) => s.mapDownloadTotals);
   const ensureDownloadTotals = useRegistryStore((s) => s.ensureDownloadTotals);
@@ -67,19 +65,6 @@ export function ProjectPage() {
   const [versionsError, setVersionsError] = useState<string | null>(null);
   const [gameVersion, setGameVersion] = useState<string>('');
 
-  const filterInvalidVersions = (vs: types.VersionInfo[]) => {
-    if (type === 'mod' && modIntegrity && id) {
-      return vs.filter((v) =>
-        modIntegrity.listings[id].complete_versions.includes(v.version),
-      );
-    }
-    if (type === 'map' && mapIntegrity && id) {
-      return vs.filter((v) =>
-        mapIntegrity.listings[id].complete_versions.includes(v.version),
-      );
-    }
-  };
-
   useEffect(() => {
     ensureDownloadTotals();
   }, [ensureDownloadTotals]);
@@ -96,17 +81,10 @@ export function ProjectPage() {
 
   useEffect(() => {
     if (!item || !type) return;
-    const source =
-      item.update.type === 'github' ? item.update.repo : item.update.url;
-    if (!source) {
-      setVersionsLoading(false);
-      setVersionsError('No update source configured');
-      return;
-    }
     let cancelled = false;
     setVersionsLoading(true);
     setVersionsError(null);
-    GetVersionsResponse(item.update.type, source)
+    GetInstallableVersionsResponse(type, item.id)
       .then(async (response) => {
         if (cancelled) return;
         if (response.status !== 'success') {
@@ -141,7 +119,7 @@ export function ProjectPage() {
         }
 
         if (!cancelled) {
-          setVersions(filterInvalidVersions(mergedVersions) || mergedVersions);
+          setVersions(mergedVersions);
           setVersionsLoading(false);
         }
       })
@@ -154,7 +132,7 @@ export function ProjectPage() {
     return () => {
       cancelled = true;
     };
-  }, [type, item?.id, item?.update.type, item?.update.repo, item?.update.url]);
+  }, [type, item?.id]);
 
   const latestVersion = versions[0];
   const latestCompatibleVersion = useMemo(() => {

--- a/railyard/frontend/src/stores/registry-store.test.ts
+++ b/railyard/frontend/src/stores/registry-store.test.ts
@@ -5,13 +5,11 @@ import { useRegistryStore } from './registry-store';
 const {
   mockGetModsResponse,
   mockGetMapsResponse,
-  mockGetIntegrityReportResponse,
   mockRefreshResponse,
   mockGetDownloadCountsByAssetType,
 } = vi.hoisted(() => ({
   mockGetModsResponse: vi.fn(),
   mockGetMapsResponse: vi.fn(),
-  mockGetIntegrityReportResponse: vi.fn(),
   mockRefreshResponse: vi.fn(),
   mockGetDownloadCountsByAssetType: vi.fn(),
 }));
@@ -19,7 +17,6 @@ const {
 vi.mock('../../wailsjs/go/registry/Registry', () => ({
   GetModsResponse: mockGetModsResponse,
   GetMapsResponse: mockGetMapsResponse,
-  GetIntegrityReportResponse: mockGetIntegrityReportResponse,
   RefreshResponse: mockRefreshResponse,
   GetDownloadCountsByAssetType: mockGetDownloadCountsByAssetType,
 }));
@@ -31,8 +28,6 @@ describe('useRegistryStore download totals', () => {
     useRegistryStore.setState({
       mods: [],
       maps: [],
-      mapIntegrity: null,
-      modIntegrity: null,
       modDownloadTotals: {},
       mapDownloadTotals: {},
       downloadTotalsLoaded: false,
@@ -146,17 +141,6 @@ describe('useRegistryStore download totals', () => {
       message: 'ok',
       maps: [],
     });
-    mockGetIntegrityReportResponse
-      .mockResolvedValueOnce({
-        status: 'success',
-        message: 'ok',
-        report: { listings: {} },
-      })
-      .mockResolvedValueOnce({
-        status: 'success',
-        message: 'ok',
-        report: { listings: {} },
-      });
     mockGetDownloadCountsByAssetType
       .mockResolvedValueOnce({
         status: 'success',
@@ -177,9 +161,6 @@ describe('useRegistryStore download totals', () => {
     expect(mockRefreshResponse).toHaveBeenCalledTimes(1);
     expect(mockGetModsResponse).toHaveBeenCalledTimes(1);
     expect(mockGetMapsResponse).toHaveBeenCalledTimes(1);
-    expect(mockGetIntegrityReportResponse).toHaveBeenCalledTimes(2);
-    expect(mockGetIntegrityReportResponse).toHaveBeenNthCalledWith(1, 'map');
-    expect(mockGetIntegrityReportResponse).toHaveBeenNthCalledWith(2, 'mod');
     expect(state.modDownloadTotals).toEqual({ mod_c: 9 });
     expect(state.mapDownloadTotals).toEqual({ map_c: 10 });
     expect(state.downloadTotalsLoaded).toBe(true);

--- a/railyard/frontend/src/stores/registry-store.ts
+++ b/railyard/frontend/src/stores/registry-store.ts
@@ -5,7 +5,6 @@ import { create } from 'zustand';
 import type { types } from '../../wailsjs/go/models';
 import {
   GetDownloadCountsByAssetType,
-  GetIntegrityReportResponse,
   GetMapsResponse,
   GetModsResponse,
   RefreshResponse,
@@ -14,8 +13,6 @@ import {
 interface RegistryState {
   mods: types.ModManifest[];
   maps: types.MapManifest[];
-  mapIntegrity: types.RegistryIntegrityReport | null;
-  modIntegrity: types.RegistryIntegrityReport | null;
   modDownloadTotals: Record<string, number>;
   mapDownloadTotals: Record<string, number>;
   downloadTotalsLoaded: boolean;
@@ -37,55 +34,10 @@ function emptyRecordByAssetType<T>(factory: () => T): Record<AssetType, T> {
   ) as Record<AssetType, T>;
 }
 
-function filterMapsAndModsByIntegrity(
-  maps: types.MapManifest[],
-  mods: types.ModManifest[],
-  mapIntegrity: types.RegistryIntegrityReport,
-  modIntegrity: types.RegistryIntegrityReport,
-) {
-  const finalMaps = [];
-  const finalMods = [];
-  let invalidCounter = 0;
-  for (const mod of mods) {
-    if (modIntegrity.listings[mod.id].has_complete_version) {
-      finalMods.push(mod);
-    } else {
-      invalidCounter++;
-    }
-  }
-  if (invalidCounter > 0) {
-    console.warn(
-      `Excluding ${invalidCounter} mods from registry due to incomplete versions`,
-    );
-  }
-
-  invalidCounter = 0;
-  for (const map of maps) {
-    if (mapIntegrity.listings[map.id].has_complete_version) {
-      finalMaps.push(map);
-    } else {
-      invalidCounter++;
-    }
-  }
-  if (invalidCounter > 0) {
-    console.warn(
-      `Excluding ${invalidCounter} maps from registry due to incomplete versions`,
-    );
-  }
-  return { finalMaps, finalMods };
-}
-
 async function loadRegistryData() {
-  const [
-    modsResponse,
-    mapsResponse,
-    mapIntegrityResponse,
-    modIntegrityResponse,
-  ] = await Promise.all([
+  const [modsResponse, mapsResponse] = await Promise.all([
     GetModsResponse(),
     GetMapsResponse(),
-    GetIntegrityReportResponse('map'),
-    GetIntegrityReportResponse('mod'),
   ]);
 
   if (modsResponse.status !== 'success') {
@@ -94,37 +46,16 @@ async function loadRegistryData() {
   if (mapsResponse.status !== 'success') {
     throw new Error(mapsResponse.message || 'Failed to load maps');
   }
-  if (mapIntegrityResponse.status !== 'success') {
-    throw new Error(
-      mapIntegrityResponse.message || 'Failed to load map integrity',
-    );
-  }
-  if (modIntegrityResponse.status !== 'success') {
-    throw new Error(
-      modIntegrityResponse.message || 'Failed to load mod integrity',
-    );
-  }
-
-  const { finalMaps, finalMods } = filterMapsAndModsByIntegrity(
-    mapsResponse.maps,
-    modsResponse.mods,
-    mapIntegrityResponse.report,
-    modIntegrityResponse.report,
-  );
 
   return {
-    mods: finalMods || [],
-    maps: finalMaps || [],
-    mapIntegrity: mapIntegrityResponse.report || null,
-    modIntegrity: modIntegrityResponse.report || null,
+    mods: modsResponse.mods || [],
+    maps: mapsResponse.maps || [],
   };
 }
 
 export const useRegistryStore = create<RegistryState>((set, get) => ({
   mods: [],
   maps: [],
-  mapIntegrity: null,
-  modIntegrity: null,
   modDownloadTotals: {},
   mapDownloadTotals: {},
   downloadTotalsLoaded: false,
@@ -204,13 +135,10 @@ export const useRegistryStore = create<RegistryState>((set, get) => ({
     if (get().initialized) return;
     set({ loading: true, error: null });
     try {
-      const { mods, maps, mapIntegrity, modIntegrity } =
-        await loadRegistryData();
+      const { mods, maps } = await loadRegistryData();
       set({
         mods,
         maps,
-        mapIntegrity,
-        modIntegrity,
         initialized: true,
         loading: false,
       });
@@ -232,13 +160,10 @@ export const useRegistryStore = create<RegistryState>((set, get) => ({
           refreshResponse.message || 'Failed to refresh registry',
         );
       }
-      const { mods, maps, mapIntegrity, modIntegrity } =
-        await loadRegistryData();
+      const { mods, maps } = await loadRegistryData();
       set({
         mods,
         maps,
-        mapIntegrity,
-        modIntegrity,
         initialized: true,
         loading: false,
       });

--- a/railyard/frontend/wailsjs/go/registry/Registry.d.ts
+++ b/railyard/frontend/wailsjs/go/registry/Registry.d.ts
@@ -27,6 +27,8 @@ export function GetInstalledMods():Promise<Array<types.InstalledModInfo>>;
 
 export function GetInstalledModsResponse():Promise<types.InstalledModsResponse>;
 
+export function GetInstallableVersionsResponse(arg1:types.AssetType,arg2:string):Promise<types.VersionsResponse>;
+
 export function GetIntegrityReport(arg1:types.AssetType):Promise<types.RegistryIntegrityReport>;
 
 export function GetIntegrityReportResponse(arg1:types.AssetType):Promise<types.RegistryIntegrityReportResponse>;

--- a/railyard/frontend/wailsjs/go/registry/Registry.d.ts
+++ b/railyard/frontend/wailsjs/go/registry/Registry.d.ts
@@ -17,6 +17,10 @@ export function GetGalleryImage(arg1:string,arg2:string,arg3:string):Promise<str
 
 export function GetGalleryImageResponse(arg1:string,arg2:string,arg3:string):Promise<types.GalleryImageResponse>;
 
+export function GetInstallableVersions(arg1:types.AssetType,arg2:string):Promise<Array<types.VersionInfo>>;
+
+export function GetInstallableVersionsResponse(arg1:types.AssetType,arg2:string):Promise<types.VersionsResponse>;
+
 export function GetInstalledMapCodes():Promise<Array<string>>;
 
 export function GetInstalledMaps():Promise<Array<types.InstalledMapInfo>>;
@@ -26,8 +30,6 @@ export function GetInstalledMapsResponse():Promise<types.InstalledMapsResponse>;
 export function GetInstalledMods():Promise<Array<types.InstalledModInfo>>;
 
 export function GetInstalledModsResponse():Promise<types.InstalledModsResponse>;
-
-export function GetInstallableVersionsResponse(arg1:types.AssetType,arg2:string):Promise<types.VersionsResponse>;
 
 export function GetIntegrityReport(arg1:types.AssetType):Promise<types.RegistryIntegrityReport>;
 

--- a/railyard/frontend/wailsjs/go/registry/Registry.js
+++ b/railyard/frontend/wailsjs/go/registry/Registry.js
@@ -50,6 +50,10 @@ export function GetInstalledModsResponse() {
   return window['go']['registry']['Registry']['GetInstalledModsResponse']();
 }
 
+export function GetInstallableVersionsResponse(arg1, arg2) {
+  return window['go']['registry']['Registry']['GetInstallableVersionsResponse'](arg1, arg2);
+}
+
 export function GetIntegrityReport(arg1) {
   return window['go']['registry']['Registry']['GetIntegrityReport'](arg1);
 }

--- a/railyard/frontend/wailsjs/go/registry/Registry.js
+++ b/railyard/frontend/wailsjs/go/registry/Registry.js
@@ -30,6 +30,14 @@ export function GetGalleryImageResponse(arg1, arg2, arg3) {
   return window['go']['registry']['Registry']['GetGalleryImageResponse'](arg1, arg2, arg3);
 }
 
+export function GetInstallableVersions(arg1, arg2) {
+  return window['go']['registry']['Registry']['GetInstallableVersions'](arg1, arg2);
+}
+
+export function GetInstallableVersionsResponse(arg1, arg2) {
+  return window['go']['registry']['Registry']['GetInstallableVersionsResponse'](arg1, arg2);
+}
+
 export function GetInstalledMapCodes() {
   return window['go']['registry']['Registry']['GetInstalledMapCodes']();
 }
@@ -48,10 +56,6 @@ export function GetInstalledMods() {
 
 export function GetInstalledModsResponse() {
   return window['go']['registry']['Registry']['GetInstalledModsResponse']();
-}
-
-export function GetInstallableVersionsResponse(arg1, arg2) {
-  return window['go']['registry']['Registry']['GetInstallableVersionsResponse'](arg1, arg2);
 }
 
 export function GetIntegrityReport(arg1) {

--- a/railyard/internal/downloader/downloader.go
+++ b/railyard/internal/downloader/downloader.go
@@ -840,9 +840,9 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 		source = modInfo.Update.Repo
 	}
 	d.Logger.Info("Fetching available versions", "mod_id", modId, "update_type", modInfo.Update.Type, "source", source)
-	versions, err := d.Registry.GetVersions(modInfo.Update.Type, source)
+	versions, err := d.Registry.GetInstallableVersions(types.AssetTypeMod, modId)
 	if err != nil {
-		return d.installError(types.AssetTypeMod, modId, version, types.ConfigData{}, types.InstallErrorVersionLookup, "Failed to get mod versions from registry", err, "mod_id", modId)
+		return d.installError(types.AssetTypeMod, modId, version, types.ConfigData{}, types.InstallErrorVersionLookup, "Mod has no installable versions in integrity cache", err, "mod_id", modId)
 	}
 
 	availableVersions := make([]string, len(versions))
@@ -977,9 +977,9 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 		source = mapInfo.Update.Repo
 	}
 	d.Logger.Info("Fetching available versions", "map_id", mapId, "update_type", mapInfo.Update.Type, "source", source)
-	versions, err := d.Registry.GetVersions(mapInfo.Update.Type, source)
+	versions, err := d.Registry.GetInstallableVersions(types.AssetTypeMap, mapId)
 	if err != nil {
-		return d.installError(types.AssetTypeMap, mapId, version, types.ConfigData{}, types.InstallErrorVersionLookup, "Failed to get map versions from registry", err, "map_id", mapId)
+		return d.installError(types.AssetTypeMap, mapId, version, types.ConfigData{}, types.InstallErrorVersionLookup, "Map has no installable versions in integrity cache", err, "map_id", mapId)
 	}
 
 	availableVersions := make([]string, len(versions))
@@ -1258,19 +1258,9 @@ func (d *Downloader) recursivelyComputeDependencies(modId string, version types.
 			return nil, fmt.Errorf("circular dependency detected: %s", strings.Join(cycle, " -> "))
 		}
 
-		depInfo, err := d.Registry.GetMod(depModID)
+		versions, err := d.Registry.GetInstallableVersions(types.AssetTypeMod, depModID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get mod info for dependency %s: %w", depModID, err)
-		}
-
-		var versions []types.VersionInfo
-		if depInfo.Update.Type == "github" {
-			versions, err = d.Registry.GetVersions("github", depInfo.Update.Repo)
-		} else {
-			versions, err = d.Registry.GetVersions(depInfo.Update.Type, depInfo.Update.URL)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to get versions for dependency %s: %w", depModID, err)
+			return nil, fmt.Errorf("dependency %s has no installable versions in integrity cache: %w", depModID, err)
 		}
 
 		existingDep, exists := installList[depModID]

--- a/railyard/internal/downloader/downloader_test.go
+++ b/railyard/internal/downloader/downloader_test.go
@@ -896,6 +896,35 @@ func TestInstallAssetError(t *testing.T) {
 			expectedStatus:    types.ResponseError,
 			expectedErrorCode: types.InstallErrorVersionNotFound,
 		},
+		{
+			name:      "Integrity cache blocks install when no complete version exists",
+			assetType: types.AssetTypeMap,
+			assetID:   "map-a",
+			version:   "1.0.0",
+			setup: func(t *testing.T, d *Downloader, reg *registry.Registry) func() {
+				t.Helper()
+				configureDownloaderConfig(t, d.Config)
+				cleanup := registrytest.MockRegistryServer(t, reg, []registrytest.UpdateFixture{
+					{AssetID: "map-a", AssetType: types.AssetTypeMap, Versions: []string{"1.0.0"}, MapCode: "AAA"},
+				})
+				registrytest.SetUnexportedField(t, reg, "integrityMaps", types.RegistryIntegrityReport{
+					SchemaVersion: 1,
+					GeneratedAt:   "1970-01-01T00:00:00Z",
+					Listings: map[string]types.IntegrityListing{
+						"map-a": {
+							HasCompleteVersion: false,
+							CompleteVersions:   []string{},
+							Versions: map[string]types.IntegrityVersionStatus{
+								"1.0.0": {IsComplete: false},
+							},
+						},
+					},
+				})
+				return cleanup
+			},
+			expectedStatus:    types.ResponseError,
+			expectedErrorCode: types.InstallErrorVersionLookup,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/railyard/internal/downloader/downloader_test.go
+++ b/railyard/internal/downloader/downloader_test.go
@@ -37,6 +37,7 @@ func setupDependencyResolverServer(t *testing.T, reg *registry.Registry, fixture
 
 	handler := http.NewServeMux()
 	mods := make([]types.ModManifest, 0, len(fixtures))
+	integrityListings := make(map[string]types.IntegrityListing, len(fixtures))
 
 	for modID, versions := range fixtures {
 		currentModID := modID
@@ -46,6 +47,17 @@ func setupDependencyResolverServer(t *testing.T, reg *registry.Registry, fixture
 		modManifest := registrytest.MockModManifestWithID(currentModID)
 		modManifest.Update = types.UpdateConfig{Type: "custom", URL: "{{BASE_URL}}" + updatePath}
 		mods = append(mods, modManifest)
+		completeVersions := make([]string, 0, len(currentVersions))
+		versionStatuses := make(map[string]types.IntegrityVersionStatus, len(currentVersions))
+		for _, version := range currentVersions {
+			completeVersions = append(completeVersions, version.Version)
+			versionStatuses[version.Version] = types.IntegrityVersionStatus{IsComplete: true}
+		}
+		integrityListings[currentModID] = types.IntegrityListing{
+			HasCompleteVersion: true,
+			CompleteVersions:   completeVersions,
+			Versions:           versionStatuses,
+		}
 
 		handler.HandleFunc(updatePath, func(w http.ResponseWriter, r *http.Request) {
 			payload := types.CustomUpdateFile{
@@ -70,6 +82,11 @@ func setupDependencyResolverServer(t *testing.T, reg *registry.Registry, fixture
 		mods[i].Update.URL = strings.ReplaceAll(mods[i].Update.URL, "{{BASE_URL}}", server.URL)
 	}
 	registrytest.SetManifestsForTest(t, reg, mods, []types.MapManifest{})
+	registrytest.SetUnexportedField(t, reg, "integrityMods", types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings:      integrityListings,
+	})
 
 	return server.Close
 }
@@ -1358,13 +1375,6 @@ func TestComputeDependencyListResolvesTransitiveDependencies(t *testing.T) {
 	})
 	defer cleanup()
 
-	depAMod, err := reg.GetMod("dep-a")
-	require.NoError(t, err)
-	depAVersions, err := reg.GetVersions(depAMod.Update.Type, depAMod.Update.Source())
-	require.NoError(t, err)
-	require.NotEmpty(t, depAVersions)
-	require.NotEmpty(t, depAVersions[0].Dependencies)
-
 	result := d.ComputeDependencyList("root", types.VersionInfo{
 		Version:      "1.0.0",
 		Dependencies: map[string]string{"dep-a": "1.0.0", "dep-b": "1.0.0"},
@@ -1397,13 +1407,6 @@ func TestComputeDependencyListFailsOnConflictingRanges(t *testing.T) {
 		},
 	})
 	defer cleanup()
-
-	depAMod, err := reg.GetMod("dep-a")
-	require.NoError(t, err)
-	depAVersions, err := reg.GetVersions(depAMod.Update.Type, depAMod.Update.Source())
-	require.NoError(t, err)
-	require.NotEmpty(t, depAVersions)
-	require.NotEmpty(t, depAVersions[0].Dependencies)
 
 	result := d.ComputeDependencyList("root", types.VersionInfo{
 		Version:      "1.0.0",

--- a/railyard/internal/profiles/profiles_sync_test.go
+++ b/railyard/internal/profiles/profiles_sync_test.go
@@ -44,7 +44,7 @@ func TestSyncActionErrorIgnoresWarnings(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Non-duplicate warning still returns error", func(t *testing.T) {
+	t.Run("Non-duplicate warning is tolerated", func(t *testing.T) {
 		err := syncInstallActionError(
 			types.SubscriptionActionSubscribe,
 			types.AssetTypeMap,

--- a/railyard/internal/profiles/profiles_update_test.go
+++ b/railyard/internal/profiles/profiles_update_test.go
@@ -277,26 +277,6 @@ func TestUpdateSubscriptionsRejectsInvalidRequests(t *testing.T) {
 	})
 }
 
-func TestUpdateSubscriptionsAcceptsSemverVersionString(t *testing.T) {
-	testutil.NewHarness(t)
-	svc := loadedUserProfilesService(t, types.InitialProfilesState())
-
-	result := svc.UpdateSubscriptions(types.UpdateSubscriptionsRequest{
-		ProfileID: types.DefaultProfileID,
-		Action:    types.SubscriptionActionSubscribe,
-		ApplyMode: types.UpdateSubscriptionsRuntimeOnly,
-		Assets: map[string]types.SubscriptionUpdateItem{
-			"map-x": {Type: types.AssetTypeMap, Version: types.Version("1.2.3")},
-		},
-	})
-	require.Equal(t, types.ResponseSuccess, result.Status)
-	require.Equal(t, "Subscriptions updated", result.Message)
-	require.Empty(t, result.Errors)
-	require.Equal(t, "1.2.3", result.Profile.Subscriptions.Maps["map-x"])
-	require.Len(t, result.Operations, 1)
-	require.Equal(t, types.Version("1.2.3"), result.Operations[0].Version)
-}
-
 func TestUpdateSubscriptionsForceSyncErrors(t *testing.T) {
 	testutil.NewHarness(t)
 	state := types.InitialProfilesState()

--- a/railyard/internal/registry/download_counts_test.go
+++ b/railyard/internal/registry/download_counts_test.go
@@ -134,7 +134,7 @@ func TestFetchFromDiskFiltersOutAssetsMissingIntegrityListings(t *testing.T) {
 			SchemaVersion: 1,
 			GeneratedAt:   "1970-01-01T00:00:00Z",
 			Listings: map[string]types.IntegrityListing{
-				"mod-a": {Versions: map[string]types.IntegrityVersionStatus{}},
+				"mod-a": {HasCompleteVersion: true, Versions: map[string]types.IntegrityVersionStatus{}},
 			},
 		},
 	))
@@ -145,7 +145,55 @@ func TestFetchFromDiskFiltersOutAssetsMissingIntegrityListings(t *testing.T) {
 			SchemaVersion: 1,
 			GeneratedAt:   "1970-01-01T00:00:00Z",
 			Listings: map[string]types.IntegrityListing{
-				"map-a": {Versions: map[string]types.IntegrityVersionStatus{}},
+				"map-a": {HasCompleteVersion: true, Versions: map[string]types.IntegrityVersionStatus{}},
+			},
+		},
+	))
+
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	reg.SetContext(context.WithValue(context.Background(), "test", "true"))
+	require.NoError(t, reg.fetchFromDisk())
+
+	require.Len(t, reg.GetMods(), 1)
+	require.Equal(t, "mod-a", reg.GetMods()[0].ID)
+	require.Len(t, reg.GetMaps(), 1)
+	require.Equal(t, "map-a", reg.GetMaps()[0].ID)
+}
+
+func TestFetchFromDiskFiltersOutAssetsWithoutCompleteIntegrityVersions(t *testing.T) {
+	testutil.NewHarness(t)
+	registrytest.WriteFixture(t, registrytest.RepositoryFixture{
+		Mods: []types.ModManifest{
+			testModManifest("mod-a"),
+			testModManifest("mod-b"),
+		},
+		Maps: []types.MapManifest{
+			testMapManifest("map-a"),
+			testMapManifest("map-b"),
+		},
+	})
+
+	require.NoError(t, files.WriteJSON(
+		filepath.Join(paths.RegistryRepoPath(), "mods", constants.INTEGRITY_JSON),
+		"mods integrity report",
+		types.RegistryIntegrityReport{
+			SchemaVersion: 1,
+			GeneratedAt:   "1970-01-01T00:00:00Z",
+			Listings: map[string]types.IntegrityListing{
+				"mod-a": {HasCompleteVersion: true, Versions: map[string]types.IntegrityVersionStatus{}},
+				"mod-b": {HasCompleteVersion: false, Versions: map[string]types.IntegrityVersionStatus{}},
+			},
+		},
+	))
+	require.NoError(t, files.WriteJSON(
+		filepath.Join(paths.RegistryRepoPath(), "maps", constants.INTEGRITY_JSON),
+		"maps integrity report",
+		types.RegistryIntegrityReport{
+			SchemaVersion: 1,
+			GeneratedAt:   "1970-01-01T00:00:00Z",
+			Listings: map[string]types.IntegrityListing{
+				"map-a": {HasCompleteVersion: true, Versions: map[string]types.IntegrityVersionStatus{}},
+				"map-b": {HasCompleteVersion: false, Versions: map[string]types.IntegrityVersionStatus{}},
 			},
 		},
 	))

--- a/railyard/internal/registry/installable_versions.go
+++ b/railyard/internal/registry/installable_versions.go
@@ -6,6 +6,7 @@ import (
 	"railyard/internal/types"
 )
 
+// getIntegrityListing returns the integrity entry for the requested asset.
 func (r *Registry) getIntegrityListing(assetType types.AssetType, assetID string) (types.IntegrityListing, bool) {
 	switch assetType {
 	case types.AssetTypeMod:
@@ -19,6 +20,7 @@ func (r *Registry) getIntegrityListing(assetType types.AssetType, assetID string
 	}
 }
 
+// resolveAssetUpdateSource resolves the raw update source for an asset manifest.
 func (r *Registry) resolveAssetUpdateSource(assetType types.AssetType, assetID string) (string, string, error) {
 	switch assetType {
 	case types.AssetTypeMod:
@@ -38,6 +40,7 @@ func (r *Registry) resolveAssetUpdateSource(assetType types.AssetType, assetID s
 	}
 }
 
+// filterVersionsByIntegrity keeps only versions marked complete in the integrity cache.
 func (r *Registry) filterVersionsByIntegrity(
 	assetType types.AssetType,
 	assetID string,
@@ -70,6 +73,7 @@ func (r *Registry) filterVersionsByIntegrity(
 	return filtered, nil
 }
 
+// GetInstallableVersions returns the integrity-approved versions for an asset.
 func (r *Registry) GetInstallableVersions(assetType types.AssetType, assetID string) ([]types.VersionInfo, error) {
 	updateType, source, err := r.resolveAssetUpdateSource(assetType, assetID)
 	if err != nil {
@@ -84,6 +88,7 @@ func (r *Registry) GetInstallableVersions(assetType types.AssetType, assetID str
 	return r.filterVersionsByIntegrity(assetType, assetID, versions)
 }
 
+// GetInstallableVersionsResponse returns installable versions with response metadata.
 func (r *Registry) GetInstallableVersionsResponse(assetType types.AssetType, assetID string) types.VersionsResponse {
 	versions, err := r.GetInstallableVersions(assetType, assetID)
 	if err != nil {

--- a/railyard/internal/registry/installable_versions.go
+++ b/railyard/internal/registry/installable_versions.go
@@ -26,21 +26,13 @@ func (r *Registry) resolveAssetUpdateSource(assetType types.AssetType, assetID s
 		if err != nil {
 			return "", "", err
 		}
-		source := manifest.Update.Source()
-		if source == "" {
-			return "", "", fmt.Errorf("mod %q has no update source configured", assetID)
-		}
-		return manifest.Update.Type, source, nil
+		return manifest.Update.Type, manifest.Update.Source(), nil
 	case types.AssetTypeMap:
 		manifest, err := r.GetMap(assetID)
 		if err != nil {
 			return "", "", err
 		}
-		source := manifest.Update.Source()
-		if source == "" {
-			return "", "", fmt.Errorf("map %q has no update source configured", assetID)
-		}
-		return manifest.Update.Type, source, nil
+		return manifest.Update.Type, manifest.Update.Source(), nil
 	default:
 		return "", "", fmt.Errorf("invalid asset type: %s", assetType)
 	}
@@ -67,12 +59,6 @@ func (r *Registry) filterVersionsByIntegrity(
 		if status.IsComplete {
 			allowedVersions[version] = struct{}{}
 		}
-	}
-
-	// Backward-compatible fallback for older integrity snapshots that declare
-	// completeness at the listing level but omit per-version data.
-	if len(allowedVersions) == 0 {
-		return cloneVersionInfos(versions), nil
 	}
 
 	filtered := make([]types.VersionInfo, 0, len(versions))

--- a/railyard/internal/registry/installable_versions.go
+++ b/railyard/internal/registry/installable_versions.go
@@ -1,0 +1,114 @@
+package registry
+
+import (
+	"fmt"
+
+	"railyard/internal/types"
+)
+
+func (r *Registry) getIntegrityListing(assetType types.AssetType, assetID string) (types.IntegrityListing, bool) {
+	switch assetType {
+	case types.AssetTypeMod:
+		listing, ok := r.integrityMods.Listings[assetID]
+		return listing, ok
+	case types.AssetTypeMap:
+		listing, ok := r.integrityMaps.Listings[assetID]
+		return listing, ok
+	default:
+		return types.IntegrityListing{}, false
+	}
+}
+
+func (r *Registry) resolveAssetUpdateSource(assetType types.AssetType, assetID string) (string, string, error) {
+	switch assetType {
+	case types.AssetTypeMod:
+		manifest, err := r.GetMod(assetID)
+		if err != nil {
+			return "", "", err
+		}
+		source := manifest.Update.Source()
+		if source == "" {
+			return "", "", fmt.Errorf("mod %q has no update source configured", assetID)
+		}
+		return manifest.Update.Type, source, nil
+	case types.AssetTypeMap:
+		manifest, err := r.GetMap(assetID)
+		if err != nil {
+			return "", "", err
+		}
+		source := manifest.Update.Source()
+		if source == "" {
+			return "", "", fmt.Errorf("map %q has no update source configured", assetID)
+		}
+		return manifest.Update.Type, source, nil
+	default:
+		return "", "", fmt.Errorf("invalid asset type: %s", assetType)
+	}
+}
+
+func (r *Registry) filterVersionsByIntegrity(
+	assetType types.AssetType,
+	assetID string,
+	versions []types.VersionInfo,
+) ([]types.VersionInfo, error) {
+	listing, ok := r.getIntegrityListing(assetType, assetID)
+	if !ok {
+		return nil, fmt.Errorf("%s %q is missing from integrity cache", assetType, assetID)
+	}
+	if !listing.HasCompleteVersion {
+		return nil, fmt.Errorf("%s %q has no complete versions in integrity cache", assetType, assetID)
+	}
+
+	allowedVersions := make(map[string]struct{}, len(listing.CompleteVersions)+len(listing.Versions))
+	for _, version := range listing.CompleteVersions {
+		allowedVersions[version] = struct{}{}
+	}
+	for version, status := range listing.Versions {
+		if status.IsComplete {
+			allowedVersions[version] = struct{}{}
+		}
+	}
+
+	// Backward-compatible fallback for older integrity snapshots that declare
+	// completeness at the listing level but omit per-version data.
+	if len(allowedVersions) == 0 {
+		return cloneVersionInfos(versions), nil
+	}
+
+	filtered := make([]types.VersionInfo, 0, len(versions))
+	for _, version := range versions {
+		if _, ok := allowedVersions[version.Version]; ok {
+			filtered = append(filtered, version)
+		}
+	}
+	return filtered, nil
+}
+
+func (r *Registry) GetInstallableVersions(assetType types.AssetType, assetID string) ([]types.VersionInfo, error) {
+	updateType, source, err := r.resolveAssetUpdateSource(assetType, assetID)
+	if err != nil {
+		return nil, err
+	}
+
+	versions, err := r.GetVersions(updateType, source)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.filterVersionsByIntegrity(assetType, assetID, versions)
+}
+
+func (r *Registry) GetInstallableVersionsResponse(assetType types.AssetType, assetID string) types.VersionsResponse {
+	versions, err := r.GetInstallableVersions(assetType, assetID)
+	if err != nil {
+		return types.VersionsResponse{
+			GenericResponse: types.ErrorResponse(err.Error()),
+			Versions:        []types.VersionInfo{},
+		}
+	}
+
+	return types.VersionsResponse{
+		GenericResponse: types.SuccessResponse("Installable versions loaded"),
+		Versions:        versions,
+	}
+}

--- a/railyard/internal/registry/integrity_test.go
+++ b/railyard/internal/registry/integrity_test.go
@@ -1,0 +1,94 @@
+package registry
+
+import (
+	"testing"
+
+	"railyard/internal/config"
+	"railyard/internal/testutil"
+	"railyard/internal/testutil/registrytest"
+	"railyard/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInstallableVersions(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	registrytest.SetManifestsForTest(t, reg, nil, []types.MapManifest{
+		func() types.MapManifest {
+			manifest := registrytest.MockMapManifestWithIDAndCode("map-a", "AAA")
+			manifest.Update = types.UpdateConfig{
+				Type: "custom",
+				URL:  "https://example.com/update.json",
+			}
+			return manifest
+		}(),
+	})
+	reg.integrityMaps = types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings: map[string]types.IntegrityListing{
+			"map-a": {
+				HasCompleteVersion: true,
+				CompleteVersions:   []string{"1.0.0", "1.1.0"},
+				Versions: map[string]types.IntegrityVersionStatus{
+					"1.0.0": {IsComplete: true},
+					"1.1.0": {IsComplete: true},
+					"2.0.0": {IsComplete: false},
+				},
+			},
+		},
+	}
+
+	reg.setCachedVersions("custom|https://example.com/update.json", []types.VersionInfo{
+		{Version: "2.0.0"},
+		{Version: "1.1.0"},
+		{Version: "1.0.0"},
+	})
+
+	filtered, err := reg.GetInstallableVersions(types.AssetTypeMap, "map-a")
+	require.NoError(t, err)
+	require.Len(t, filtered, 2)
+	require.Equal(t, "1.1.0", filtered[0].Version)
+	require.Equal(t, "1.0.0", filtered[1].Version)
+}
+
+func TestGetInstallableVersionsRejectsMissingOrIncompleteListings(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	registrytest.SetManifestsForTest(t, reg, nil, []types.MapManifest{
+		func() types.MapManifest {
+			manifest := registrytest.MockMapManifestWithIDAndCode("missing-map", "BBB")
+			manifest.Update = types.UpdateConfig{
+				Type: "custom",
+				URL:  "https://example.com/missing-update.json",
+			}
+			return manifest
+		}(),
+		func() types.MapManifest {
+			manifest := registrytest.MockMapManifestWithIDAndCode("map-a", "AAA")
+			manifest.Update = types.UpdateConfig{
+				Type: "custom",
+				URL:  "https://example.com/update.json",
+			}
+			return manifest
+		}(),
+	})
+	reg.setCachedVersions("custom|https://example.com/missing-update.json", []types.VersionInfo{
+		{Version: "1.0.0"},
+	})
+	reg.setCachedVersions("custom|https://example.com/update.json", []types.VersionInfo{
+		{Version: "1.0.0"},
+	})
+	reg.integrityMaps = types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings: map[string]types.IntegrityListing{
+			"map-a": {HasCompleteVersion: false},
+		},
+	}
+
+	_, err := reg.GetInstallableVersions(types.AssetTypeMap, "missing-map")
+	require.ErrorContains(t, err, "missing from integrity cache")
+
+	_, err = reg.GetInstallableVersions(types.AssetTypeMap, "map-a")
+	require.ErrorContains(t, err, "has no complete versions")
+}

--- a/railyard/internal/registry/last_updated.go
+++ b/railyard/internal/registry/last_updated.go
@@ -12,9 +12,9 @@ import (
 const lastUpdatedWorkerLimit = 6
 
 type lastUpdatedArgs struct {
+	assetType  types.AssetType
 	id         string
 	updateType string
-	source     string
 }
 
 func (r *Registry) loadLastUpdated(
@@ -31,13 +31,15 @@ func (r *Registry) loadLastUpdated(
 
 	mapSources := getLastUpdatedArgs(
 		maps,
+		func(manifest types.MapManifest) types.AssetType { return types.AssetTypeMap },
 		func(manifest types.MapManifest) string { return manifest.ID },
-		func(manifest types.MapManifest) types.UpdateConfig { return manifest.Update },
+		func(manifest types.MapManifest) string { return manifest.Update.Type },
 	)
 	modSources := getLastUpdatedArgs(
 		mods,
+		func(manifest types.ModManifest) types.AssetType { return types.AssetTypeMod },
 		func(manifest types.ModManifest) string { return manifest.ID },
-		func(manifest types.ModManifest) types.UpdateConfig { return manifest.Update },
+		func(manifest types.ModManifest) string { return manifest.Update.Type },
 	)
 
 	mapEntries, mapWarnings := r.resolveLastUpdated(mapSources)
@@ -101,9 +103,9 @@ func (r *Registry) resolveLastUpdated(
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			versions, err := r.GetVersions(current.updateType, current.source)
+			versions, err := r.GetInstallableVersions(current.assetType, current.id)
 			if err != nil {
-				r.logger.Warn("Failed to fetch versions for last updated", "asset_id", current.id, "update_type", current.updateType, "source", current.source, "error", err)
+				r.logger.Warn("Failed to fetch installable versions for last updated", "asset_type", current.assetType, "asset_id", current.id, "error", err)
 				mu.Lock()
 				warnings = append(warnings, fmt.Errorf("failed to fetch versions for %q: %w", current.id, err))
 				results[current.id] = 0 // Default to epoch start if we can't fetch version
@@ -131,23 +133,19 @@ func (r *Registry) resolveLastUpdated(
 	return results, warnings
 }
 
-// getLastUpdatedArgs retrieves the Source and UpdateType for a list of manifests, converting each into the lastUpdatedArgs function input struct.
+// getLastUpdatedArgs converts manifests into the asset identifiers needed for installable version lookups.
 func getLastUpdatedArgs[T any](
 	manifests []T,
+	assetTypeFn func(manifest T) types.AssetType,
 	idFn func(manifest T) string,
-	updateFn func(manifest T) types.UpdateConfig,
+	updateTypeFn func(manifest T) string,
 ) []lastUpdatedArgs {
 	sources := make([]lastUpdatedArgs, 0, len(manifests))
 	for _, manifest := range manifests {
-		id := idFn(manifest)
-		update := updateFn(manifest)
-		updateType := update.Type
-		source := update.Source()
-
 		sources = append(sources, lastUpdatedArgs{
-			id:         id,
-			updateType: updateType,
-			source:     source,
+			assetType:  assetTypeFn(manifest),
+			id:         idFn(manifest),
+			updateType: updateTypeFn(manifest),
 		})
 	}
 	return sources

--- a/railyard/internal/registry/last_updated.go
+++ b/railyard/internal/registry/last_updated.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -115,10 +116,19 @@ func (r *Registry) resolveLastUpdated(
 
 			latest, err := determineLatestTimestamp(r.logger, versions, current.updateType)
 			if err != nil {
-				r.logger.Warn("Failed to parse version dates for last updated", "asset_id", current.id, "version_count", len(versions), "error", err)
+				fallback, fallbackErr := r.latestIntegrityCheckedAt(current.assetType, current.id)
+				if fallbackErr != nil {
+					r.logger.Warn("Failed to parse version dates for last updated", "asset_id", current.id, "version_count", len(versions), "error", err)
+					mu.Lock()
+					warnings = append(warnings, fmt.Errorf("failed to resolve latest update for %q: %w", current.id, errors.Join(err, fallbackErr)))
+					results[current.id] = 0 // Default to epoch start if we can't parse version dates
+					mu.Unlock()
+					return
+				}
+
+				r.logger.Warn("Falling back to integrity checked_at for last updated", "asset_type", current.assetType, "asset_id", current.id, "error", err, "timestamp", fallback)
 				mu.Lock()
-				warnings = append(warnings, fmt.Errorf("failed to resolve latest update for %q: %w", current.id, err))
-				results[current.id] = 0 // Default to epoch start if we can't parse version dates
+				results[current.id] = fallback
 				mu.Unlock()
 				return
 			}
@@ -131,6 +141,35 @@ func (r *Registry) resolveLastUpdated(
 
 	wg.Wait()
 	return results, warnings
+}
+
+// latestIntegrityCheckedAt returns the latest complete-version checked_at timestamp for an asset.
+func (r *Registry) latestIntegrityCheckedAt(assetType types.AssetType, assetID string) (int64, error) {
+	listing, _ := r.getIntegrityListing(assetType, assetID)
+
+	best := int64(0)
+	for version, status := range listing.Versions {
+		if !status.IsComplete {
+			continue
+		}
+		if status.CheckedAt == "" {
+			return 0, fmt.Errorf("%s %q version %q is missing checked_at", assetType, assetID, version)
+		}
+		parsed, err := time.Parse(time.RFC3339, status.CheckedAt)
+		if err != nil {
+			return 0, fmt.Errorf("%s %q version %q has invalid checked_at %q: %w", assetType, assetID, version, status.CheckedAt, err)
+		}
+		timestamp := parsed.Unix()
+		if timestamp > best {
+			best = timestamp
+		}
+	}
+
+	if best == 0 {
+		return 0, fmt.Errorf("%s %q has no complete versions with checked_at", assetType, assetID)
+	}
+
+	return best, nil
 }
 
 // getLastUpdatedArgs converts manifests into the asset identifiers needed for installable version lookups.

--- a/railyard/internal/registry/last_updated_test.go
+++ b/railyard/internal/registry/last_updated_test.go
@@ -112,3 +112,31 @@ func TestLoadLastUpdatedFallsBackToEpochOnFailures(t *testing.T) {
 	require.Equal(t, int64(0), modLastUpdated["mod-bad"])
 	require.Equal(t, int64(0), mapLastUpdated["map-bad"])
 }
+
+func TestLoadLastUpdatedFallsBackToIntegrityCheckedAtWhenVersionDatesDoNotParse(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	reg.SetContext(context.WithValue(context.Background(), "test", "true"))
+	closeServer := registrytest.MockLastUpdatedServer(t, reg, []registrytest.LastUpdatedFixture{
+		{
+			AssetID:   "map-a",
+			AssetType: types.AssetTypeMap,
+			Path:      "/updates/map-a.json",
+			Versions: []types.CustomUpdateVersion{
+				{Version: "1.0.0", Date: "2026-04-14T00:00:00Z"},
+			},
+			Status: http.StatusOK,
+		},
+	})
+	defer closeServer()
+
+	integrity := reg.integrityMaps
+	listing := integrity.Listings["map-a"]
+	status := listing.Versions["1.0.0"]
+	status.CheckedAt = "2026-04-15T03:51:46Z"
+	listing.Versions["1.0.0"] = status
+	integrity.Listings["map-a"] = listing
+	reg.integrityMaps = integrity
+
+	_, mapLastUpdated := reg.loadLastUpdated(reg.mods, reg.maps)
+	require.Equal(t, mustUnix(t, "2026-04-15T03:51:46Z"), mapLastUpdated["map-a"])
+}

--- a/railyard/internal/registry/manifests.go
+++ b/railyard/internal/registry/manifests.go
@@ -170,8 +170,14 @@ func filterManifestsByIntegrity[T any](
 	filtered := make([]T, 0, len(manifests))
 	for _, manifest := range manifests {
 		assetID := idFn(manifest)
-		if _, ok := listings[assetID]; !ok {
+		listing, ok := listings[assetID]
+		if !ok {
 			logger.Warn("Skipping manifest missing integrity listing", "asset_type", assetType, "asset_id", assetID)
+			continue
+		}
+		// Only manifests that are listed as complete are valid and should be displayed to the user
+		if !listing.HasCompleteVersion {
+			logger.Warn("Skipping manifest without any complete integrity versions", "asset_type", assetType, "asset_id", assetID)
 			continue
 		}
 		filtered = append(filtered, manifest)

--- a/railyard/internal/registry/manifests.go
+++ b/railyard/internal/registry/manifests.go
@@ -70,6 +70,13 @@ func (r *Registry) fetchFromDisk() error {
 		r.logger,
 	)
 
+	// Populate the in-memory registry view before deriving last_updated so
+	// installable version lookups can resolve manifests and integrity entries.
+	r.mods = mods
+	r.maps = maps
+	r.integrityMaps = mapIntegrity
+	r.integrityMods = modIntegrity
+
 	modLastUpdated, mapLastUpdated := r.loadLastUpdated(mods, maps)
 	updateManifestLastUpdated(mods, maps, modLastUpdated, mapLastUpdated)
 

--- a/railyard/internal/testutil/registrytest/registry_fixture.go
+++ b/railyard/internal/testutil/registrytest/registry_fixture.go
@@ -174,11 +174,12 @@ func WriteFixture(t *testing.T, fixture RepositoryFixture) {
 
 func buildIntegrityReport(ids []string) types.RegistryIntegrityReport {
 	listings := make(map[string]types.IntegrityListing, len(ids))
+	hasComplete := true
 	for _, id := range ids {
 		listings[id] = types.IntegrityListing{
-			HasCompleteVersion:   false,
+			HasCompleteVersion:   true,
 			LatestSemverVersion:  nil,
-			LatestSemverComplete: nil,
+			LatestSemverComplete: &hasComplete,
 			CompleteVersions:     []string{},
 			IncompleteVersions:   []string{},
 			Versions:             map[string]types.IntegrityVersionStatus{},
@@ -206,4 +207,16 @@ func SetManifestsForTest(t *testing.T, registryValue any, mods []types.ModManife
 	t.Helper()
 	SetUnexportedField(t, registryValue, "mods", mods)
 	SetUnexportedField(t, registryValue, "maps", maps)
+
+	modIDs := make([]string, 0, len(mods))
+	for _, mod := range mods {
+		modIDs = append(modIDs, mod.ID)
+	}
+	mapIDs := make([]string, 0, len(maps))
+	for _, item := range maps {
+		mapIDs = append(mapIDs, item.ID)
+	}
+
+	SetUnexportedField(t, registryValue, "integrityMods", buildIntegrityReport(modIDs))
+	SetUnexportedField(t, registryValue, "integrityMaps", buildIntegrityReport(mapIDs))
 }

--- a/railyard/internal/testutil/registrytest/registry_last_updated_mock.go
+++ b/railyard/internal/testutil/registrytest/registry_last_updated_mock.go
@@ -27,6 +27,8 @@ func MockLastUpdatedServer(t *testing.T, reg any, fixtures []LastUpdatedFixture)
 	mux := http.NewServeMux()
 	mods := make([]types.ModManifest, 0)
 	maps := make([]types.MapManifest, 0)
+	modListings := make(map[string]types.IntegrityListing)
+	mapListings := make(map[string]types.IntegrityListing)
 
 	for _, fixture := range fixtures {
 		current := fixture
@@ -52,6 +54,17 @@ func MockLastUpdatedServer(t *testing.T, reg any, fixtures []LastUpdatedFixture)
 			Type: "custom",
 			URL:  server.URL + fixture.Path,
 		}
+		completeVersions := make([]string, 0, len(fixture.Versions))
+		versionStatuses := make(map[string]types.IntegrityVersionStatus, len(fixture.Versions))
+		for _, version := range fixture.Versions {
+			completeVersions = append(completeVersions, version.Version)
+			versionStatuses[version.Version] = types.IntegrityVersionStatus{IsComplete: true}
+		}
+		listing := types.IntegrityListing{
+			HasCompleteVersion: true,
+			CompleteVersions:   completeVersions,
+			Versions:           versionStatuses,
+		}
 		switch fixture.AssetType {
 		case types.AssetTypeMap:
 			maps = append(maps, types.MapManifest{
@@ -60,6 +73,7 @@ func MockLastUpdatedServer(t *testing.T, reg any, fixtures []LastUpdatedFixture)
 					Update: update,
 				},
 			})
+			mapListings[fixture.AssetID] = listing
 		case types.AssetTypeMod:
 			mods = append(mods, types.ModManifest{
 				AssetManifest: types.AssetManifest{
@@ -67,10 +81,21 @@ func MockLastUpdatedServer(t *testing.T, reg any, fixtures []LastUpdatedFixture)
 					Update: update,
 				},
 			})
+			modListings[fixture.AssetID] = listing
 		}
 	}
 
 	SetUnexportedField(t, reg, "httpClient", server.Client())
 	SetManifestsForTest(t, reg, mods, maps)
+	SetUnexportedField(t, reg, "integrityMods", types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings:      modListings,
+	})
+	SetUnexportedField(t, reg, "integrityMaps", types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings:      mapListings,
+	})
 	return server.Close
 }

--- a/railyard/internal/testutil/registrytest/registry_mock_server.go
+++ b/railyard/internal/testutil/registrytest/registry_mock_server.go
@@ -94,6 +94,8 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 	zipByDownloadPath := map[string][]byte{}
 	mods := []types.ModManifest{}
 	maps := []types.MapManifest{}
+	modIntegrityListings := map[string]types.IntegrityListing{}
+	mapIntegrityListings := map[string]types.IntegrityListing{}
 	handler := http.NewServeMux()
 
 	for _, fixture := range fixtures {
@@ -118,6 +120,7 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 				},
 				CityCode: mapCode,
 			})
+			mapIntegrityListings[current.AssetID] = integrityListingFromFixture(current)
 		} else {
 			mods = append(mods, types.ModManifest{
 				AssetManifest: types.AssetManifest{
@@ -125,6 +128,7 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 					Update: types.UpdateConfig{Type: "custom", URL: "{{BASE_URL}}" + updatePath},
 				},
 			})
+			modIntegrityListings[current.AssetID] = integrityListingFromFixture(current)
 		}
 
 		handler.HandleFunc(updatePath, func(w http.ResponseWriter, r *http.Request) {
@@ -191,5 +195,34 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 	}
 
 	SetManifestsForTest(t, reg, mods, maps)
+	SetUnexportedField(t, reg, "integrityMods", types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings:      modIntegrityListings,
+	})
+	SetUnexportedField(t, reg, "integrityMaps", types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings:      mapIntegrityListings,
+	})
 	return server.Close
+}
+
+func integrityListingFromFixture(fixture UpdateFixture) types.IntegrityListing {
+	hasComplete := len(fixture.Versions) > 0 && !fixture.FailVersions
+	latestComplete := hasComplete
+	completeVersions := append([]string{}, fixture.Versions...)
+	versions := make(map[string]types.IntegrityVersionStatus, len(fixture.Versions))
+	for _, version := range fixture.Versions {
+		versions[version] = types.IntegrityVersionStatus{IsComplete: hasComplete}
+	}
+
+	return types.IntegrityListing{
+		HasCompleteVersion:   hasComplete,
+		LatestSemverVersion:  nil,
+		LatestSemverComplete: &latestComplete,
+		CompleteVersions:     completeVersions,
+		IncompleteVersions:   []string{},
+		Versions:             versions,
+	}
 }


### PR DESCRIPTION
As stated in title.

Currently the full integrity completeness check contract differed between frontend (required is_complete) vs. backend (required integrity cache entry available (no completeness check)

This lead to a bug wherein a map that was recently uploaded could be downloadable/discoverable from the FE buttons (namely install) that were not gated by the separate completeness check

The other change here is on time precision. Custom JSON entries report time in `YYYY-MM-DD` which when localized could become dates in the future for some users.

For consistency, this PR makes all entries use UTC/Zulu time.

<img width="1878" height="560" alt="image" src="https://github.com/user-attachments/assets/83a44842-fb0d-4c10-8acf-bdcfe03ac0cf" />
Full Timestamp only shown in version page
<img width="1842" height="459" alt="image" src="https://github.com/user-attachments/assets/08073260-be8d-47cc-b502-59c6432cb087" />
Others still calendar (UTC) dates