### PR TITLE
[Frontend] Address Search Lag

### DIFF
--- a/packages/asset-listings-state/src/filter-and-sort.ts
+++ b/packages/asset-listings-state/src/filter-and-sort.ts
@@ -60,6 +60,7 @@ export function buildAssetSearchText<TItem extends AssetSearchable>(
   return values.filter(Boolean).join(' ');
 }
 
+// Cache lowercased search text per tagged item to avoid rebuilding it on each query.
 function getNormalizedSearchText<TTaggedItem extends TaggedListingItem>(
   item: TTaggedItem,
   buildSearchText: (item: TTaggedItem) => string,
@@ -74,6 +75,7 @@ function getNormalizedSearchText<TTaggedItem extends TaggedListingItem>(
   return normalized;
 }
 
+// Prefer a cheap token-inclusion match before falling back to fuzzy search.
 function filterByQueryFastPath<TTaggedItem extends TaggedListingItem>(
   items: TTaggedItem[],
   query: string,

--- a/packages/asset-listings-state/src/filter-and-sort.ts
+++ b/packages/asset-listings-state/src/filter-and-sort.ts
@@ -14,6 +14,8 @@ type SearchableItem<TItem> = {
   searchText: string;
 };
 
+const normalizedSearchTextCache = new WeakMap<object, string>();
+
 export interface TaggedListingItem<TItem = { id: string }> {
   type: AssetType;
   item: TItem;
@@ -56,6 +58,40 @@ export function buildAssetSearchText<TItem extends AssetSearchable>(
   }
 
   return values.filter(Boolean).join(' ');
+}
+
+function getNormalizedSearchText<TTaggedItem extends TaggedListingItem>(
+  item: TTaggedItem,
+  buildSearchText: (item: TTaggedItem) => string,
+): string {
+  const cached = normalizedSearchTextCache.get(item as object);
+  if (cached) {
+    return cached;
+  }
+
+  const normalized = buildSearchText(item).toLowerCase();
+  normalizedSearchTextCache.set(item as object, normalized);
+  return normalized;
+}
+
+function filterByQueryFastPath<TTaggedItem extends TaggedListingItem>(
+  items: TTaggedItem[],
+  query: string,
+  buildSearchText: (item: TTaggedItem) => string,
+): TTaggedItem[] {
+  const normalizedTerms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (normalizedTerms.length === 0) {
+    return items;
+  }
+
+  return items.filter((item) => {
+    const searchText = getNormalizedSearchText(item, buildSearchText);
+    return normalizedTerms.every((term) => searchText.includes(term));
+  });
 }
 
 export interface TaggedListingFilterState<TMapFilters, TSortState = SortState> {
@@ -217,16 +253,25 @@ function filterTaggedItems<
 
   const query = filters.query.trim();
   if (query) {
-    const searchable: SearchableItem<TTaggedItem>[] = result.map((entry) => ({
-      entry,
-      searchText: accessors.buildSearchText(entry),
-    }));
-
-    const fuse = new Fuse(
-      searchable,
-      fuseOptions ?? ASSET_LISTING_FUSE_SEARCH_OPTIONS,
+    const fastMatches = filterByQueryFastPath(
+      result,
+      query,
+      accessors.buildSearchText,
     );
-    result = fuse.search(query).map(({ item }) => item.entry);
+    if (fastMatches.length > 0) {
+      result = fastMatches;
+    } else {
+      const searchable: SearchableItem<TTaggedItem>[] = result.map((entry) => ({
+        entry,
+        searchText: accessors.buildSearchText(entry),
+      }));
+
+      const fuse = new Fuse(
+        searchable,
+        fuseOptions ?? ASSET_LISTING_FUSE_SEARCH_OPTIONS,
+      );
+      result = fuse.search(query).map(({ item }) => item.entry);
+    }
   }
 
   return result;

--- a/packages/asset-listings-ui/src/components/gallery-image.tsx
+++ b/packages/asset-listings-ui/src/components/gallery-image.tsx
@@ -88,5 +88,13 @@ export function GalleryImage({
     );
   }
 
-  return <img src={imageUrl} alt="" className={cn('w-full object-cover', className)} />;
+  return (
+    <img
+      src={imageUrl}
+      alt=""
+      loading="lazy"
+      decoding="async"
+      className={cn('w-full object-cover', className)}
+    />
+  );
 }

--- a/packages/asset-listings-ui/src/components/item-card.tsx
+++ b/packages/asset-listings-ui/src/components/item-card.tsx
@@ -625,7 +625,11 @@ export const ItemCard = memo(function ItemCard({
               showDownloads={presentation.showDownloads}
               totalDownloads={totalDownloads}
             />
-            <ItemBadges badges={presentation.badges} maxWidthPercentage={0.65} />
+            <ItemBadges
+              badges={presentation.badges}
+              fixedVisibleCount={3}
+              maxWidthPercentage={0.65}
+            />
           </div>
         </div>
       </article>

--- a/packages/asset-listings-ui/src/components/search-bar.tsx
+++ b/packages/asset-listings-ui/src/components/search-bar.tsx
@@ -7,6 +7,7 @@ export interface SearchBarProps {
   onQueryChange: (query: string) => void;
   placeholder?: string;
   ariaLabel?: string;
+  debounceMs?: number;
 }
 
 const DEFAULT_PLACEHOLDER = 'Search';
@@ -17,6 +18,7 @@ export function SearchBar({
   onQueryChange,
   placeholder = DEFAULT_PLACEHOLDER,
   ariaLabel = DEFAULT_ARIA_LABEL,
+  debounceMs = 0,
 }: SearchBarProps) {
   const [draftQuery, setDraftQuery] = useState(query);
 
@@ -24,12 +26,24 @@ export function SearchBar({
     setDraftQuery(query);
   }, [query]);
 
-  const handleQueryChange = (nextQuery: string) => {
-    setDraftQuery(nextQuery);
-    startTransition(() => {
-      onQueryChange(nextQuery);
-    });
-  };
+  useEffect(() => {
+    if (draftQuery === query) return;
+
+    if (debounceMs <= 0) {
+      startTransition(() => {
+        onQueryChange(draftQuery);
+      });
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      startTransition(() => {
+        onQueryChange(draftQuery);
+      });
+    }, debounceMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [debounceMs, draftQuery, onQueryChange, query]);
 
   return (
     <div className="relative group">
@@ -37,7 +51,7 @@ export function SearchBar({
       <input
         placeholder={placeholder}
         value={draftQuery}
-        onChange={(e) => handleQueryChange(e.target.value)}
+        onChange={(e) => setDraftQuery(e.target.value)}
         aria-label={ariaLabel}
         className="h-11 w-full rounded-xl border border-border bg-card pl-11 pr-11 text-sm text-foreground shadow-xs placeholder:text-muted-foreground transition-[border-color,box-shadow] outline-none focus:border-ring focus:ring-[3px] focus:ring-ring/25 dark:bg-input/30"
       />
@@ -46,7 +60,12 @@ export function SearchBar({
           variant="ghost"
           size="icon"
           className="absolute right-1.5 top-1/2 -translate-y-1/2 h-8 w-8 text-muted-foreground hover:text-foreground"
-          onClick={() => handleQueryChange('')}
+          onClick={() => {
+            setDraftQuery('');
+            startTransition(() => {
+              onQueryChange('');
+            });
+          }}
           aria-label="Clear search"
         >
           <X className="h-3.5 w-3.5" />

--- a/packages/asset-listings-ui/src/components/search-bar.tsx
+++ b/packages/asset-listings-ui/src/components/search-bar.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@subway-builder-modded/shared-ui';
 import { Search, X } from 'lucide-react';
+import { startTransition, useEffect, useState } from 'react';
 
 export interface SearchBarProps {
   query: string;
@@ -17,22 +18,35 @@ export function SearchBar({
   placeholder = DEFAULT_PLACEHOLDER,
   ariaLabel = DEFAULT_ARIA_LABEL,
 }: SearchBarProps) {
+  const [draftQuery, setDraftQuery] = useState(query);
+
+  useEffect(() => {
+    setDraftQuery(query);
+  }, [query]);
+
+  const handleQueryChange = (nextQuery: string) => {
+    setDraftQuery(nextQuery);
+    startTransition(() => {
+      onQueryChange(nextQuery);
+    });
+  };
+
   return (
     <div className="relative group">
       <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none transition-colors group-focus-within:text-primary" />
       <input
         placeholder={placeholder}
-        value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
+        value={draftQuery}
+        onChange={(e) => handleQueryChange(e.target.value)}
         aria-label={ariaLabel}
         className="h-11 w-full rounded-xl border border-border bg-card pl-11 pr-11 text-sm text-foreground shadow-xs placeholder:text-muted-foreground transition-[border-color,box-shadow] outline-none focus:border-ring focus:ring-[3px] focus:ring-ring/25 dark:bg-input/30"
       />
-      {query && (
+      {draftQuery && (
         <Button
           variant="ghost"
           size="icon"
           className="absolute right-1.5 top-1/2 -translate-y-1/2 h-8 w-8 text-muted-foreground hover:text-foreground"
-          onClick={() => onQueryChange('')}
+          onClick={() => handleQueryChange('')}
           aria-label="Clear search"
         >
           <X className="h-3.5 w-3.5" />

--- a/packages/asset-listings-ui/src/components/search-bar.tsx
+++ b/packages/asset-listings-ui/src/components/search-bar.tsx
@@ -20,48 +20,48 @@ export function SearchBar({
   ariaLabel = DEFAULT_ARIA_LABEL,
   debounceMs = 0,
 }: SearchBarProps) {
-  const [draftQuery, setDraftQuery] = useState(query);
+  const [pendingQuery, setPendingQuery] = useState(query);
 
   useEffect(() => {
-    setDraftQuery(query);
+    setPendingQuery(query);
   }, [query]);
 
   useEffect(() => {
-    if (draftQuery === query) return;
+    if (pendingQuery === query) return;
 
     if (debounceMs <= 0) {
       startTransition(() => {
-        onQueryChange(draftQuery);
+        onQueryChange(pendingQuery);
       });
       return;
     }
 
     const timeoutId = window.setTimeout(() => {
       startTransition(() => {
-        onQueryChange(draftQuery);
+        onQueryChange(pendingQuery);
       });
     }, debounceMs);
 
     return () => window.clearTimeout(timeoutId);
-  }, [debounceMs, draftQuery, onQueryChange, query]);
+  }, [debounceMs, onQueryChange, pendingQuery, query]);
 
   return (
     <div className="relative group">
       <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none transition-colors group-focus-within:text-primary" />
       <input
         placeholder={placeholder}
-        value={draftQuery}
-        onChange={(e) => setDraftQuery(e.target.value)}
+        value={pendingQuery}
+        onChange={(e) => setPendingQuery(e.target.value)}
         aria-label={ariaLabel}
         className="h-11 w-full rounded-xl border border-border bg-card pl-11 pr-11 text-sm text-foreground shadow-xs placeholder:text-muted-foreground transition-[border-color,box-shadow] outline-none focus:border-ring focus:ring-[3px] focus:ring-ring/25 dark:bg-input/30"
       />
-      {draftQuery && (
+      {pendingQuery && (
         <Button
           variant="ghost"
           size="icon"
           className="absolute right-1.5 top-1/2 -translate-y-1/2 h-8 w-8 text-muted-foreground hover:text-foreground"
           onClick={() => {
-            setDraftQuery('');
+            setPendingQuery('');
             startTransition(() => {
               onQueryChange('');
             });

--- a/railyard/frontend/src/hooks/use-filtered-installed-items.ts
+++ b/railyard/frontend/src/hooks/use-filtered-installed-items.ts
@@ -54,6 +54,11 @@ export function useFilteredInstalledItems({
     () => createTaggedListingAccessors<InstalledTaggedItem>(),
     [],
   );
+  const countFilters = useMemo(
+    () =>
+      filters.query ? { ...filters, query: '' } : filters,
+    [filters],
+  );
 
   usePaginationSync({ defaultPerPage, filters, setFilters, setPage });
 
@@ -61,10 +66,10 @@ export function useFilteredInstalledItems({
     () =>
       buildDimensionCounts({
         items,
-        filters: filters as TaggedItemFilterState,
+        filters: countFilters as TaggedItemFilterState,
         accessors,
       }),
-    [accessors, filters, items],
+    [accessors, countFilters, items],
   );
 
   const filtered = useMemo(() => {

--- a/railyard/frontend/src/hooks/use-filtered-installed-items.ts
+++ b/railyard/frontend/src/hooks/use-filtered-installed-items.ts
@@ -55,8 +55,7 @@ export function useFilteredInstalledItems({
     [],
   );
   const countFilters = useMemo(
-    () =>
-      filters.query ? { ...filters, query: '' } : filters,
+    () => (filters.query ? { ...filters, query: '' } : filters),
     [filters],
   );
 

--- a/railyard/frontend/src/hooks/use-filtered-items.ts
+++ b/railyard/frontend/src/hooks/use-filtered-items.ts
@@ -3,7 +3,7 @@ import {
   type SourceAssetQueryFilterState,
 } from '@subway-builder-modded/asset-listings-state';
 import { type PerPage } from '@subway-builder-modded/config';
-import { useMemo } from 'react';
+import { useDeferredValue, useMemo } from 'react';
 
 import { usePaginationSync } from '@/hooks/use-pagination-sync';
 import {
@@ -62,10 +62,23 @@ export function useFilteredItems({
     () => createTaggedListingAccessors<TaggedItem>(),
     [],
   );
+  const deferredQuery = useDeferredValue(filters.query);
+  const deferredFilters = useMemo(
+    () =>
+      deferredQuery === filters.query
+        ? filters
+        : { ...filters, query: deferredQuery },
+    [deferredQuery, filters],
+  );
 
   const dimCounts = useMemo(
-    () => buildDimensionCounts({ items: allItems, filters, accessors }),
-    [accessors, allItems, filters],
+    () =>
+      buildDimensionCounts({
+        items: allItems,
+        filters: deferredFilters,
+        accessors,
+      }),
+    [accessors, allItems, deferredFilters],
   );
 
   const filteredPage = useMemo(
@@ -73,13 +86,20 @@ export function useFilteredItems({
       filterAndPaginateTaggedItems({
         items: allItems,
         page,
-        filters,
+        filters: deferredFilters,
         modDownloadTotals,
         mapDownloadTotals,
         compareItems,
         accessors,
       }),
-    [accessors, allItems, filters, mapDownloadTotals, modDownloadTotals, page],
+    [
+      accessors,
+      allItems,
+      deferredFilters,
+      mapDownloadTotals,
+      modDownloadTotals,
+      page,
+    ],
   );
 
   return {

--- a/railyard/frontend/src/hooks/use-filtered-items.ts
+++ b/railyard/frontend/src/hooks/use-filtered-items.ts
@@ -70,15 +70,22 @@ export function useFilteredItems({
         : { ...filters, query: deferredQuery },
     [deferredQuery, filters],
   );
+  const countFilters = useMemo(
+    () =>
+      deferredFilters.query
+        ? { ...deferredFilters, query: '' }
+        : deferredFilters,
+    [deferredFilters],
+  );
 
   const dimCounts = useMemo(
     () =>
       buildDimensionCounts({
         items: allItems,
-        filters: deferredFilters,
+        filters: countFilters,
         accessors,
       }),
-    [accessors, allItems, deferredFilters],
+    [accessors, allItems, countFilters],
   );
 
   const filteredPage = useMemo(

--- a/railyard/frontend/src/hooks/use-gallery-image.ts
+++ b/railyard/frontend/src/hooks/use-gallery-image.ts
@@ -18,16 +18,6 @@ function getCacheKey(type: AssetType, id: string, imagePath: string) {
   return `${type}:${id}:${imagePath}`;
 }
 
-async function preloadBrowserImage(imageUrl: string): Promise<void> {
-  await new Promise<void>((resolve) => {
-    const img = new Image();
-    img.decoding = 'async';
-    img.onload = () => resolve();
-    img.onerror = () => resolve();
-    img.src = imageUrl;
-  });
-}
-
 async function requestGalleryImage(
   type: AssetType,
   id: string,
@@ -44,9 +34,6 @@ async function requestGalleryImage(
     }
 
     const imageUrl = response.imageUrl || null;
-    if (imageUrl) {
-      await preloadBrowserImage(imageUrl);
-    }
     return { imageUrl, error: false };
   } catch {
     return { imageUrl: null, error: true };

--- a/railyard/frontend/src/pages/BrowsePage.tsx
+++ b/railyard/frontend/src/pages/BrowsePage.tsx
@@ -353,6 +353,7 @@ function BrowsePageContent({
             onQueryChange={handleQueryChange}
             placeholder={SEARCH_BAR_PLACEHOLDER}
             ariaLabel="Search mods and maps"
+            debounceMs={150}
           />
         ),
         controlsLeft: (

--- a/railyard/frontend/src/pages/LibraryPage.tsx
+++ b/railyard/frontend/src/pages/LibraryPage.tsx
@@ -505,6 +505,7 @@ export function LibraryPage() {
               }
               placeholder={SEARCH_BAR_PLACEHOLDER}
               ariaLabel="Search installed mods and maps"
+              debounceMs={150}
             />
           </div>
           <Button

--- a/railyard/frontend/src/stores/browse-store.ts
+++ b/railyard/frontend/src/stores/browse-store.ts
@@ -55,10 +55,13 @@ export const useBrowseStore = create<
       switchFilter(state.filters, state.page, state.scopedByType, type),
     ),
   setPage: (page) =>
-    set((state) => ({
-      page,
-      scopedByType: syncFilter(state.scopedByType, state.filters, page),
-    })),
+    set((state) => {
+      if (state.page === page) return state;
+      return {
+        page,
+        scopedByType: syncFilter(state.scopedByType, state.filters, page),
+      };
+    }),
   setViewMode: (viewMode) => set({ viewMode, viewModeInitialized: true }),
   initializeViewMode: (viewMode) => {
     if (get().viewModeInitialized) return;

--- a/railyard/frontend/src/stores/library-store.ts
+++ b/railyard/frontend/src/stores/library-store.ts
@@ -68,10 +68,13 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
       switchFilter(state.filters, state.page, state.scopedByType, type),
     ),
   setPage: (page) =>
-    set((state) => ({
-      page,
-      scopedByType: syncFilter(state.scopedByType, state.filters, page),
-    })),
+    set((state) => {
+      if (state.page === page) return state;
+      return {
+        page,
+        scopedByType: syncFilter(state.scopedByType, state.filters, page),
+      };
+    }),
   toggleSelected: (id) =>
     set((state) => {
       const next = new Set(state.selectedIds);

--- a/website/hooks/use-filtered-items.ts
+++ b/website/hooks/use-filtered-items.ts
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   buildAssetSearchText,
@@ -233,14 +227,6 @@ export function useFilteredItems({
   const [scopedByType, setScopedByType] = useState<FilterByAssetType>(
     initialState.scopedByType,
   );
-  const deferredQuery = useDeferredValue(filters.query);
-  const deferredFilters = useMemo(
-    () =>
-      deferredQuery === filters.query
-        ? filters
-        : { ...filters, query: deferredQuery },
-    [deferredQuery, filters],
-  );
 
   const allItems = useMemo<TaggedItem[]>(
     () => buildTaggedItems(mods, maps),
@@ -266,7 +252,7 @@ export function useFilteredItems({
       filterAndPaginateTaggedItems({
         items: allItems,
         page: requestedPage,
-        filters: deferredFilters,
+        filters,
         modDownloadTotals,
         mapDownloadTotals,
         compareItems,
@@ -332,13 +318,7 @@ export function useFilteredItems({
           ],
         },
       }),
-    [
-      allItems,
-      deferredFilters,
-      mapDownloadTotals,
-      modDownloadTotals,
-      requestedPage,
-    ],
+    [allItems, filters, mapDownloadTotals, modDownloadTotals, requestedPage],
   );
 
   const setFilters = useCallback((updater: SearchFilterUpdater) => {

--- a/website/hooks/use-filtered-items.ts
+++ b/website/hooks/use-filtered-items.ts
@@ -1,6 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import {
   buildAssetSearchText,
@@ -227,6 +233,14 @@ export function useFilteredItems({
   const [scopedByType, setScopedByType] = useState<FilterByAssetType>(
     initialState.scopedByType,
   );
+  const deferredQuery = useDeferredValue(filters.query);
+  const deferredFilters = useMemo(
+    () =>
+      deferredQuery === filters.query
+        ? filters
+        : { ...filters, query: deferredQuery },
+    [deferredQuery, filters],
+  );
 
   const allItems = useMemo<TaggedItem[]>(
     () => buildTaggedItems(mods, maps),
@@ -252,7 +266,7 @@ export function useFilteredItems({
       filterAndPaginateTaggedItems({
         items: allItems,
         page: requestedPage,
-        filters,
+        filters: deferredFilters,
         modDownloadTotals,
         mapDownloadTotals,
         compareItems,
@@ -318,7 +332,13 @@ export function useFilteredItems({
           ],
         },
       }),
-    [allItems, filters, mapDownloadTotals, modDownloadTotals, requestedPage],
+    [
+      allItems,
+      deferredFilters,
+      mapDownloadTotals,
+      modDownloadTotals,
+      requestedPage,
+    ],
   );
 
   const setFilters = useCallback((updater: SearchFilterUpdater) => {


### PR DESCRIPTION
Few things to make search less expensive
- keep a `pendingQuery` so that we "commit" queries only after typing ceases, and so that each key stroke causes a full recompute
- filter-and-sort now tries cached lowercase substring/token matching before trying Fuse/fuzzy-search (which is expensive)
- dimensional queries no longer compute against search text 
- card view no longer badge is no longer dynamically rendered, and image loading is now lazy