### PR TITLE
[Backend] Prevent double  application loading

### DIFF
--- a/railyard/app.go
+++ b/railyard/app.go
@@ -51,6 +51,7 @@ type App struct {
 
 	gameMu        sync.Mutex
 	gameCmd       *exec.Cmd
+	gameStarting  bool
 	pmtilesServer *http.Server
 	startupMu     sync.RWMutex
 	startupReady  bool
@@ -58,6 +59,10 @@ type App struct {
 	deepLinks deepLinkQueue
 
 	cachedGameVersion types.GameVersionResponse
+
+	launchGameTestReady chan<- struct{}
+	launchGameTestBlock <-chan struct{}
+	emitEventFunc       func(name string, optionalData ...interface{})
 }
 
 // NewApp creates a new App application struct
@@ -102,21 +107,21 @@ func (a *App) startup(ctx context.Context) {
 	}
 
 	a.Downloader.OnExtractProgress = func(itemId string, extracted int64, total int64) {
-		wailsruntime.EventsEmit(ctx, "extract:progress", map[string]interface{}{
+		a.emitEvent("extract:progress", map[string]interface{}{
 			"itemId":          itemId,
 			"amountExtracted": extracted,
 			"total":           total,
 		})
 	}
 	a.Downloader.OnProgress = func(itemId string, received int64, total int64) {
-		wailsruntime.EventsEmit(ctx, "download:progress", map[string]interface{}{
+		a.emitEvent("download:progress", map[string]interface{}{
 			"itemId":   itemId,
 			"received": received,
 			"total":    total,
 		})
 	}
 	a.Downloader.OnCancelled = func(itemId string, assetType types.AssetType, phase string) {
-		wailsruntime.EventsEmit(ctx, "download:cancelled", map[string]interface{}{
+		a.emitEvent("download:cancelled", map[string]interface{}{
 			"itemId":    itemId,
 			"assetType": string(assetType),
 			"phase":     phase,
@@ -126,7 +131,7 @@ func (a *App) startup(ctx context.Context) {
 		return a.GetGameVersion()
 	}
 	a.Downloader.OnRegistryUpdate = func() {
-		wailsruntime.EventsEmit(ctx, "registry:update")
+		a.emitEvent("registry:update")
 	}
 	if _, err := a.Config.ResolveConfig(); err != nil {
 		log.Printf("Warning: failed to resolve config on startup: %v", err)
@@ -172,6 +177,17 @@ func (a *App) setStartupReady(ready bool) {
 	a.startupMu.Lock()
 	defer a.startupMu.Unlock()
 	a.startupReady = ready
+}
+
+func (a *App) emitEvent(name string, optionalData ...interface{}) {
+	if a.emitEventFunc != nil {
+		a.emitEventFunc(name, optionalData...)
+		return
+	}
+	if a.ctx == nil {
+		return
+	}
+	wailsruntime.EventsEmit(a.ctx, name, optionalData...)
 }
 
 // IsStartupReady reports whether backend startup routines have completed.
@@ -411,11 +427,38 @@ func (a *App) GetGameVersion() types.GameVersionResponse {
 
 func (a *App) LaunchGame() types.GenericResponse {
 	a.gameMu.Lock()
+	if a.gameStarting {
+		a.gameMu.Unlock()
+		return types.ErrorResponse("game is already starting")
+	}
 	if a.gameCmd != nil && a.gameCmd.ProcessState == nil {
 		a.gameMu.Unlock()
 		return types.ErrorResponse("game is already running")
 	}
+	a.gameStarting = true
 	a.gameMu.Unlock()
+
+	started := false
+	defer func() {
+		if started {
+			return
+		}
+		a.gameMu.Lock()
+		a.gameStarting = false
+		a.gameMu.Unlock()
+		a.emitEvent("game:status", "stopped")
+	}()
+
+	a.emitEvent("game:status", "starting")
+	if a.launchGameTestReady != nil {
+		select {
+		case a.launchGameTestReady <- struct{}{}:
+		default:
+		}
+	}
+	if a.launchGameTestBlock != nil {
+		<-a.launchGameTestBlock
+	}
 
 	cfg := a.Config.GetConfig()
 	if !cfg.Validation.ExecutablePathValid {
@@ -439,7 +482,7 @@ func (a *App) LaunchGame() types.GenericResponse {
 		return types.ErrorResponse(err.Error())
 	}
 
-	wailsruntime.EventsEmit(a.ctx, "server:port", port)
+	a.emitEvent("server:port", port)
 	a.Logger.Info(fmt.Sprintf("Debug thumbnails: http://127.0.0.1:%d/debug/thumbnails", port))
 
 	a.generateMissingThumbnails(port)
@@ -523,11 +566,13 @@ func (a *App) LaunchGame() types.GenericResponse {
 
 	a.gameMu.Lock()
 	a.gameCmd = cmd
+	a.gameStarting = false
 	a.gameMu.Unlock()
+	started = true
 
-	wailsruntime.EventsEmit(a.ctx, "game:status", "running")
+	a.emitEvent("game:status", "running")
 
-	wailsruntime.EventsEmit(a.ctx, "game:log", map[string]string{
+	a.emitEvent("game:log", map[string]string{
 		"stream": "stdout",
 		"line":   fmt.Sprintf("> %s %s", strings.Split(a.gameCmd.Path, string(os.PathSeparator))[len(strings.Split(a.gameCmd.Path, string(os.PathSeparator)))-1], strings.Join(a.gameCmd.Args[1:], " ")),
 	})
@@ -541,6 +586,7 @@ func (a *App) LaunchGame() types.GenericResponse {
 		err := cmd.Wait()
 		a.gameMu.Lock()
 		a.gameCmd = nil
+		a.gameStarting = false
 		a.gameMu.Unlock()
 
 		exitCode := 0
@@ -552,8 +598,8 @@ func (a *App) LaunchGame() types.GenericResponse {
 		} else {
 			a.Logger.Info("Game exited normally")
 		}
-		wailsruntime.EventsEmit(a.ctx, "game:exit", exitCode)
-		wailsruntime.EventsEmit(a.ctx, "game:status", "stopped")
+		a.emitEvent("game:exit", exitCode)
+		a.emitEvent("game:status", "stopped")
 	}()
 
 	return types.SuccessResponse("Game launched")
@@ -563,7 +609,7 @@ func (a *App) streamGameOutput(r io.Reader, stream string) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
-		wailsruntime.EventsEmit(a.ctx, "game:log", map[string]string{
+		a.emitEvent("game:log", map[string]string{
 			"stream": stream,
 			"line":   line,
 		})
@@ -583,7 +629,13 @@ func (a *App) StopGame() types.GenericResponse {
 	a.Logger.Info("Killing game process")
 	a.gameMu.Lock()
 	cmd := a.gameCmd
+	starting := a.gameStarting
 	a.gameMu.Unlock()
+
+	if starting && cmd == nil {
+		a.Logger.Warn("Game is still starting and cannot be stopped yet")
+		return types.ErrorResponse("game is still starting")
+	}
 
 	if cmd == nil || cmd.ProcessState != nil {
 		a.Logger.Warn("No game process to kill")
@@ -601,7 +653,10 @@ func (a *App) StopGame() types.GenericResponse {
 	}
 
 	a.Logger.Info("Game process killed successfully")
+	a.gameMu.Lock()
 	a.gameCmd = nil
+	a.gameStarting = false
+	a.gameMu.Unlock()
 	return types.SuccessResponse("Game stopped")
 }
 

--- a/railyard/app.go
+++ b/railyard/app.go
@@ -60,6 +60,7 @@ type App struct {
 
 	cachedGameVersion types.GameVersionResponse
 
+	// Test-only hooks for controlling the launch-starting window and event sink.
 	launchGameTestReady chan<- struct{}
 	launchGameTestBlock <-chan struct{}
 	emitEventFunc       func(name string, optionalData ...interface{})
@@ -179,12 +180,14 @@ func (a *App) setStartupReady(ready bool) {
 	a.startupReady = ready
 }
 
+// emitEvent forwards frontend events through Wails, with a test override.
 func (a *App) emitEvent(name string, optionalData ...interface{}) {
 	if a.emitEventFunc != nil {
 		a.emitEventFunc(name, optionalData...)
 		return
 	}
 	if a.ctx == nil {
+		a.Logger.Warn("dropping event without Wails context", "event", name)
 		return
 	}
 	wailsruntime.EventsEmit(a.ctx, name, optionalData...)

--- a/railyard/app_test.go
+++ b/railyard/app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"railyard/internal/config"
 	"railyard/internal/logger"
 	"railyard/internal/types"
 
@@ -34,4 +35,33 @@ func TestOpenInFileExplorerRejectsInvalidPaths(t *testing.T) {
 	missing := app.OpenInFileExplorer("this-path-does-not-exist")
 	require.Equal(t, types.ResponseError, missing.Status)
 	require.Contains(t, missing.Message, "failed to resolve path")
+}
+
+func TestLaunchGameRejectsConcurrentStartWhileStarting(t *testing.T) {
+	app := newTestApp()
+	app.Config = config.NewConfig(app.Logger)
+	app.emitEventFunc = func(string, ...interface{}) {}
+
+	ready := make(chan struct{}, 1)
+	block := make(chan struct{})
+	app.launchGameTestReady = ready
+	app.launchGameTestBlock = block
+
+	firstResult := make(chan types.GenericResponse, 1)
+	go func() {
+		firstResult <- app.LaunchGame()
+	}()
+
+	<-ready
+
+	second := app.LaunchGame()
+	require.Equal(t, types.ResponseError, second.Status)
+	require.Equal(t, "game is already starting", second.Message)
+
+	close(block)
+
+	first := <-firstResult
+	require.Equal(t, types.ResponseError, first.Status)
+	require.Equal(t, "game executable path is not configured or invalid", first.Message)
+	require.False(t, app.gameStarting)
 }

--- a/railyard/frontend/src/components/layout/Navbar.tsx
+++ b/railyard/frontend/src/components/layout/Navbar.tsx
@@ -102,6 +102,7 @@ export function Navbar() {
   const refreshing = useRegistryStore((s) => s.refreshing);
   const canLaunch = useConfigStore((s) => s.validation?.executablePathValid);
   const running = useGameStore((s) => s.running);
+  const starting = useGameStore((s) => s.starting);
   const launch = useGameStore((s) => s.launch);
   const stop = useGameStore((s) => s.stop);
   const installedMaps = useInstalledStore((s) => s.installedMaps);
@@ -241,6 +242,16 @@ export function Navbar() {
                   />
                 </Button>
               </NavbarItem>
+            ) : starting ? (
+              <NavbarItem
+                asChild
+                className="bg-[color-mix(in_srgb,var(--install-primary)_14%,transparent)] text-[var(--install-primary)]"
+              >
+                <Button variant="ghost" size="sm" disabled>
+                  <Play className="mr-1.5 h-[1.125rem] w-[1.125rem] animate-pulse" />
+                  Starting
+                </Button>
+              </NavbarItem>
             ) : (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -250,7 +261,7 @@ export function Navbar() {
                         variant="ghost"
                         size="sm"
                         onClick={handleLaunch}
-                        disabled={!canLaunch}
+                        disabled={!canLaunch || starting}
                         className="disabled:opacity-50"
                       >
                         <Play className="mr-1.5 h-[1.125rem] w-[1.125rem]" />

--- a/railyard/frontend/src/pages/LogsPage.tsx
+++ b/railyard/frontend/src/pages/LogsPage.tsx
@@ -56,6 +56,7 @@ export function LogsPage() {
     selectedSessionId,
     selectSession,
     running,
+    starting,
     launch,
     stop,
     clearLogs,
@@ -142,8 +143,11 @@ export function LogsPage() {
 
       <div className="relative z-10 mb-4 flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <Badge variant={running ? 'success' : 'secondary'} size="sm">
-            {running ? 'Running' : 'Stopped'}
+          <Badge
+            variant={running ? 'success' : starting ? 'default' : 'secondary'}
+            size="sm"
+          >
+            {running ? 'Running' : starting ? 'Starting' : 'Stopped'}
           </Badge>
           {logs.length > 0 && (
             <span className="tabular-nums text-xs text-muted-foreground">
@@ -169,11 +173,13 @@ export function LogsPage() {
                     variant="ghost"
                     size="sm"
                     onClick={handleLaunch}
-                    disabled={!canLaunch}
+                    disabled={!canLaunch || starting}
                     className="h-7 gap-1.5 px-2.5 text-xs font-semibold hover:bg-accent/45 hover:text-primary disabled:opacity-50"
                   >
-                    <Play className="h-3 w-3" />
-                    Launch
+                    <Play
+                      className={cn('h-3 w-3', starting && 'animate-pulse')}
+                    />
+                    {starting ? 'Starting' : 'Launch'}
                   </Button>
                 </span>
               </TooltipTrigger>

--- a/railyard/frontend/src/stores/game-store.test.ts
+++ b/railyard/frontend/src/stores/game-store.test.ts
@@ -2,17 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useGameStore } from './game-store';
 
-const {
-  mockIsGameRunning,
-  mockLaunchGame,
-  mockStopGame,
-  mockEventsOn,
-} = vi.hoisted(() => ({
-  mockIsGameRunning: vi.fn(),
-  mockLaunchGame: vi.fn(),
-  mockStopGame: vi.fn(),
-  mockEventsOn: vi.fn(),
-}));
+const { mockIsGameRunning, mockLaunchGame, mockStopGame, mockEventsOn } =
+  vi.hoisted(() => ({
+    mockIsGameRunning: vi.fn(),
+    mockLaunchGame: vi.fn(),
+    mockStopGame: vi.fn(),
+    mockEventsOn: vi.fn(),
+  }));
 
 const eventHandlers = new Map<string, (payload: unknown) => void>();
 

--- a/railyard/frontend/src/stores/game-store.test.ts
+++ b/railyard/frontend/src/stores/game-store.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGameStore } from './game-store';
+
+const {
+  mockIsGameRunning,
+  mockLaunchGame,
+  mockStopGame,
+  mockEventsOn,
+} = vi.hoisted(() => ({
+  mockIsGameRunning: vi.fn(),
+  mockLaunchGame: vi.fn(),
+  mockStopGame: vi.fn(),
+  mockEventsOn: vi.fn(),
+}));
+
+const eventHandlers = new Map<string, (payload: unknown) => void>();
+
+vi.mock('../../wailsjs/go/main/App', () => ({
+  IsGameRunning: mockIsGameRunning,
+  LaunchGame: mockLaunchGame,
+  StopGame: mockStopGame,
+}));
+
+vi.mock('../../wailsjs/runtime/runtime', () => ({
+  EventsOn: mockEventsOn,
+}));
+
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useGameStore launch state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventHandlers.clear();
+    mockEventsOn.mockImplementation(
+      (event: string, handler: (payload: unknown) => void) => {
+        eventHandlers.set(event, handler);
+      },
+    );
+    mockIsGameRunning.mockResolvedValue({
+      status: 'success',
+      message: 'ok',
+      running: false,
+    });
+    mockLaunchGame.mockResolvedValue({
+      status: 'success',
+      message: 'Game launched',
+    });
+    mockStopGame.mockResolvedValue({
+      status: 'success',
+      message: 'Game stopped',
+    });
+
+    useGameStore.setState({
+      running: false,
+      starting: false,
+      sessions: [],
+      selectedSessionId: null,
+      maxLogs: 5000,
+      serverPort: null,
+    });
+  });
+
+  it('blocks duplicate launch calls while the game is starting', async () => {
+    const deferred = createDeferred<{ status: string; message: string }>();
+    mockLaunchGame.mockReturnValueOnce(deferred.promise);
+
+    useGameStore.getState().initialize();
+    await flushPromises();
+
+    const firstLaunch = useGameStore.getState().launch();
+    expect(useGameStore.getState().starting).toBe(true);
+    expect(mockLaunchGame).toHaveBeenCalledTimes(1);
+
+    await useGameStore.getState().launch();
+    expect(mockLaunchGame).toHaveBeenCalledTimes(1);
+
+    deferred.resolve({ status: 'success', message: 'Game launched' });
+    await firstLaunch;
+
+    expect(useGameStore.getState().starting).toBe(true);
+    eventHandlers.get('game:status')?.('running');
+    expect(useGameStore.getState().starting).toBe(false);
+    expect(useGameStore.getState().running).toBe(true);
+  });
+
+  it('clears starting when launch fails', async () => {
+    mockLaunchGame.mockResolvedValueOnce({
+      status: 'error',
+      message: 'boom',
+    });
+
+    useGameStore.getState().initialize();
+    await flushPromises();
+
+    await expect(useGameStore.getState().launch()).rejects.toThrow('boom');
+    expect(useGameStore.getState().starting).toBe(false);
+    expect(useGameStore.getState().running).toBe(false);
+  });
+});

--- a/railyard/frontend/src/stores/game-store.ts
+++ b/railyard/frontend/src/stores/game-store.ts
@@ -49,6 +49,7 @@ function createNewSessionPatch(
 
 interface GameState {
   running: boolean;
+  starting: boolean;
   sessions: GameLogSession[];
   selectedSessionId: string | null;
   maxLogs: number;
@@ -61,8 +62,9 @@ interface GameState {
   clearLogs: () => void;
 }
 
-export const useGameStore = create<GameState>((set) => ({
+export const useGameStore = create<GameState>((set, get) => ({
   running: false,
+  starting: false,
   sessions: [],
   selectedSessionId: null,
   maxLogs: 5000,
@@ -116,7 +118,7 @@ export const useGameStore = create<GameState>((set) => ({
     // Check initial state
     IsGameRunning().then((response) => {
       if (response.status !== 'success' || !response.running) {
-        set({ running: false });
+        set({ running: false, starting: false });
         return;
       }
 
@@ -126,7 +128,7 @@ export const useGameStore = create<GameState>((set) => ({
           (session) => session.endedAt === null,
         );
         if (hasActiveSession) {
-          return { running: true };
+          return { running: true, starting: false };
         }
 
         const { sessionId, sessions } = createNewSessionPatch(
@@ -135,6 +137,7 @@ export const useGameStore = create<GameState>((set) => ({
         );
         return {
           running: true,
+          starting: false,
           selectedSessionId: sessionId,
           sessions,
         };
@@ -143,6 +146,11 @@ export const useGameStore = create<GameState>((set) => ({
 
     // Listen for events from backend
     EventsOn('game:status', (status: string) => {
+      if (status === 'starting') {
+        set({ starting: true });
+        return;
+      }
+
       if (status === 'running') {
         const now = Date.now();
         set((state) => {
@@ -150,7 +158,7 @@ export const useGameStore = create<GameState>((set) => ({
             (session) => session.endedAt === null,
           );
           if (hasActiveSession) {
-            return { running: true };
+            return { running: true, starting: false };
           }
 
           const { sessionId, sessions } = createNewSessionPatch(
@@ -159,6 +167,7 @@ export const useGameStore = create<GameState>((set) => ({
           );
           return {
             running: true,
+            starting: false,
             selectedSessionId: sessionId,
             sessions,
           };
@@ -171,7 +180,7 @@ export const useGameStore = create<GameState>((set) => ({
           (session) => session.endedAt === null,
         );
         if (activeIndex === -1) {
-          return { running: false, serverPort: null };
+          return { running: false, starting: false, serverPort: null };
         }
 
         const nextSessions = [...state.sessions];
@@ -182,6 +191,7 @@ export const useGameStore = create<GameState>((set) => ({
 
         return {
           running: false,
+          starting: false,
           serverPort: null,
           sessions: nextSessions,
         };
@@ -210,9 +220,20 @@ export const useGameStore = create<GameState>((set) => ({
   },
 
   launch: async () => {
-    const response = await LaunchGame();
-    if (response.status === 'error') {
-      throw new Error(response.message || 'Failed to launch game');
+    if (get().running || get().starting) {
+      return;
+    }
+
+    set({ starting: true });
+
+    try {
+      const response = await LaunchGame();
+      if (response.status === 'error') {
+        throw new Error(response.message || 'Failed to launch game');
+      }
+    } catch (error) {
+      set({ starting: false });
+      throw error;
     }
   },
 


### PR DESCRIPTION
This PR makes BE more robust to concurrent app launches

- Game launch state now has a real starting phase in both backend and frontend. 
  - This is the intermediate state between launch click and confirmation of logging pipe creation
- Launch buttons disable correctly during startup, with a wails event being the trigger to enable
- Added some new BE tests (and override channels in app to validate this behavior)

https://github.com/user-attachments/assets/3b8428eb-f3f9-4653-8727-f0ede9693314

