### PR TITLE
[Backend] Enable .railyard_{asset_type} extraction in imports (and remote)

### DIFF
--- a/railyard/internal/downloader/downloader_test.go
+++ b/railyard/internal/downloader/downloader_test.go
@@ -241,6 +241,28 @@ func seedInstalledLocalMap(t *testing.T, d *Downloader, reg *registry.Registry, 
 	require.NoError(t, os.WriteFile(filepath.Join(localMapDir, constants.RailyardAssetMarker), []byte("marker"), 0o644))
 }
 
+func mockMapZipWithReservedPayload(t *testing.T, code string) []byte {
+	t.Helper()
+
+	configJSON, err := json.Marshal(types.ConfigData{
+		Code: code,
+		Name: "Fixture Map",
+	})
+	require.NoError(t, err)
+
+	return registrytest.MockZip(t, map[string][]byte{
+		"config.json":                           configJSON,
+		"demand_data.json":                      []byte("{}"),
+		"roads.geojson":                         []byte(`{"type":"FeatureCollection","features":[]}`),
+		"runways_taxiways.geojson":              []byte(`{"type":"FeatureCollection","features":[]}`),
+		"buildings_index.json":                  []byte("{}"),
+		"tiles.pmtiles":                         []byte("tiles"),
+		"thumbnail.svg":                         []byte("<svg></svg>"),
+		".railyard_map/data/example.json":       []byte(`{"ok":true}`),
+		".railyard_map/nested/notes/readme.txt": []byte("payload"),
+	})
+}
+
 func assertFilesExist(t *testing.T, basePath string, names []string, messagePrefix string) {
 	t.Helper()
 	for _, name := range names {
@@ -1107,6 +1129,67 @@ func TestMapContractFilesWritten(t *testing.T) {
 				_, err := os.Stat(filepath.Join(mapDir, fileName))
 				require.True(t, errors.Is(err, fs.ErrNotExist), "expected map data file to be absent: %s", fileName)
 			}
+		})
+	}
+}
+
+func TestMapReservedPayloadCopied(t *testing.T) {
+	testCases := []struct {
+		name       string
+		runInstall func(t *testing.T, d *Downloader, reg *registry.Registry) types.AssetInstallResponse
+	}{
+		{
+			name: "downloaded map install",
+			runInstall: func(t *testing.T, d *Downloader, reg *registry.Registry) types.AssetInstallResponse {
+				t.Helper()
+				cleanup := registrytest.MockRegistryServer(t, reg, []registrytest.UpdateFixture{
+					{
+						AssetID:      "map-a",
+						AssetType:    types.AssetTypeMap,
+						Versions:     []string{"1.0.0"},
+						MapCode:      "AAA",
+						ArchiveBytes: mockMapZipWithReservedPayload(t, "AAA"),
+					},
+				})
+				defer cleanup()
+				return d.InstallAsset(types.InstallAssetRequest{
+					AssetType: types.AssetTypeMap,
+					AssetID:   "map-a",
+					Version:   "1.0.0",
+				})
+			},
+		},
+		{
+			name: "local map import",
+			runInstall: func(t *testing.T, d *Downloader, _ *registry.Registry) types.AssetInstallResponse {
+				t.Helper()
+				zipPath := filepath.Join(t.TempDir(), "local-map.zip")
+				require.NoError(t, os.WriteFile(zipPath, mockMapZipWithReservedPayload(t, "AAA"), 0o644))
+				return d.ImportAsset(types.AssetTypeMap, zipPath, false)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, reg, _ := newConfiguredDownloader(t, true)
+
+			resp := tc.runInstall(t, d, reg)
+			require.Equal(t, types.ResponseSuccess, resp.Status, resp.Message)
+
+			helperRoot := filepath.Join(d.getMapDataPath(), "AAA", ".railyard_map")
+			assertFilesExist(t, helperRoot, []string{
+				filepath.Join("data", "example.json"),
+				filepath.Join("nested", "notes", "readme.txt"),
+			}, "expected reserved payload file")
+
+			payloadJSON, err := os.ReadFile(filepath.Join(helperRoot, "data", "example.json"))
+			require.NoError(t, err)
+			require.JSONEq(t, `{"ok":true}`, string(payloadJSON))
+
+			payloadText, err := os.ReadFile(filepath.Join(helperRoot, "nested", "notes", "readme.txt"))
+			require.NoError(t, err)
+			require.Equal(t, "payload", string(payloadText))
 		})
 	}
 }

--- a/railyard/internal/downloader/downloader_test.go
+++ b/railyard/internal/downloader/downloader_test.go
@@ -241,7 +241,7 @@ func seedInstalledLocalMap(t *testing.T, d *Downloader, reg *registry.Registry, 
 	require.NoError(t, os.WriteFile(filepath.Join(localMapDir, constants.RailyardAssetMarker), []byte("marker"), 0o644))
 }
 
-func mockMapZipWithReservedPayload(t *testing.T, code string) []byte {
+func mockMapZipWithSharedPayload(t *testing.T, code string) []byte {
 	t.Helper()
 
 	configJSON, err := json.Marshal(types.ConfigData{
@@ -1148,7 +1148,7 @@ func TestMapReservedPayloadCopied(t *testing.T) {
 						AssetType:    types.AssetTypeMap,
 						Versions:     []string{"1.0.0"},
 						MapCode:      "AAA",
-						ArchiveBytes: mockMapZipWithReservedPayload(t, "AAA"),
+						ArchiveBytes: mockMapZipWithSharedPayload(t, "AAA"),
 					},
 				})
 				defer cleanup()
@@ -1164,7 +1164,7 @@ func TestMapReservedPayloadCopied(t *testing.T) {
 			runInstall: func(t *testing.T, d *Downloader, _ *registry.Registry) types.AssetInstallResponse {
 				t.Helper()
 				zipPath := filepath.Join(t.TempDir(), "local-map.zip")
-				require.NoError(t, os.WriteFile(zipPath, mockMapZipWithReservedPayload(t, "AAA"), 0o644))
+				require.NoError(t, os.WriteFile(zipPath, mockMapZipWithSharedPayload(t, "AAA"), 0o644))
 				return d.ImportAsset(types.AssetTypeMap, zipPath, false)
 			},
 		},

--- a/railyard/internal/downloader/downloader_test.go
+++ b/railyard/internal/downloader/downloader_test.go
@@ -1181,7 +1181,7 @@ func TestMapReservedPayloadCopied(t *testing.T) {
 			assertFilesExist(t, helperRoot, []string{
 				filepath.Join("data", "example.json"),
 				filepath.Join("nested", "notes", "readme.txt"),
-			}, "expected reserved payload file")
+			}, "expected shared payload file")
 
 			payloadJSON, err := os.ReadFile(filepath.Join(helperRoot, "data", "example.json"))
 			require.NoError(t, err)

--- a/railyard/internal/downloader/extractor.go
+++ b/railyard/internal/downloader/extractor.go
@@ -43,14 +43,18 @@ func reportExtractProgress(fn ExtractProgressFunc, itemID string, extracted int6
 	fn(itemID, extracted, total)
 }
 
-// countSharedMapPayloadFiles counts optional shared payload files that are copied into the map data directory.
-func countSharedMapPayloadFiles(zipFiles []*zip.File) (int, error) {
+// countSharedAssetPayloadFiles counts optional shared payload files that are copied into an asset directory.
+func countSharedAssetPayloadFiles(assetType types.AssetType, zipFiles []*zip.File) (int, error) {
 	count := 0
 	for _, file := range zipFiles {
-		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		// Reuse the shared payload parser here so progress accounting follows
+		// the same acceptance rules as validation and extraction.
+		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(assetType, file.Name)
 		if err != nil {
 			return 0, err
 		}
+		// isHelperEntry means this archive entry targets .railyard_<asset>;
+		// non-helper entries are counted by their normal extraction paths.
 		if !isHelperEntry || relPath == "" || file.FileInfo().IsDir() {
 			continue
 		}
@@ -60,22 +64,28 @@ func countSharedMapPayloadFiles(zipFiles []*zip.File) (int, error) {
 	return count, nil
 }
 
-// copySharedMapPayload copies optional .railyard_map entries into the staged map directory.
-func copySharedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode string, progress *atomic.Int64, total int64, onProgress ExtractProgressFunc) error {
-	helperRoot := paths.JoinLocalPath(stagingFolder, files.SharedAssetPayloadDir(types.AssetTypeMap))
+// copySharedAssetPayload copies optional .railyard_<asset> entries into the staged asset directory.
+func copySharedAssetPayload(assetType types.AssetType, stagingFolder string, zipFiles []*zip.File, itemID string, progress *atomic.Int64, total int64, onProgress ExtractProgressFunc) error {
+	helperRoot := paths.JoinLocalPath(stagingFolder, files.SharedAssetPayloadDir(assetType))
 
 	for _, file := range zipFiles {
-		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		// Parser identifies .railyard_<asset> entries and strips the helper
+		// root so the remaining path can be copied under the staged asset folder.
+		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(assetType, file.Name)
 		if err != nil {
 			return err
 		}
+		// isHelperEntry distinguishes shared payload files from normal asset
+		// archive contents, which continue through the existing extractors.
 		if !isHelperEntry {
 			continue
 		}
 
+		// relPath == "" identifies the .railyard_<asset> root entry itself;
+		// only directories are valid there because files need a path below it.
 		if relPath == "" {
 			if !file.FileInfo().IsDir() {
-				return fmt.Errorf("shared payload root %q must be a directory", files.SharedAssetPayloadDir(types.AssetTypeMap))
+				return fmt.Errorf("shared payload root %q must be a directory", files.SharedAssetPayloadDir(assetType))
 			}
 			if err := os.MkdirAll(helperRoot, os.ModePerm); err != nil {
 				return err
@@ -85,6 +95,8 @@ func copySharedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode s
 
 		destinationPath := paths.JoinLocalPath(helperRoot, relPath)
 		if file.FileInfo().IsDir() {
+			// Preserve explicit directories from the archive so nested payload
+			// layouts remain byte-for-byte discoverable by mods at runtime.
 			if err := os.MkdirAll(destinationPath, os.ModePerm); err != nil {
 				return err
 			}
@@ -100,6 +112,8 @@ func copySharedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode s
 			return err
 		}
 
+		// Shared payload files are data for other assets to read, so copy them
+		// uncompressed instead of using the game's gzipped city-data convention.
 		writeErr := files.WriteArchiveStream(destinationPath, srcFile, false)
 		closeErr := srcFile.Close()
 		if writeErr != nil {
@@ -109,7 +123,7 @@ func copySharedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode s
 			return closeErr
 		}
 
-		reportExtractProgress(onProgress, cityCode, progress.Add(1), total)
+		reportExtractProgress(onProgress, itemID, progress.Add(1), total)
 	}
 
 	return nil
@@ -265,7 +279,7 @@ func extractMap(d *Downloader, filePath string, mapId string, version string, sk
 			filesCount++
 		}
 	}
-	sharedPayloadFileCount, err := countSharedMapPayloadFiles(reader.File)
+	sharedPayloadFileCount, err := countSharedAssetPayloadFiles(types.AssetTypeMap, reader.File)
 	if err != nil {
 		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidArchive, "Failed map archive inspection", err, "file_path", filePath)
 	}
@@ -356,7 +370,7 @@ func extractMap(d *Downloader, filePath string, mapId string, version string, sk
 					return <-errChan
 				}
 
-				if err := copySharedMapPayload(stagingFolder, reader.File, configData.Code, &extractCount, int64(filesCount), d.OnExtractProgress); err != nil {
+				if err := copySharedAssetPayload(types.AssetTypeMap, stagingFolder, reader.File, configData.Code, &extractCount, int64(filesCount), d.OnExtractProgress); err != nil {
 					return err
 				}
 

--- a/railyard/internal/downloader/extractor.go
+++ b/railyard/internal/downloader/extractor.go
@@ -43,11 +43,11 @@ func reportExtractProgress(fn ExtractProgressFunc, itemID string, extracted int6
 	fn(itemID, extracted, total)
 }
 
-// countReservedMapPayloadFiles counts optional helper payload files that are copied into the map data directory.
-func countReservedMapPayloadFiles(zipFiles []*zip.File) (int, error) {
+// countSharedMapPayloadFiles counts optional shared payload files that are copied into the map data directory.
+func countSharedMapPayloadFiles(zipFiles []*zip.File) (int, error) {
 	count := 0
 	for _, file := range zipFiles {
-		relPath, isHelperEntry, err := files.ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
 		if err != nil {
 			return 0, err
 		}
@@ -60,12 +60,12 @@ func countReservedMapPayloadFiles(zipFiles []*zip.File) (int, error) {
 	return count, nil
 }
 
-// copyReservedMapPayload copies optional .railyard_map entries into the staged map directory.
-func copyReservedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode string, progress *atomic.Int64, total int64, onProgress ExtractProgressFunc) error {
-	helperRoot := paths.JoinLocalPath(stagingFolder, files.ReservedAssetPayloadDir(types.AssetTypeMap))
+// copySharedMapPayload copies optional .railyard_map entries into the staged map directory.
+func copySharedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode string, progress *atomic.Int64, total int64, onProgress ExtractProgressFunc) error {
+	helperRoot := paths.JoinLocalPath(stagingFolder, files.SharedAssetPayloadDir(types.AssetTypeMap))
 
 	for _, file := range zipFiles {
-		relPath, isHelperEntry, err := files.ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
 		if err != nil {
 			return err
 		}
@@ -75,7 +75,7 @@ func copyReservedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode
 
 		if relPath == "" {
 			if !file.FileInfo().IsDir() {
-				return fmt.Errorf("reserved payload root %q must be a directory", files.ReservedAssetPayloadDir(types.AssetTypeMap))
+				return fmt.Errorf("shared payload root %q must be a directory", files.SharedAssetPayloadDir(types.AssetTypeMap))
 			}
 			if err := os.MkdirAll(helperRoot, os.ModePerm); err != nil {
 				return err
@@ -265,11 +265,11 @@ func extractMap(d *Downloader, filePath string, mapId string, version string, sk
 			filesCount++
 		}
 	}
-	reservedPayloadFileCount, err := countReservedMapPayloadFiles(reader.File)
+	sharedPayloadFileCount, err := countSharedMapPayloadFiles(reader.File)
 	if err != nil {
 		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidArchive, "Failed map archive inspection", err, "file_path", filePath)
 	}
-	filesCount += reservedPayloadFileCount
+	filesCount += sharedPayloadFileCount
 	if configData.ThumbnailBbox != nil {
 		if fileStruct, ok := filesFound[files.MapArchiveKeyThumbnail]; !ok || !fileStruct.Found {
 			filesCount++
@@ -356,7 +356,7 @@ func extractMap(d *Downloader, filePath string, mapId string, version string, sk
 					return <-errChan
 				}
 
-				if err := copyReservedMapPayload(stagingFolder, reader.File, configData.Code, &extractCount, int64(filesCount), d.OnExtractProgress); err != nil {
+				if err := copySharedMapPayload(stagingFolder, reader.File, configData.Code, &extractCount, int64(filesCount), d.OnExtractProgress); err != nil {
 					return err
 				}
 

--- a/railyard/internal/downloader/extractor.go
+++ b/railyard/internal/downloader/extractor.go
@@ -47,15 +47,11 @@ func reportExtractProgress(fn ExtractProgressFunc, itemID string, extracted int6
 func countSharedAssetPayloadFiles(assetType types.AssetType, zipFiles []*zip.File) (int, error) {
 	count := 0
 	for _, file := range zipFiles {
-		// Reuse the shared payload parser here so progress accounting follows
-		// the same acceptance rules as validation and extraction.
-		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(assetType, file.Name)
+		relPath, isSharedEntry, err := files.SharedAssetPayloadRelativePath(assetType, file.Name)
 		if err != nil {
 			return 0, err
 		}
-		// isHelperEntry means this archive entry targets .railyard_<asset>;
-		// non-helper entries are counted by their normal extraction paths.
-		if !isHelperEntry || relPath == "" || file.FileInfo().IsDir() {
+		if !isSharedEntry || relPath == "" || file.FileInfo().IsDir() {
 			continue
 		}
 		count++

--- a/railyard/internal/downloader/extractor.go
+++ b/railyard/internal/downloader/extractor.go
@@ -69,20 +69,18 @@ func copySharedAssetPayload(assetType types.AssetType, stagingFolder string, zip
 	helperRoot := paths.JoinLocalPath(stagingFolder, files.SharedAssetPayloadDir(assetType))
 
 	for _, file := range zipFiles {
-		// Parser identifies .railyard_<asset> entries and strips the helper
-		// root so the remaining path can be copied under the staged asset folder.
-		relPath, isHelperEntry, err := files.SharedAssetPayloadRelativePath(assetType, file.Name)
+		// Parser identifies .railyard_<asset> entries and strips the helper root
+		relPath, isSharedEntry, err := files.SharedAssetPayloadRelativePath(assetType, file.Name)
 		if err != nil {
 			return err
 		}
-		// isHelperEntry distinguishes shared payload files from normal asset
-		// archive contents, which continue through the existing extractors.
-		if !isHelperEntry {
+		// ignore normal asset archive entries
+		if !isSharedEntry {
 			continue
 		}
 
-		// relPath == "" identifies the .railyard_<asset> root entry itself;
-		// only directories are valid there because files need a path below it.
+		// Identify the .railyard_<asset> root entry itself;
+		// Only directories are valid there because files need a path below it.
 		if relPath == "" {
 			if !file.FileInfo().IsDir() {
 				return fmt.Errorf("shared payload root %q must be a directory", files.SharedAssetPayloadDir(assetType))
@@ -96,7 +94,7 @@ func copySharedAssetPayload(assetType types.AssetType, stagingFolder string, zip
 		destinationPath := paths.JoinLocalPath(helperRoot, relPath)
 		if file.FileInfo().IsDir() {
 			// Preserve explicit directories from the archive so nested payload
-			// layouts remain byte-for-byte discoverable by mods at runtime.
+			// layouts remain discoverable by other assets at runtime.
 			if err := os.MkdirAll(destinationPath, os.ModePerm); err != nil {
 				return err
 			}
@@ -112,8 +110,7 @@ func copySharedAssetPayload(assetType types.AssetType, stagingFolder string, zip
 			return err
 		}
 
-		// Shared payload files are data for other assets to read, so copy them
-		// uncompressed instead of using the game's gzipped city-data convention.
+		// Payload files are data for other assets to read, so copy them uncompressed.
 		writeErr := files.WriteArchiveStream(destinationPath, srcFile, false)
 		closeErr := srcFile.Close()
 		if writeErr != nil {

--- a/railyard/internal/downloader/extractor.go
+++ b/railyard/internal/downloader/extractor.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"archive/zip"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -40,6 +41,78 @@ func reportExtractProgress(fn ExtractProgressFunc, itemID string, extracted int6
 		return
 	}
 	fn(itemID, extracted, total)
+}
+
+// countReservedMapPayloadFiles counts optional helper payload files that are copied into the map data directory.
+func countReservedMapPayloadFiles(zipFiles []*zip.File) (int, error) {
+	count := 0
+	for _, file := range zipFiles {
+		relPath, isHelperEntry, err := files.ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		if err != nil {
+			return 0, err
+		}
+		if !isHelperEntry || relPath == "" || file.FileInfo().IsDir() {
+			continue
+		}
+		count++
+	}
+
+	return count, nil
+}
+
+// copyReservedMapPayload copies optional .railyard_map entries into the staged map directory.
+func copyReservedMapPayload(stagingFolder string, zipFiles []*zip.File, cityCode string, progress *atomic.Int64, total int64, onProgress ExtractProgressFunc) error {
+	helperRoot := paths.JoinLocalPath(stagingFolder, files.ReservedAssetPayloadDir(types.AssetTypeMap))
+
+	for _, file := range zipFiles {
+		relPath, isHelperEntry, err := files.ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		if err != nil {
+			return err
+		}
+		if !isHelperEntry {
+			continue
+		}
+
+		if relPath == "" {
+			if !file.FileInfo().IsDir() {
+				return fmt.Errorf("reserved payload root %q must be a directory", files.ReservedAssetPayloadDir(types.AssetTypeMap))
+			}
+			if err := os.MkdirAll(helperRoot, os.ModePerm); err != nil {
+				return err
+			}
+			continue
+		}
+
+		destinationPath := paths.JoinLocalPath(helperRoot, relPath)
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(destinationPath, os.ModePerm); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(destinationPath), os.ModePerm); err != nil {
+			return err
+		}
+
+		srcFile, err := file.Open()
+		if err != nil {
+			return err
+		}
+
+		writeErr := files.WriteArchiveStream(destinationPath, srcFile, false)
+		closeErr := srcFile.Close()
+		if writeErr != nil {
+			return writeErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+
+		reportExtractProgress(onProgress, cityCode, progress.Add(1), total)
+	}
+
+	return nil
 }
 
 // extractMod processes the downloaded mod zip file, extracts it to the appropriate location.
@@ -192,6 +265,11 @@ func extractMap(d *Downloader, filePath string, mapId string, version string, sk
 			filesCount++
 		}
 	}
+	reservedPayloadFileCount, err := countReservedMapPayloadFiles(reader.File)
+	if err != nil {
+		return d.installError(types.AssetTypeMap, mapId, version, configData, types.InstallErrorInvalidArchive, "Failed map archive inspection", err, "file_path", filePath)
+	}
+	filesCount += reservedPayloadFileCount
 	if configData.ThumbnailBbox != nil {
 		if fileStruct, ok := filesFound[files.MapArchiveKeyThumbnail]; !ok || !fileStruct.Found {
 			filesCount++
@@ -276,6 +354,10 @@ func extractMap(d *Downloader, filePath string, mapId string, version string, sk
 				close(errChan)
 				if len(errChan) > 0 {
 					return <-errChan
+				}
+
+				if err := copyReservedMapPayload(stagingFolder, reader.File, configData.Code, &extractCount, int64(filesCount), d.OnExtractProgress); err != nil {
+					return err
 				}
 
 				return createAssetMarker(paths.JoinLocalPath(stagingFolder, constants.RailyardAssetMarker))

--- a/railyard/internal/files/archive.go
+++ b/railyard/internal/files/archive.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"railyard/internal/logger"
 	"railyard/internal/types"
-	"strings"
 )
 
 // WriteArchiveStream writes an archive entry stream to a destination path, conditionally using gzip compression based on the useGzip flag.
@@ -204,8 +203,8 @@ func ReadJSONFromTarArchive[T any](archivePath string, targetFileName string) (T
 			continue
 		}
 
-		normalizedName := strings.ReplaceAll(header.Name, "\\", "/")
-		if path.Base(normalizedName) != targetFileName {
+		normalizedName, ok := NormalizeArchiveEntryPath(header.Name)
+		if !ok || path.Base(normalizedName) != targetFileName {
 			continue
 		}
 

--- a/railyard/internal/files/asset_payload.go
+++ b/railyard/internal/files/asset_payload.go
@@ -1,0 +1,69 @@
+package files
+
+import (
+	"fmt"
+	"strings"
+
+	"railyard/internal/types"
+)
+
+// ReservedAssetPayloadDir returns the reserved helper-folder name for an asset type.
+func ReservedAssetPayloadDir(assetType types.AssetType) string {
+	switch assetType {
+	case types.AssetTypeMap:
+		return ".railyard_map"
+	case types.AssetTypeMod:
+		return ".railyard_mod"
+	default:
+		panic("unsupported asset type for reserved payload dir: " + string(assetType))
+	}
+}
+
+// ReservedAssetPayloadRelativePath validates a reserved helper-folder entry and returns its relative path.
+func ReservedAssetPayloadRelativePath(assetType types.AssetType, entryName string) (string, bool, error) {
+	reservedDir := ReservedAssetPayloadDir(assetType)
+	normalized := strings.ReplaceAll(entryName, "\\", "/")
+	if normalized == "" {
+		return "", false, nil
+	}
+
+	if strings.HasPrefix(normalized, "/") {
+		if strings.Contains(normalized, reservedDir) {
+			return "", true, fmt.Errorf("reserved payload entry %q must not be absolute", entryName)
+		}
+		return "", false, nil
+	}
+
+	trimmed := strings.TrimSuffix(normalized, "/")
+	if trimmed == "" {
+		return "", false, nil
+	}
+
+	parts := strings.Split(trimmed, "/")
+	hasReservedDir := false
+	for i, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			if hasReservedDir || strings.Contains(normalized, reservedDir) {
+				return "", true, fmt.Errorf("reserved payload entry %q contains an invalid path segment", entryName)
+			}
+			return "", false, nil
+		}
+		if part != reservedDir {
+			continue
+		}
+		hasReservedDir = true
+		if i != 0 {
+			return "", true, fmt.Errorf("reserved payload directory %q must be at archive root", reservedDir)
+		}
+	}
+
+	if !hasReservedDir {
+		return "", false, nil
+	}
+
+	if len(parts) == 1 {
+		return "", true, nil
+	}
+
+	return strings.Join(parts[1:], "/"), true, nil
+}

--- a/railyard/internal/files/asset_payload.go
+++ b/railyard/internal/files/asset_payload.go
@@ -7,58 +7,96 @@ import (
 	"railyard/internal/types"
 )
 
-// ReservedAssetPayloadDir returns the reserved helper-folder name for an asset type.
-func ReservedAssetPayloadDir(assetType types.AssetType) string {
+// NormalizeArchiveEntryPath normalizes a ZIP entry path and reports whether it contains a usable value.
+func NormalizeArchiveEntryPath(entryName string) (string, bool) {
+	normalized := strings.ReplaceAll(entryName, "\\", "/")
+	if normalized == "" {
+		return "", false
+	}
+
+	trimmed := strings.TrimSuffix(normalized, "/")
+	if trimmed == "" {
+		return "", false
+	}
+
+	return trimmed, true
+}
+
+// ArchiveEntryParts normalizes a ZIP entry path and splits it into path segments.
+func ArchiveEntryParts(entryName string) (string, []string, bool) {
+	normalized, ok := NormalizeArchiveEntryPath(entryName)
+	if !ok {
+		return "", nil, false
+	}
+
+	return normalized, strings.Split(normalized, "/"), true
+}
+
+// HasInvalidArchivePathSegments reports whether a normalized archive path contains unsafe segments.
+func HasInvalidArchivePathSegments(parts []string) bool {
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasArchivePathPrefix(normalized string) bool {
+	return strings.HasPrefix(normalized, "/")
+}
+
+func pathSegmentIndex(parts []string, target string) int {
+	for i, part := range parts {
+		if part == target {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// SharedAssetPayloadDir returns the shared helper-folder name for an asset type.
+func SharedAssetPayloadDir(assetType types.AssetType) string {
 	switch assetType {
 	case types.AssetTypeMap:
 		return ".railyard_map"
 	case types.AssetTypeMod:
 		return ".railyard_mod"
 	default:
-		panic("unsupported asset type for reserved payload dir: " + string(assetType))
+		panic("unsupported asset type for shared payload dir: " + string(assetType))
 	}
 }
 
-// ReservedAssetPayloadRelativePath validates a reserved helper-folder entry and returns its relative path.
-func ReservedAssetPayloadRelativePath(assetType types.AssetType, entryName string) (string, bool, error) {
-	reservedDir := ReservedAssetPayloadDir(assetType)
-	normalized := strings.ReplaceAll(entryName, "\\", "/")
-	if normalized == "" {
+// SharedAssetPayloadRelativePath validates a shared helper-folder entry and returns its relative path.
+func SharedAssetPayloadRelativePath(assetType types.AssetType, entryName string) (string, bool, error) {
+	payloadDir := SharedAssetPayloadDir(assetType)
+	normalized, parts, ok := ArchiveEntryParts(entryName)
+	if !ok {
 		return "", false, nil
 	}
 
-	if strings.HasPrefix(normalized, "/") {
-		if strings.Contains(normalized, reservedDir) {
-			return "", true, fmt.Errorf("reserved payload entry %q must not be absolute", entryName)
+	payloadIndex := pathSegmentIndex(parts, payloadDir)
+	if hasArchivePathPrefix(normalized) {
+		if payloadIndex >= 0 {
+			return "", true, fmt.Errorf("shared payload entry %q must not be absolute", entryName)
 		}
 		return "", false, nil
 	}
 
-	trimmed := strings.TrimSuffix(normalized, "/")
-	if trimmed == "" {
+	if HasInvalidArchivePathSegments(parts) {
+		if payloadIndex >= 0 {
+			return "", true, fmt.Errorf("shared payload entry %q contains an invalid path segment", entryName)
+		}
 		return "", false, nil
 	}
 
-	parts := strings.Split(trimmed, "/")
-	hasReservedDir := false
-	for i, part := range parts {
-		if part == "" || part == "." || part == ".." {
-			if hasReservedDir || strings.Contains(normalized, reservedDir) {
-				return "", true, fmt.Errorf("reserved payload entry %q contains an invalid path segment", entryName)
-			}
-			return "", false, nil
-		}
-		if part != reservedDir {
-			continue
-		}
-		hasReservedDir = true
-		if i != 0 {
-			return "", true, fmt.Errorf("reserved payload directory %q must be at archive root", reservedDir)
-		}
-	}
-
-	if !hasReservedDir {
+	if payloadIndex < 0 {
 		return "", false, nil
+	}
+	if payloadIndex != 0 {
+		return "", true, fmt.Errorf("shared payload directory %q must be at archive root", payloadDir)
 	}
 
 	if len(parts) == 1 {

--- a/railyard/internal/files/asset_payload.go
+++ b/railyard/internal/files/asset_payload.go
@@ -72,6 +72,8 @@ func SharedAssetPayloadDir(assetType types.AssetType) string {
 // SharedAssetPayloadRelativePath validates a shared helper-folder entry and returns its relative path.
 func SharedAssetPayloadRelativePath(assetType types.AssetType, entryName string) (string, bool, error) {
 	payloadDir := SharedAssetPayloadDir(assetType)
+	// ZIP paths are slash-separated by convention, but some Windows tools emit
+	// backslashes; normalize before applying archive-path policy.
 	normalized, parts, ok := ArchiveEntryParts(entryName)
 	if !ok {
 		return "", false, nil
@@ -79,6 +81,8 @@ func SharedAssetPayloadRelativePath(assetType types.AssetType, entryName string)
 
 	payloadIndex := pathSegmentIndex(parts, payloadDir)
 	if hasArchivePathPrefix(normalized) {
+		// Absolute archive paths are not valid shared payload entries. If the
+		// payload folder appears there, fail the archive instead of ignoring it.
 		if payloadIndex >= 0 {
 			return "", true, fmt.Errorf("shared payload entry %q must not be absolute", entryName)
 		}
@@ -86,6 +90,8 @@ func SharedAssetPayloadRelativePath(assetType types.AssetType, entryName string)
 	}
 
 	if HasInvalidArchivePathSegments(parts) {
+		// Traversal-like entries are only this helper's concern when they target
+		// the shared payload folder; other archive validation remains separate.
 		if payloadIndex >= 0 {
 			return "", true, fmt.Errorf("shared payload entry %q contains an invalid path segment", entryName)
 		}
@@ -96,6 +102,8 @@ func SharedAssetPayloadRelativePath(assetType types.AssetType, entryName string)
 		return "", false, nil
 	}
 	if payloadIndex != 0 {
+		// v1 intentionally supports only a root-level .railyard_<asset> folder so
+		// consumers have one stable, discoverable path to probe.
 		return "", true, fmt.Errorf("shared payload directory %q must be at archive root", payloadDir)
 	}
 

--- a/railyard/internal/files/asset_payload_test.go
+++ b/railyard/internal/files/asset_payload_test.go
@@ -1,0 +1,51 @@
+package files
+
+import (
+	"testing"
+
+	"railyard/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedAssetPayloadRelativePathCrossPlatformEntries(t *testing.T) {
+	tests := []struct {
+		name         string
+		entryName    string
+		wantRelPath  string
+		wantIsShared bool
+		wantErr      bool
+	}{
+		{
+			name:         "normalizes windows separators",
+			entryName:    `.railyard_map\data\example.json`,
+			wantRelPath:  "data/example.json",
+			wantIsShared: true,
+		},
+		{
+			name:         "rejects windows drive path",
+			entryName:    `C:\.railyard_map\data\example.json`,
+			wantIsShared: true,
+			wantErr:      true,
+		},
+		{
+			name:         "rejects unc path",
+			entryName:    `\\server\share\.railyard_map\data\example.json`,
+			wantIsShared: true,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relPath, isSharedEntry, err := SharedAssetPayloadRelativePath(types.AssetTypeMap, tt.entryName)
+			require.Equal(t, tt.wantIsShared, isSharedEntry)
+			require.Equal(t, tt.wantRelPath, relPath)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/railyard/internal/files/map_validation.go
+++ b/railyard/internal/files/map_validation.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"strings"
 
 	"railyard/internal/paths"
 	"railyard/internal/types"
@@ -49,12 +48,12 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 	}
 
 	for _, file := range zipFiles {
-		if _, isHelperEntry, _ := ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name); isHelperEntry {
+		if _, isHelperEntry, _ := SharedAssetPayloadRelativePath(types.AssetTypeMap, file.Name); isHelperEntry {
 			continue
 		}
 
-		normalizedName := strings.ReplaceAll(strings.TrimSuffix(file.Name, "/"), "\\", "/")
-		if normalizedName == "" || strings.Contains(normalizedName, "/") {
+		normalizedName, ok := NormalizeArchiveEntryPath(file.Name)
+		if !ok || path.Base(normalizedName) != normalizedName {
 			continue
 		}
 
@@ -99,12 +98,12 @@ func ValidateMapArchive(filePath string) (types.ConfigData, types.DownloaderErro
 	}
 
 	for _, file := range reader.File {
-		relPath, isHelperEntry, helperErr := ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		relPath, isHelperEntry, helperErr := SharedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
 		if helperErr != nil {
 			return configData, types.InstallErrorInvalidArchive, helperErr
 		}
 		if isHelperEntry && relPath == "" && !file.FileInfo().IsDir() {
-			return configData, types.InstallErrorInvalidArchive, fmt.Errorf("reserved payload root %q must be a directory", ReservedAssetPayloadDir(types.AssetTypeMap))
+			return configData, types.InstallErrorInvalidArchive, fmt.Errorf("shared payload root %q must be a directory", SharedAssetPayloadDir(types.AssetTypeMap))
 		}
 	}
 

--- a/railyard/internal/files/map_validation.go
+++ b/railyard/internal/files/map_validation.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 
 	"railyard/internal/paths"
 	"railyard/internal/types"
@@ -48,7 +49,16 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 	}
 
 	for _, file := range zipFiles {
-		switch file.Name {
+		if _, isHelperEntry, _ := ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name); isHelperEntry {
+			continue
+		}
+
+		normalizedName := strings.ReplaceAll(strings.TrimSuffix(file.Name, "/"), "\\", "/")
+		if normalizedName == "" || strings.Contains(normalizedName, "/") {
+			continue
+		}
+
+		switch normalizedName {
 		case MapConfigFileName:
 			filesFound[MapArchiveKeyConfig] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
 		case MapDemandFileName:
@@ -62,10 +72,10 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 		case MapOceanDepthFileName:
 			filesFound[MapArchiveKeyOceanDepth] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
 		}
-		if path.Ext(file.Name) == MapTileFileExt {
+		if path.Ext(normalizedName) == MapTileFileExt {
 			filesFound[MapArchiveKeyTiles] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
 		}
-		if path.Ext(file.Name) == MapThumbnailFileExt {
+		if path.Ext(normalizedName) == MapThumbnailFileExt {
 			filesFound[MapArchiveKeyThumbnail] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
 		}
 	}
@@ -86,6 +96,16 @@ func ValidateMapArchive(filePath string) (types.ConfigData, types.DownloaderErro
 
 	if !requiredFilesPresent(filesFound) {
 		return configData, types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{"The map archive is missing one or more required files."}}
+	}
+
+	for _, file := range reader.File {
+		relPath, isHelperEntry, helperErr := ReservedAssetPayloadRelativePath(types.AssetTypeMap, file.Name)
+		if helperErr != nil {
+			return configData, types.InstallErrorInvalidArchive, helperErr
+		}
+		if isHelperEntry && relPath == "" && !file.FileInfo().IsDir() {
+			return configData, types.InstallErrorInvalidArchive, fmt.Errorf("reserved payload root %q must be a directory", ReservedAssetPayloadDir(types.AssetTypeMap))
+		}
 	}
 
 	configReader, err := filesFound[MapArchiveKeyConfig].FileObject.Open()

--- a/railyard/internal/files/map_validation_test.go
+++ b/railyard/internal/files/map_validation_test.go
@@ -40,6 +40,17 @@ func TestValidateMapArchive(t *testing.T) {
 			wantCode:    "AAA",
 		},
 		{
+			name: "valid archive with reserved payload",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f[".railyard_map/data/example.json"] = []byte(`{"ok":true}`)
+				return f
+			}(),
+			wantErrType: "",
+			wantErr:     false,
+			wantCode:    "AAA",
+		},
+		{
 			name: "missing required file",
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")
@@ -70,6 +81,36 @@ func TestValidateMapArchive(t *testing.T) {
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")
 				delete(f, "AAA.pmtiles")
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "rejects nested reserved payload folder",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f["nested/.railyard_map/data/example.json"] = []byte(`{"ok":true}`)
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "rejects unsafe reserved payload path traversal",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f[".railyard_map/../data/example.json"] = []byte(`{"ok":true}`)
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "rejects reserved payload root file",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f[".railyard_map"] = []byte(`not-a-dir`)
 				return f
 			}(),
 			wantErrType: types.InstallErrorInvalidArchive,

--- a/railyard/internal/files/map_validation_test.go
+++ b/railyard/internal/files/map_validation_test.go
@@ -40,7 +40,7 @@ func TestValidateMapArchive(t *testing.T) {
 			wantCode:    "AAA",
 		},
 		{
-			name: "valid archive with reserved payload",
+			name: "valid archive with shared payload",
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")
 				f[".railyard_map/data/example.json"] = []byte(`{"ok":true}`)
@@ -87,7 +87,18 @@ func TestValidateMapArchive(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name: "rejects nested reserved payload folder",
+			name: "accepts shared payload with windows separators",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f[".railyard_map\\data\\example.json"] = []byte(`{"ok":true}`)
+				return f
+			}(),
+			wantErrType: "",
+			wantErr:     false,
+			wantCode:    "AAA",
+		},
+		{
+			name: "rejects nested shared payload folder",
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")
 				f["nested/.railyard_map/data/example.json"] = []byte(`{"ok":true}`)
@@ -97,7 +108,17 @@ func TestValidateMapArchive(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name: "rejects unsafe reserved payload path traversal",
+			name: "rejects absolute shared payload path",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f["/.railyard_map/data/example.json"] = []byte(`{"ok":true}`)
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "rejects unsafe shared payload path traversal",
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")
 				f[".railyard_map/../data/example.json"] = []byte(`{"ok":true}`)
@@ -107,7 +128,7 @@ func TestValidateMapArchive(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name: "rejects reserved payload root file",
+			name: "rejects shared payload root file",
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")
 				f[".railyard_map"] = []byte(`not-a-dir`)

--- a/railyard/internal/testutil/registrytest/registry_mock_server.go
+++ b/railyard/internal/testutil/registrytest/registry_mock_server.go
@@ -21,6 +21,7 @@ type UpdateFixture struct {
 	Versions     []string
 	MapCode      string
 	FailVersions bool
+	ArchiveBytes []byte
 	// MissingModManifest serves a mod zip without manifest.json to exercise invalid-archive paths.
 	MissingModManifest bool
 }
@@ -162,6 +163,10 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 		}
 		for _, version := range current.Versions {
 			downloadPath := "/downloads/" + current.AssetID + "-" + version + ".zip"
+			if current.ArchiveBytes != nil {
+				zipByDownloadPath[downloadPath] = current.ArchiveBytes
+				continue
+			}
 			if current.AssetType == types.AssetTypeMap {
 				mapCode := current.MapCode
 				if mapCode == "" {


### PR DESCRIPTION
As stated in title. Allows for maps to conditionally provide .railyard_map top level in the ZIP. Bit complicated since map processing logic is not a simple copy like mods, but this should work.


Additional entries shown in download counts
<img width="388" height="139" alt="image" src="https://github.com/user-attachments/assets/06cc38d6-b619-4db5-9bb1-6e6e2009d8f4" />
<img width="1233" height="412" alt="image" src="https://github.com/user-attachments/assets/af0417e0-ba26-4176-8bc9-7eef34babfb4" />
