### PR TITLE
[Frontend] Fix download being enabled for assets with no valid version

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -14,7 +14,8 @@
     }
   },
   "dependencies": {
-    "@radix-ui/react-dialog": "^1.1.15"
+    "@radix-ui/react-dialog": "^1.1.15",
+    "shiki": "^4.0.1"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
@@ -33,7 +34,6 @@
     "lucide-react": ">=0.4",
     "radix-ui": ">=1.4",
     "react": "^19.0.0",
-    "shiki": ">=1",
     "tailwind-merge": ">=3"
   }
 }

--- a/packages/shared-ui/src/components/code-display.tsx
+++ b/packages/shared-ui/src/components/code-display.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { useEffect, useState, type CSSProperties } from 'react';
-import { cn } from '../lib/cn';
+
 import { TerminalFrame } from './terminal-frame';
 
 export type CodeDisplayProps = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,7 +229,7 @@ importers:
         specifier: '>=1.4'
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       shiki:
-        specifier: '>=1'
+        specifier: ^4.0.1
         version: 4.0.2
       tailwind-merge:
         specifier: '>=3'

--- a/railyard/frontend/src/components/project/ProjectHeader.tsx
+++ b/railyard/frontend/src/components/project/ProjectHeader.tsx
@@ -132,7 +132,12 @@ export function ProjectHeader({
   const installedVersion = getInstalledVersion(item.id);
   const installing = isInstalling(item.id);
   const uninstalling = isUninstalling(item.id);
-  const effectiveVersion = latestCompatibleVersion ?? latestVersion;
+  const noCompatibleVersion = Boolean(
+    gameVersion && latestVersion && !latestCompatibleVersion,
+  );
+  const effectiveVersion = noCompatibleVersion
+    ? undefined
+    : (latestCompatibleVersion ?? latestVersion);
   const [pendingLatestVersion, setPendingLatestVersion] = useState<
     string | null
   >(null);
@@ -176,8 +181,6 @@ export function ProjectHeader({
     installedVersion !== updateTargetVersion;
   const authorAlias = item.author.author_alias;
   const authorAttributionLink = item.author.attribution_link;
-  const noCompatibleVersion =
-    gameVersion && latestVersion && !latestCompatibleVersion;
 
   const doInstall = async (version: string, replaceOnConflict = false) => {
     try {
@@ -311,7 +314,9 @@ export function ProjectHeader({
         installUpdateTooltip = 'Uninstalling...';
         break;
       case !!noCompatibleVersion:
-        installUpdateTooltip = `No compatible version (game ${gameVersion})`;
+        installUpdateTooltip = latestVersion?.game_version
+          ? `Not compatible with your game version (you have ${gameVersion}, need ${latestVersion.game_version})`
+          : `No compatible version for game ${gameVersion}`;
         break;
       case !!effectiveVersion:
         installUpdateTooltip = `Install ${effectiveVersion!.version}`;
@@ -369,30 +374,32 @@ export function ProjectHeader({
         <div className="flex items-center gap-1">
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn(
-                  installing
-                    ? cn(
-                        UNINSTALL_ACCENT.iconButton,
-                        '!bg-[color-mix(in_srgb,var(--local-tone-primary)_20%,transparent)]',
-                      )
-                    : cn(installUpdateAccent.iconButton, ACTION_ICON_BASE),
-                )}
-                disabled={installUpdateDisabled}
-                onClick={() => {
-                  void handleInstallUpdateClick();
-                }}
-              >
-                {installing ? (
-                  <X />
-                ) : isInstalled ? (
-                  <CircleFadingArrowUp />
-                ) : (
-                  <Download />
-                )}
-              </Button>
+              <span className="inline-flex">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  className={cn(
+                    installing
+                      ? cn(
+                          UNINSTALL_ACCENT.iconButton,
+                          '!bg-[color-mix(in_srgb,var(--local-tone-primary)_20%,transparent)]',
+                        )
+                      : cn(installUpdateAccent.iconButton, ACTION_ICON_BASE),
+                  )}
+                  disabled={installUpdateDisabled}
+                  onClick={() => {
+                    void handleInstallUpdateClick();
+                  }}
+                >
+                  {installing ? (
+                    <X />
+                  ) : isInstalled ? (
+                    <CircleFadingArrowUp />
+                  ) : (
+                    <Download />
+                  )}
+                </Button>
+              </span>
             </TooltipTrigger>
             <TooltipContent>{installUpdateTooltip}</TooltipContent>
           </Tooltip>

--- a/railyard/frontend/src/lib/version-compatibility.test.ts
+++ b/railyard/frontend/src/lib/version-compatibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectLatestCompatibleVersion } from './version-compatibility';
+
+describe('selectLatestCompatibleVersion', () => {
+  const versions = [
+    { version: '2.0.0', game_version: '>=3.0.0' },
+    { version: '1.0.0', game_version: '>=1.0.0 <2.0.0' },
+  ];
+
+  it('returns the latest version when the game version is unknown', () => {
+    expect(selectLatestCompatibleVersion(versions, '')?.version).toBe('2.0.0');
+  });
+
+  it('returns the first compatible version for the current game version', () => {
+    expect(selectLatestCompatibleVersion(versions, '1.5.0')?.version).toBe(
+      '1.0.0',
+    );
+  });
+
+  it('does not fall back to an incompatible latest version', () => {
+    expect(selectLatestCompatibleVersion(versions, '2.5.0')).toBeUndefined();
+  });
+});

--- a/railyard/frontend/src/lib/version-compatibility.ts
+++ b/railyard/frontend/src/lib/version-compatibility.ts
@@ -1,0 +1,17 @@
+import { isCompatible } from '@/lib/semver';
+
+interface GameCompatibleVersion {
+  game_version: string;
+}
+
+export function selectLatestCompatibleVersion<T extends GameCompatibleVersion>(
+  versions: T[],
+  gameVersion: string,
+): T | undefined {
+  const latestVersion = versions[0];
+  if (!latestVersion || !gameVersion) return latestVersion;
+
+  return versions.find(
+    (version) => isCompatible(gameVersion, version.game_version) !== false,
+  );
+}

--- a/railyard/frontend/src/pages/ProjectPage.tsx
+++ b/railyard/frontend/src/pages/ProjectPage.tsx
@@ -24,7 +24,7 @@ import { Link, useRoute } from 'wouter';
 import { ProjectGallery } from '@/components/project/ProjectGallery';
 import { ProjectHeader } from '@/components/project/ProjectHeader';
 import { ProjectVersions } from '@/components/project/ProjectVersions';
-import { isCompatible } from '@/lib/semver';
+import { selectLatestCompatibleVersion } from '@/lib/version-compatibility';
 import { useRegistryStore } from '@/stores/registry-store';
 import { useUIStore } from '@/stores/ui-store';
 
@@ -136,13 +136,8 @@ export function ProjectPage() {
 
   const latestVersion = versions[0];
   const latestCompatibleVersion = useMemo(() => {
-    if (!gameVersion) return latestVersion;
-    return (
-      versions.find(
-        (v) => isCompatible(gameVersion, v.game_version) !== false,
-      ) ?? latestVersion
-    );
-  }, [versions, gameVersion, latestVersion]);
+    return selectLatestCompatibleVersion(versions, gameVersion);
+  }, [versions, gameVersion]);
 
   const totalDownloads = id
     ? type === 'mod'


### PR DESCRIPTION
Simple change... right now, when no compatible version exists, we fall back to latestVersion which enabled `ProjectHeader` regardless of actual user game version