### PR TITLE
[Backend/Frontend] Strict game version compatibility + country name search (expanded ISO)

### DIFF
--- a/packages/asset-listings-state/src/country-search.ts
+++ b/packages/asset-listings-state/src/country-search.ts
@@ -1,0 +1,128 @@
+const COUNTRY_CODE_PATTERN = /^[A-Za-z]{2}$/;
+const ENGLISH_REGION_NAMES = new Intl.DisplayNames(['en'], { type: 'region' });
+
+type CountrySearchOverride = {
+  exonym?: string;
+  endonym?: string;
+  aliases?: string[];
+};
+
+const COUNTRY_SEARCH_OVERRIDES: Record<string, CountrySearchOverride> = {
+  CI: {
+    aliases: ['Ivory Coast'],
+  },
+  CZ: {
+    aliases: ['Czech Republic'],
+  },
+  GB: {
+    aliases: ['UK', 'Britain', 'Great Britain'],
+  },
+  MK: {
+    aliases: ['Macedonia'],
+  },
+  MM: {
+    aliases: ['Burma'],
+  },
+  SZ: {
+    aliases: ['Swaziland'],
+  },
+  TL: {
+    aliases: ['East Timor'],
+  },
+  XK: {
+    exonym: 'Kosovo',
+    endonym: 'Kosove',
+  },
+};
+
+const countrySearchTermCache = new Map<string, string[]>();
+
+export function normalizeCountryCode(
+  code: string | null | undefined,
+): string | undefined {
+  const normalized = (code ?? '').trim().toUpperCase();
+  return COUNTRY_CODE_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+export function normalizeMapCountry(country: string | null | undefined): string {
+  return normalizeCountryCode(country) ?? '';
+}
+
+function uniqueTerms(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+
+  return result;
+}
+
+function toSearchTermVariants(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  const asciiFolded = trimmed.normalize('NFKD').replace(/\p{M}+/gu, '');
+  return uniqueTerms([trimmed, asciiFolded]);
+}
+
+function getRegionName(locale: string, code: string): string | undefined {
+  try {
+    const displayName =
+      locale === 'en'
+        ? ENGLISH_REGION_NAMES.of(code)
+        : new Intl.DisplayNames([locale], { type: 'region' }).of(code);
+    if (!displayName || displayName.toUpperCase() === code) {
+      return undefined;
+    }
+    return displayName;
+  } catch {
+    return undefined;
+  }
+}
+
+function getCountryEndonym(code: string): string | undefined {
+  try {
+    const locale = new Intl.Locale(`und-${code}`).maximize();
+    return getRegionName(locale.baseName, code);
+  } catch {
+    return undefined;
+  }
+}
+
+export function reverseIsoCountryCodeToNames(code: string): string[] {
+  const normalized = normalizeCountryCode(code);
+  if (!normalized) {
+    return [];
+  }
+
+  const cached = countrySearchTermCache.get(normalized);
+  if (cached) {
+    return cached;
+  }
+
+  const overrides = COUNTRY_SEARCH_OVERRIDES[normalized];
+  const terms = uniqueTerms([
+    normalized,
+    overrides?.exonym ?? getRegionName('en', normalized) ?? '',
+    overrides?.endonym ?? getCountryEndonym(normalized) ?? '',
+    ...(overrides?.aliases ?? []),
+  ]).flatMap(toSearchTermVariants);
+
+  const deduped = uniqueTerms(terms);
+  countrySearchTermCache.set(normalized, deduped);
+  return deduped;
+}
+
+export function buildCountryCodeSearchTerms(
+  country: string | null | undefined,
+): string[] {
+  const normalized = normalizeCountryCode(country);
+  return normalized ? reverseIsoCountryCodeToNames(normalized) : [];
+}

--- a/packages/asset-listings-state/src/filter-and-sort.test.ts
+++ b/packages/asset-listings-state/src/filter-and-sort.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildAssetSearchText,
   buildFilteredTaggedListingCounts,
   filterAndSortTaggedItems,
   matchesSingleValueFilter,
@@ -11,10 +12,17 @@ import {
   type TaggedListingAccessors,
   type TaggedListingItem,
 } from './filter-and-sort';
+import {
+  buildCountryCodeSearchTerms,
+  normalizeMapCountry,
+  reverseIsoCountryCodeToNames,
+} from './country-search';
 
 interface TestItem {
   id: string;
   name: string;
+  city_code?: string;
+  country?: string;
   tags?: string[];
   location?: string;
   quality?: string;
@@ -30,6 +38,15 @@ interface TestMapFilters {
 }
 
 type TestTaggedItem = TaggedListingItem<TestItem>;
+type SearchFilters = {
+  query: string;
+  type: 'mod' | 'map';
+  sort: { field: string; direction: 'asc' | 'desc' };
+  randomSeed: number;
+  perPage: number;
+  mod: { tags: string[] };
+  map: TestMapFilters;
+};
 
 const items: TestTaggedItem[] = [
   {
@@ -124,8 +141,78 @@ const accessors: TaggedListingAccessors<TestTaggedItem, TestMapFilters> = {
   dimensions: testDimensions,
 };
 
+const searchAccessors: TaggedListingAccessors<TestTaggedItem, TestMapFilters> = {
+  buildSearchText: (item) => buildAssetSearchText(item, () => ''),
+  dimensions: testDimensions,
+};
+
 const compareItems = (left: TestTaggedItem, right: TestTaggedItem) =>
   left.item.name.localeCompare(right.item.name);
+
+const searchFuseOptions = { keys: ['searchText'], threshold: 0.4 } as const;
+
+function getRegionEndonym(locale: string, code: string): string | undefined {
+  return new Intl.DisplayNames([locale], { type: 'region' }).of(code);
+}
+
+function foldAscii(value: string): string {
+  return value.normalize('NFKD').replace(/\p{M}+/gu, '');
+}
+
+function makeMapItem(overrides: Partial<TestItem> = {}): TestTaggedItem {
+  return {
+    type: 'map',
+    item: {
+      id: 'map-prague',
+      name: 'Prague Metro',
+      country: 'CZ',
+      city_code: 'PRG',
+      ...overrides,
+    },
+  };
+}
+
+function makeFilters(overrides: Partial<SearchFilters>): SearchFilters {
+  return {
+    query: '',
+    type: 'map',
+    sort: { field: 'name', direction: 'asc' },
+    randomSeed: 1,
+    perPage: 12,
+    mod: { tags: [] },
+    map: mapFilters,
+    ...overrides,
+  };
+}
+
+function runSearch(
+  searchItems: TestTaggedItem[],
+  filters: Partial<SearchFilters>,
+): TestTaggedItem[] {
+  return filterAndSortTaggedItems({
+    items: searchItems,
+    filters: makeFilters(filters),
+    modDownloadTotals: {},
+    mapDownloadTotals: {},
+    compareItems,
+    accessors: searchAccessors,
+    fuseOptions: searchFuseOptions,
+  });
+}
+
+function expectCountryAliasesPresent(
+  searchText: string,
+  code: string,
+  exonym: string,
+  endonym: string | undefined,
+) {
+  expect(searchText).toContain(code);
+  expect(searchText).toContain(exonym);
+  if (endonym) {
+    expect(searchText).toContain(endonym);
+    expect(searchText).toContain(foldAscii(endonym));
+  }
+}
 
 describe('filter helpers', () => {
   it('matches selected single values and many-values filters', () => {
@@ -133,6 +220,42 @@ describe('filter helpers', () => {
     expect(matchesSingleValueFilter('asia', ['europe'])).toBe(false);
     expect(matchesZeroOrManyValuesFilter(['ui', 'sim'], ['ui'])).toBe(true);
     expect(matchesZeroOrManyValuesFilter(['sim'], ['ui'])).toBe(false);
+  });
+});
+
+describe('country search helpers', () => {
+  it('normalizes ISO country codes once at the manifest boundary', () => {
+    expect(normalizeMapCountry(' cz ')).toBe('CZ');
+    expect(normalizeMapCountry(' Ukraine ')).toBe('');
+    expect(normalizeMapCountry('1!')).toBe('');
+    expect(normalizeMapCountry(undefined)).toBe('');
+  });
+
+  it('expands ISO country codes into exonym and endonym search terms', () => {
+    const czechEndonym = getRegionEndonym('cs-CZ', 'CZ');
+    const ukrainianEndonym = getRegionEndonym('uk-UA', 'UA');
+
+    expect(reverseIsoCountryCodeToNames('CZ')).toEqual(
+      expect.arrayContaining([
+        'CZ',
+        'Czechia',
+        'Czech Republic',
+        czechEndonym ?? '',
+      ]),
+    );
+    if (czechEndonym) {
+      expect(reverseIsoCountryCodeToNames('CZ')).toContain(foldAscii(czechEndonym));
+    }
+    expect(reverseIsoCountryCodeToNames('UA')).toEqual(
+      expect.arrayContaining(['UA', 'Ukraine', ukrainianEndonym ?? '']),
+    );
+    expect(reverseIsoCountryCodeToNames('GB')).toEqual(
+      expect.arrayContaining(['GB', 'United Kingdom', 'UK']),
+    );
+  });
+
+  it('keeps non-ISO country labels searchable without expansion', () => {
+    expect(buildCountryCodeSearchTerms('Czechia')).toEqual([]);
   });
 });
 
@@ -148,6 +271,13 @@ describe('seeded ordering', () => {
 });
 
 describe('filterAndSortTaggedItems', () => {
+  it('includes country aliases in map search text', () => {
+    const czechEndonym = getRegionEndonym('cs-CZ', 'CZ');
+    const searchText = buildAssetSearchText(makeMapItem(), () => '');
+
+    expectCountryAliasesPresent(searchText, 'CZ', 'Czechia', czechEndonym);
+  });
+
   it('filters by type, tags, and map attributes before sorting', () => {
     const result = filterAndSortTaggedItems({
       items,
@@ -169,7 +299,7 @@ describe('filterAndSortTaggedItems', () => {
       mapDownloadTotals: {},
       compareItems,
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(result.map((item) => item.item.id)).toEqual(['map-eu']);
@@ -178,23 +308,26 @@ describe('filterAndSortTaggedItems', () => {
   it('supports text search through Fuse', () => {
     const result = filterAndSortTaggedItems({
       items,
-      filters: {
+      filters: makeFilters({
         query: 'signal',
         type: 'mod',
-        sort: { field: 'name', direction: 'asc' },
-        randomSeed: 1,
-        perPage: 12,
-        mod: { tags: [] },
-        map: mapFilters,
-      },
+      }),
       modDownloadTotals: {},
       mapDownloadTotals: {},
       compareItems,
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(result.map((item) => item.item.id)).toEqual(['mod-sim']);
+  });
+
+  it('matches map queries against country exonyms and endonyms', () => {
+    const result = runSearch([makeMapItem()], {
+      query: 'cesko',
+    });
+
+    expect(result.map((item) => item.item.id)).toEqual(['map-prague']);
   });
 
   it('uses seeded random ordering when random sort is requested', () => {
@@ -213,7 +346,7 @@ describe('filterAndSortTaggedItems', () => {
       mapDownloadTotals: {},
       compareItems,
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(result.map((item) => item.item.id)).toEqual(
@@ -265,7 +398,7 @@ describe('filterAndSortTaggedItems', () => {
         },
       },
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(counts.mapCount).toBe(1);

--- a/packages/asset-listings-state/src/filter-and-sort.ts
+++ b/packages/asset-listings-state/src/filter-and-sort.ts
@@ -9,12 +9,19 @@ import {
   type SortState,
 } from '@subway-builder-modded/config';
 
+import { buildCountryCodeSearchTerms } from './country-search';
+
 type SearchableItem<TItem> = {
   entry: TItem;
   searchText: string;
 };
 
-const normalizedSearchTextCache = new WeakMap<object, string>();
+type CachedSearchText = {
+  raw: string;
+  normalized: string;
+};
+
+const searchTextCache = new WeakMap<object, CachedSearchText>();
 
 export interface TaggedListingItem<TItem = { id: string }> {
   type: AssetType;
@@ -49,7 +56,7 @@ export function buildAssetSearchText<TItem extends AssetSearchable>(
   } else {
     values.push(
       item.city_code ?? '',
-      item.country ?? '',
+      ...buildCountryCodeSearchTerms(item.country),
       item.location ?? '',
       item.source_quality ?? '',
       item.level_of_detail ?? '',
@@ -60,19 +67,22 @@ export function buildAssetSearchText<TItem extends AssetSearchable>(
   return values.filter(Boolean).join(' ');
 }
 
-// Cache lowercased search text per tagged item to avoid rebuilding it on each query.
-function getNormalizedSearchText<TTaggedItem extends TaggedListingItem>(
+function getCachedSearchText<TTaggedItem extends TaggedListingItem>(
   item: TTaggedItem,
   buildSearchText: (item: TTaggedItem) => string,
-): string {
-  const cached = normalizedSearchTextCache.get(item as object);
+): CachedSearchText {
+  const cached = searchTextCache.get(item as object);
   if (cached) {
     return cached;
   }
 
-  const normalized = buildSearchText(item).toLowerCase();
-  normalizedSearchTextCache.set(item as object, normalized);
-  return normalized;
+  const raw = buildSearchText(item);
+  const next = {
+    raw,
+    normalized: raw.toLowerCase(),
+  };
+  searchTextCache.set(item as object, next);
+  return next;
 }
 
 // Prefer a cheap token-inclusion match before falling back to fuzzy search.
@@ -91,8 +101,8 @@ function filterByQueryFastPath<TTaggedItem extends TaggedListingItem>(
   }
 
   return items.filter((item) => {
-    const searchText = getNormalizedSearchText(item, buildSearchText);
-    return normalizedTerms.every((term) => searchText.includes(term));
+    const searchText = getCachedSearchText(item, buildSearchText);
+    return normalizedTerms.every((term) => searchText.normalized.includes(term));
   });
 }
 
@@ -265,7 +275,7 @@ function filterTaggedItems<
     } else {
       const searchable: SearchableItem<TTaggedItem>[] = result.map((entry) => ({
         entry,
-        searchText: accessors.buildSearchText(entry),
+        searchText: getCachedSearchText(entry, accessors.buildSearchText).raw,
       }));
 
       const fuse = new Fuse(

--- a/packages/asset-listings-state/src/index.ts
+++ b/packages/asset-listings-state/src/index.ts
@@ -14,6 +14,12 @@ export {
 	type TaggedListingItem,
 } from './filter-and-sort';
 export {
+	buildCountryCodeSearchTerms,
+	normalizeCountryCode,
+	normalizeMapCountry,
+	reverseIsoCountryCodeToNames,
+} from './country-search';
+export {
 	createDefaultSourceFilters,
 	createSourceFilterByAssetType,
 	type AssetQueryFilterStoreState,

--- a/packages/asset-listings-ui/src/components/item-card.tsx
+++ b/packages/asset-listings-ui/src/components/item-card.tsx
@@ -82,7 +82,7 @@ function buildItemCardPresentation(
     isMap,
     badges: mapBadges,
     mapCityCode: isMap ? (city_code ?? '').trim() : '',
-    mapCountry: isMap ? (country ?? '').trim().toUpperCase() : '',
+    mapCountry: isMap ? (country ?? '') : '',
     mapPopulation: isMap ? population : undefined,
     showDownloads: typeof totalDownloads === 'number',
   };

--- a/railyard/app.go
+++ b/railyard/app.go
@@ -31,6 +31,7 @@ import (
 	"railyard/internal/updater"
 	"railyard/internal/utils"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/beescuit/asar"
 	"github.com/protomaps/go-pmtiles/pmtiles"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
@@ -343,19 +344,29 @@ func (a *App) cleanupTmpStaging(stage string) {
 }
 
 // GetGameVersion attempts to detect the installed Subway Builder version.
-// Returns an empty version with a warning status if detection fails.
+// Returns a semver-compliant version on success, or a warning response if detection fails.
 func (a *App) GetGameVersion() types.GameVersionResponse {
 	a.Logger.Info("Attempting to resolve game version")
 	if a.cachedGameVersion != (types.GameVersionResponse{}) {
 		a.Logger.Info("Returning cached game version", "version", a.cachedGameVersion.Version)
 		return a.cachedGameVersion
 	}
-	cfg := a.Config.GetConfig()
-	if !cfg.Validation.ExecutablePathValid {
-		return types.GameVersionResponse{
+
+	gameVersionNotDetected := func(message string, args ...any) types.GameVersionResponse {
+		if message != "" {
+			a.Logger.Warn(message, args...)
+		}
+		resp := types.GameVersionResponse{
 			GenericResponse: types.WarnResponse("Game version not detected"),
 			Version:         "",
 		}
+		a.cachedGameVersion = resp
+		return resp
+	}
+
+	cfg := a.Config.GetConfig()
+	if !cfg.Validation.ExecutablePathValid {
+		return gameVersionNotDetected("")
 	}
 	exePath := cfg.Config.ExecutablePath
 
@@ -368,41 +379,17 @@ func (a *App) GetGameVersion() types.GameVersionResponse {
 
 	archiveFile, err := os.Open(asarPath)
 	if err != nil {
-		a.Logger.Warn("Failed to open app.asar for game version detection", "error", err, "asarPath", asarPath)
-		a.cachedGameVersion = types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
-		return types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
+		return gameVersionNotDetected("Failed to open app.asar for game version detection", "error", err, "asarPath", asarPath)
 	}
 
 	archive, err := asar.Decode(archiveFile)
 	if err != nil {
-		a.Logger.Warn("Failed to decode app.asar for game version detection", "error", err, "asarPath", asarPath)
-		a.cachedGameVersion = types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
-		return types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
+		return gameVersionNotDetected("Failed to decode app.asar for game version detection", "error", err, "asarPath", asarPath)
 	}
 
 	packageFile := archive.Find("package.json")
 	if packageFile == nil {
-		a.Logger.Warn("Failed to find package.json in app.asar", "asarPath", asarPath)
-		a.cachedGameVersion = types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
-		return types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
+		return gameVersionNotDetected("Failed to find package.json in app.asar", "asarPath", asarPath)
 	}
 
 	packageReader := packageFile.Open()
@@ -411,21 +398,18 @@ func (a *App) GetGameVersion() types.GameVersionResponse {
 	}
 
 	if err := json.NewDecoder(packageReader).Decode(&pkg); err != nil {
-		a.Logger.Warn("Failed to decode package.json", "asarPath", asarPath, "error", err)
-		a.cachedGameVersion = types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
-		return types.GameVersionResponse{
-			GenericResponse: types.WarnResponse("Game version not detected"),
-			Version:         "",
-		}
+		return gameVersionNotDetected("Failed to decode package.json", "asarPath", asarPath, "error", err)
 	}
 
-	a.Logger.Info("Game version detected", "version", pkg.Version)
+	version := strings.TrimSpace(pkg.Version)
+	if _, err := semver.NewVersion(strings.TrimPrefix(version, "v")); err != nil {
+		return gameVersionNotDetected("Detected game version is not valid semver", "version", pkg.Version, "error", err)
+	}
+
+	a.Logger.Info("Game version detected", "version", version)
 	resp := types.GameVersionResponse{
 		GenericResponse: types.SuccessResponse("Game version detected"),
-		Version:         pkg.Version,
+		Version:         version,
 	}
 	a.cachedGameVersion = resp
 	return resp

--- a/railyard/frontend/src/components/library/LibraryList.tsx
+++ b/railyard/frontend/src/components/library/LibraryList.tsx
@@ -253,8 +253,8 @@ function LibraryListRow({
   const map = isMap ? (entry.item as types.MapManifest) : null;
 
   const mapCityCode = map?.city_code?.trim().toUpperCase() ?? '';
-  const mapCountry = map?.country?.trim().toUpperCase() ?? '';
-  const CountryFlag = isMap ? getCountryFlagIcon(mapCountry) : null;
+  const mapCountry = map?.country ?? '';
+  const CountryFlag = getCountryFlagIcon(mapCountry);
 
   const badges = isMap
     ? [

--- a/railyard/frontend/src/components/project/ProjectHeader.tsx
+++ b/railyard/frontend/src/components/project/ProjectHeader.tsx
@@ -132,8 +132,10 @@ export function ProjectHeader({
   const installedVersion = getInstalledVersion(item.id);
   const installing = isInstalling(item.id);
   const uninstalling = isUninstalling(item.id);
+  const requiresKnownGameVersion = type === 'map';
+  const missingGameVersion = requiresKnownGameVersion && !gameVersion.trim();
   const noCompatibleVersion = Boolean(
-    gameVersion && latestVersion && !latestCompatibleVersion,
+    latestVersion && !latestCompatibleVersion,
   );
   const effectiveVersion = noCompatibleVersion
     ? undefined
@@ -312,6 +314,9 @@ export function ProjectHeader({
         break;
       case uninstalling:
         installUpdateTooltip = 'Uninstalling...';
+        break;
+      case missingGameVersion:
+        installUpdateTooltip = 'Current game version could not be detected';
         break;
       case !!noCompatibleVersion:
         installUpdateTooltip = latestVersion?.game_version

--- a/railyard/frontend/src/components/project/ProjectHeader.tsx
+++ b/railyard/frontend/src/components/project/ProjectHeader.tsx
@@ -444,9 +444,8 @@ export function ProjectHeader({
       ].filter((v): v is string => Boolean(v))
     : (item.tags ?? []);
 
-  const CountryFlag = mapItem?.country
-    ? getCountryFlagIcon(mapItem.country.trim().toUpperCase())
-    : null;
+  const mapCountry = mapItem?.country ?? '';
+  const CountryFlag = getCountryFlagIcon(mapCountry);
 
   return (
     <>
@@ -479,7 +478,7 @@ export function ProjectHeader({
                         {CountryFlag && (
                           <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
                         )}
-                        <span>{mapItem.country.trim().toUpperCase()}</span>
+                        <span>{mapCountry}</span>
                       </span>
                     </>
                   )}

--- a/railyard/frontend/src/components/project/ProjectVersions.tsx
+++ b/railyard/frontend/src/components/project/ProjectVersions.tsx
@@ -38,7 +38,6 @@ import semver from 'semver';
 import { toast } from 'sonner';
 import { Link } from 'wouter';
 
-import { isCompatible } from '@/lib/semver';
 import {
   handleSubscriptionMutationError,
   useSubscriptionMutationLockState,
@@ -50,6 +49,7 @@ import {
   isCancellationSyncError,
   toSubscriptionSyncErrorState,
 } from '@/lib/subscription-sync-error';
+import { isVersionInstallable } from '@/lib/version-compatibility';
 import { useDownloadQueueStore } from '@/stores/download-queue-store';
 import {
   AssetConflictError,
@@ -235,8 +235,18 @@ export function ProjectVersions({
           const installing = isInstalling(itemId);
           const installingVersion = getInstallingVersion(itemId);
           const uninstalling = isUninstalling(itemId);
-          const compat = isCompatible(gameVersion, v.game_version);
-          const incompatible = compat === false;
+          const requireStrictCompatibility = type === 'map';
+          const installable = isVersionInstallable(
+            gameVersion,
+            v.game_version,
+            {
+              requireKnownGameVersion: requireStrictCompatibility,
+              requireExplicitCompatibility: requireStrictCompatibility,
+            },
+          );
+          const missingGameVersion =
+            requireStrictCompatibility && !gameVersion.trim();
+          const installBlocked = !installable;
 
           return (
             <ProjectVersionRow
@@ -250,7 +260,7 @@ export function ProjectVersions({
               date={v.date}
               downloads={v.downloads}
               changelogHref={`/project/${typeListingPath}/${itemId}/changelog/${encodeURIComponent(v.version)}`}
-              className={incompatible ? 'opacity-50' : undefined}
+              className={installBlocked ? 'opacity-50' : undefined}
               renderLink={(href, className, children) => (
                 <Link href={href} className={className}>
                   {children}
@@ -272,7 +282,7 @@ export function ProjectVersions({
                     <CheckCircle className="h-2.5 w-2.5" />
                     Installed
                   </Badge>
-                ) : incompatible ? (
+                ) : installBlocked ? (
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -288,8 +298,9 @@ export function ProjectVersions({
                         </span>
                       </TooltipTrigger>
                       <TooltipContent>
-                        Not compatible with your game version (you have{' '}
-                        {gameVersion}, need {v.game_version})
+                        {missingGameVersion
+                          ? 'Current game version could not be detected.'
+                          : `Not compatible with your game version (you have ${gameVersion}, need ${v.game_version})`}
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>

--- a/railyard/frontend/src/components/shared/ItemCard.tsx
+++ b/railyard/frontend/src/components/shared/ItemCard.tsx
@@ -38,7 +38,7 @@ export function ItemCard({
 }: ItemCardWrapperProps) {
   const isMap = isMapManifest(item);
   const mapItem = isMap ? (item as types.MapManifest) : null;
-  const CountryFlag = mapItem ? getCountryFlagIcon(mapItem.country) : null;
+  const CountryFlag = getCountryFlagIcon(mapItem?.country);
 
   const formatDescription = useMemo(() => {
     if (descriptionMode === 'preview') {
@@ -61,9 +61,7 @@ export function ItemCard({
       city_code={mapItem?.city_code}
       country={mapItem?.country}
       countryFlag={
-        CountryFlag ? (
-          <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
-        ) : undefined
+        CountryFlag && <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
       }
       location={mapItem?.location}
       source_quality={mapItem?.source_quality}

--- a/railyard/frontend/src/lib/version-compatibility.test.ts
+++ b/railyard/frontend/src/lib/version-compatibility.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { selectLatestCompatibleVersion } from './version-compatibility';
+import {
+  isVersionInstallable,
+  selectLatestCompatibleVersion,
+} from './version-compatibility';
 
 describe('selectLatestCompatibleVersion', () => {
   const versions = [
@@ -12,6 +15,15 @@ describe('selectLatestCompatibleVersion', () => {
     expect(selectLatestCompatibleVersion(versions, '')?.version).toBe('2.0.0');
   });
 
+  it('can require a known explicitly compatible game version', () => {
+    expect(
+      selectLatestCompatibleVersion(versions, '', {
+        requireKnownGameVersion: true,
+        requireExplicitCompatibility: true,
+      }),
+    ).toBeUndefined();
+  });
+
   it('returns the first compatible version for the current game version', () => {
     expect(selectLatestCompatibleVersion(versions, '1.5.0')?.version).toBe(
       '1.0.0',
@@ -20,5 +32,25 @@ describe('selectLatestCompatibleVersion', () => {
 
   it('does not fall back to an incompatible latest version', () => {
     expect(selectLatestCompatibleVersion(versions, '2.5.0')).toBeUndefined();
+  });
+});
+
+describe('isVersionInstallable', () => {
+  it('rejects unknown game versions when requested', () => {
+    expect(
+      isVersionInstallable('', '<=1.3.0', {
+        requireKnownGameVersion: true,
+        requireExplicitCompatibility: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects invalid explicit compatibility when requested', () => {
+    expect(
+      isVersionInstallable('1.3.0', 'definitely-not-a-range', {
+        requireKnownGameVersion: true,
+        requireExplicitCompatibility: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/railyard/frontend/src/lib/version-compatibility.ts
+++ b/railyard/frontend/src/lib/version-compatibility.ts
@@ -4,14 +4,49 @@ interface GameCompatibleVersion {
   game_version: string;
 }
 
+interface CompatibilityOptions {
+  requireKnownGameVersion?: boolean;
+  requireExplicitCompatibility?: boolean;
+}
+
+export function isVersionInstallable(
+  gameVersion: string,
+  requiredRange: string,
+  options: CompatibilityOptions = {},
+): boolean {
+  const {
+    requireKnownGameVersion = false,
+    requireExplicitCompatibility = false,
+  } = options;
+
+  if (!gameVersion) {
+    return !requireKnownGameVersion;
+  }
+
+  const compatibility = isCompatible(gameVersion, requiredRange);
+  return requireExplicitCompatibility
+    ? compatibility === true
+    : compatibility !== false;
+}
+
 export function selectLatestCompatibleVersion<T extends GameCompatibleVersion>(
   versions: T[],
   gameVersion: string,
+  options?: CompatibilityOptions,
 ): T | undefined {
   const latestVersion = versions[0];
-  if (!latestVersion || !gameVersion) return latestVersion;
+  if (!latestVersion) return undefined;
+  if (!gameVersion) {
+    return isVersionInstallable(
+      gameVersion,
+      latestVersion.game_version,
+      options,
+    )
+      ? latestVersion
+      : undefined;
+  }
 
-  return versions.find(
-    (version) => isCompatible(gameVersion, version.game_version) !== false,
+  return versions.find((version) =>
+    isVersionInstallable(gameVersion, version.game_version, options),
   );
 }

--- a/railyard/frontend/src/pages/ChangelogPage.tsx
+++ b/railyard/frontend/src/pages/ChangelogPage.tsx
@@ -50,7 +50,6 @@ import { toast } from 'sonner';
 import { Link, useRoute } from 'wouter';
 
 import { ChangelogDependencies } from '@/components/project/ChangelogDependencies';
-import { isCompatible } from '@/lib/semver';
 import {
   handleSubscriptionMutationError,
   useSubscriptionMutationLockState,
@@ -62,6 +61,7 @@ import {
   isCancellationSyncError,
   toSubscriptionSyncErrorState,
 } from '@/lib/subscription-sync-error';
+import { isVersionInstallable } from '@/lib/version-compatibility';
 import { useDownloadQueueStore } from '@/stores/download-queue-store';
 import {
   AssetConflictError,
@@ -257,12 +257,19 @@ export function ChangelogPage() {
 
   const doInstall = async (version: string, replaceOnConflict = false) => {
     if (!item || !type) return;
-    if (
-      versionInfo?.version === version &&
-      isCompatible(gameVersion, versionInfo.game_version) === false
-    ) {
+    const requireStrictCompatibility = type === 'map';
+    const installable =
+      versionInfo?.version === version
+        ? isVersionInstallable(gameVersion, versionInfo.game_version, {
+            requireKnownGameVersion: requireStrictCompatibility,
+            requireExplicitCompatibility: requireStrictCompatibility,
+          })
+        : true;
+    if (!installable) {
       toast.error(
-        `Cannot install ${version}: it is not compatible with game version ${gameVersion}.`,
+        !gameVersion.trim() && requireStrictCompatibility
+          ? `Cannot install ${version}: current game version could not be detected.`
+          : `Cannot install ${version}: it is not compatible with game version ${gameVersion}.`,
       );
       return;
     }
@@ -366,8 +373,18 @@ export function ChangelogPage() {
 
   const renderInstallButton = () => {
     if (!versionInfo) return null;
-    const compat = isCompatible(gameVersion, versionInfo.game_version);
-    const incompatible = compat === false;
+    const requireStrictCompatibility = type === 'map';
+    const installable = isVersionInstallable(
+      gameVersion,
+      versionInfo.game_version,
+      {
+        requireKnownGameVersion: requireStrictCompatibility,
+        requireExplicitCompatibility: requireStrictCompatibility,
+      },
+    );
+    const missingGameVersion =
+      requireStrictCompatibility && !gameVersion.trim();
+    const installBlocked = !installable;
 
     if (uninstalling) {
       return (
@@ -423,7 +440,7 @@ export function ChangelogPage() {
         </div>
       );
     }
-    if (incompatible) {
+    if (installBlocked) {
       return (
         <TooltipProvider>
           <Tooltip>
@@ -440,8 +457,9 @@ export function ChangelogPage() {
               </span>
             </TooltipTrigger>
             <TooltipContent>
-              Not compatible with your game version (you have {gameVersion},
-              need {versionInfo.game_version})
+              {missingGameVersion
+                ? 'Current game version could not be detected.'
+                : `Not compatible with your game version (you have ${gameVersion}, need ${versionInfo.game_version})`}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/railyard/frontend/src/pages/LibraryPage.tsx
+++ b/railyard/frontend/src/pages/LibraryPage.tsx
@@ -1,3 +1,4 @@
+import { normalizeMapCountry } from '@subway-builder-modded/asset-listings-state';
 import {
   AssetSidebarPanel,
   EmptyState,
@@ -103,7 +104,7 @@ function localMapManifestFromInstalled(
       config.creator,
     ),
     city_code: config.code,
-    country: config.country ?? '',
+    country: normalizeMapCountry(config.country),
     location: '',
     population: config.population,
     data_source: '',

--- a/railyard/frontend/src/pages/ProjectPage.tsx
+++ b/railyard/frontend/src/pages/ProjectPage.tsx
@@ -136,8 +136,11 @@ export function ProjectPage() {
 
   const latestVersion = versions[0];
   const latestCompatibleVersion = useMemo(() => {
-    return selectLatestCompatibleVersion(versions, gameVersion);
-  }, [versions, gameVersion]);
+    return selectLatestCompatibleVersion(versions, gameVersion, {
+      requireKnownGameVersion: type === 'map',
+      requireExplicitCompatibility: type === 'map',
+    });
+  }, [versions, gameVersion, type]);
 
   const totalDownloads = id
     ? type === 'mod'

--- a/railyard/internal/constants/mod_constants.go
+++ b/railyard/internal/constants/mod_constants.go
@@ -11,6 +11,10 @@ var MOD_VERSION string
 // GameDependencyKey is the manifest dependency key used to declare the required Subway Builder version.
 const GameDependencyKey = "subway-builder"
 
+// DefaultMapGameVersionConstraint is the compatibility range applied to map versions
+// that do not explicitly declare a game_version override.
+const DefaultMapGameVersionConstraint = "<=1.3.0"
+
 //go:embed mod_template.js
 var modTemplate string
 

--- a/railyard/internal/downloader/downloader_test.go
+++ b/railyard/internal/downloader/downloader_test.go
@@ -127,6 +127,12 @@ func newConfiguredDownloader(t *testing.T, withValidConfig bool) (*Downloader, *
 		Config:      cfg,
 		Logger:      logger.LoggerAtPath(""),
 		OnCancelled: func(string, types.AssetType, string) {},
+		GetGameVersion: func() types.GameVersionResponse {
+			return types.GameVersionResponse{
+				GenericResponse: types.SuccessResponse("Game version loaded"),
+				Version:         "1.3.0",
+			}
+		},
 	}
 	d.tempPath = t.TempDir()
 	d.mapTilePath = t.TempDir()
@@ -673,6 +679,12 @@ func TestCancelDuringExtractRemovesInstalledFiles(t *testing.T) {
 		Config:      cfg,
 		Logger:      logger.LoggerAtPath(""),
 		OnCancelled: func(string, types.AssetType, string) {}, // no-op for testing
+		GetGameVersion: func() types.GameVersionResponse {
+			return types.GameVersionResponse{
+				GenericResponse: types.SuccessResponse("Game version loaded"),
+				Version:         "1.3.0",
+			}
+		},
 	}
 	d.tempPath = t.TempDir()
 	d.mapTilePath = d.getMapTilePath()

--- a/railyard/internal/profiles/installable_versions.go
+++ b/railyard/internal/profiles/installable_versions.go
@@ -1,0 +1,96 @@
+package profiles
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"railyard/internal/constants"
+	"railyard/internal/types"
+
+	semver "github.com/Masterminds/semver/v3"
+)
+
+type installableVersionsFunc func(assetID string) ([]types.VersionInfo, error)
+
+// installableVersionsResolver resolves installable versions for profile operations.
+func (s *UserProfiles) installableVersionsResolver(assetType types.AssetType) installableVersionsFunc {
+	if assetType != types.AssetTypeMap {
+		return func(assetID string) ([]types.VersionInfo, error) {
+			return s.Registry.GetInstallableVersions(assetType, assetID)
+		}
+	}
+
+	var (
+		once           sync.Once
+		currentVersion *semver.Version
+		resolveErr     error
+	)
+
+	resolveCurrentVersion := func() (*semver.Version, error) {
+		once.Do(func() {
+			currentVersion, resolveErr = s.resolveCurrentGameVersion()
+		})
+		return currentVersion, resolveErr
+	}
+
+	return func(assetID string) ([]types.VersionInfo, error) {
+		versions, err := s.Registry.GetInstallableVersions(assetType, assetID)
+		if err != nil {
+			return nil, err
+		}
+
+		currentVersion, err := resolveCurrentVersion()
+		if err != nil {
+			return nil, err
+		}
+
+		return filterCompatibleMapVersions(versions, currentVersion), nil
+	}
+}
+
+// resolveCurrentGameVersion loads and parses the current game version for profile compatibility checks.
+func (s *UserProfiles) resolveCurrentGameVersion() (*semver.Version, error) {
+	if s.Downloader == nil || s.Downloader.GetGameVersion == nil {
+		return nil, fmt.Errorf("failed to resolve current game version")
+	}
+
+	gameVersionResp := s.Downloader.GetGameVersion()
+	if gameVersionResp.Status != types.ResponseSuccess {
+		return nil, fmt.Errorf("failed to resolve current game version")
+	}
+
+	gameVersion := strings.TrimSpace(gameVersionResp.Version)
+	currentVersion, err := semver.NewVersion(strings.TrimPrefix(gameVersion, "v"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse current game version %q: %w", gameVersion, err)
+	}
+
+	return currentVersion, nil
+}
+
+// filterCompatibleMapVersions keeps only map versions compatible with the current game version.
+func filterCompatibleMapVersions(versions []types.VersionInfo, currentVersion *semver.Version) []types.VersionInfo {
+	filtered := make([]types.VersionInfo, 0, len(versions))
+	for _, version := range versions {
+		if isCompatibleMapVersion(currentVersion, version.GameVersion) {
+			filtered = append(filtered, version)
+		}
+	}
+	return filtered
+}
+
+// isCompatibleMapVersion reports whether a map version is compatible with the current game version.
+func isCompatibleMapVersion(currentVersion *semver.Version, requiredRange string) bool {
+	requiredRange = strings.TrimSpace(requiredRange)
+	if requiredRange == "" {
+		return !currentVersion.GreaterThan(semver.MustParse(strings.TrimPrefix(constants.DefaultMapGameVersionConstraint, "<=")))
+	}
+
+	constraint, err := semver.NewConstraint(strings.TrimPrefix(requiredRange, "v"))
+	if err != nil {
+		return false
+	}
+
+	return constraint.Check(currentVersion)
+}

--- a/railyard/internal/profiles/profiles_sync.go
+++ b/railyard/internal/profiles/profiles_sync.go
@@ -92,12 +92,12 @@ type assetPurgeArgs struct {
 }
 
 // Helper struct to capture which functions are required to update subscriptions for a specific asset type, generic on the installed asset info type (T) and the manifest type (U).
-type assetSyncArgs[T any, U any] struct {
+type assetSyncArgs[T any] struct {
 	assetType     types.AssetType                                                 // The type of asset being synced: map or mod (or others in the future).
 	subscriptions map[string]string                                               // The desired subscription state for the profile, keyed by asset ID and valued by version.
 	isStale       func() bool                                                     // Returns true when the sync snapshot is stale due to a newer profile update.
 	installedArgs installedVersionArgs[T]                                         // Non-shared installed-version resolver args.
-	availableArgs availableVersionArgs[U]                                         // Non-shared available-version resolver args.
+	availableArgs availableVersionArgs                                            // Non-shared available-version resolver args.
 	install       func(assetID string, version string) types.AssetInstallResponse // The function to call to install the asset (using the downloader).
 	uninstall     func(assetID string) types.AssetUninstallResponse               // The function to call to uninstall the asset (using the downloader).
 }
@@ -110,17 +110,13 @@ type installedVersionArgs[T any] struct {
 }
 
 // Helper struct to capture what is needed to resolve available versions for a specific asset type via the registry.
-type availableVersionArgs[U any] struct {
-	getManifestsFn func() []U
-	idFn           func(U) string
-	updateTypeFn   func(U) string
-	updateSourceFn func(U) string
-	getVersionsFn  func(string, string) ([]types.VersionInfo, error)
+type availableVersionArgs struct {
+	getVersionsFn installableVersionsFunc
 }
 
 // TODO: Consolidate this into a generic argument builder using types.AssetType to reduce duplication
-func (s *UserProfiles) buildMapSyncArgs(profile types.UserProfile, isStale func() bool, replaceOnConflict bool) assetSyncArgs[types.InstalledMapInfo, types.MapManifest] {
-	return assetSyncArgs[types.InstalledMapInfo, types.MapManifest]{
+func (s *UserProfiles) buildMapSyncArgs(profile types.UserProfile, isStale func() bool, replaceOnConflict bool) assetSyncArgs[types.InstalledMapInfo] {
+	return assetSyncArgs[types.InstalledMapInfo]{
 		assetType:     types.AssetTypeMap,
 		subscriptions: profile.Subscriptions.Maps,
 		isStale:       isStale,
@@ -129,12 +125,8 @@ func (s *UserProfiles) buildMapSyncArgs(profile types.UserProfile, isStale func(
 			idFn:                 func(item types.InstalledMapInfo) string { return item.ID },
 			versionFn:            func(item types.InstalledMapInfo) string { return item.Version },
 		},
-		availableArgs: availableVersionArgs[types.MapManifest]{
-			getManifestsFn: s.Registry.GetMaps,
-			idFn:           func(item types.MapManifest) string { return item.ID },
-			updateTypeFn:   func(item types.MapManifest) string { return item.Update.Type },
-			updateSourceFn: func(item types.MapManifest) string { return item.Update.Source() },
-			getVersionsFn:  s.Registry.GetVersions,
+		availableArgs: availableVersionArgs{
+			getVersionsFn: s.installableVersionsResolver(types.AssetTypeMap),
 		},
 		install: func(assetID string, version string) types.AssetInstallResponse {
 			return s.Downloader.InstallAsset(types.InstallAssetRequest{
@@ -152,8 +144,8 @@ func (s *UserProfiles) buildMapSyncArgs(profile types.UserProfile, isStale func(
 	}
 }
 
-func (s *UserProfiles) buildModSyncArgs(profile types.UserProfile, isStale func() bool, skipDependencyInstall bool) assetSyncArgs[types.InstalledModInfo, types.ModManifest] {
-	return assetSyncArgs[types.InstalledModInfo, types.ModManifest]{
+func (s *UserProfiles) buildModSyncArgs(profile types.UserProfile, isStale func() bool, skipDependencyInstall bool) assetSyncArgs[types.InstalledModInfo] {
+	return assetSyncArgs[types.InstalledModInfo]{
 		assetType:     types.AssetTypeMod,
 		subscriptions: profile.Subscriptions.Mods,
 		isStale:       isStale,
@@ -162,12 +154,8 @@ func (s *UserProfiles) buildModSyncArgs(profile types.UserProfile, isStale func(
 			idFn:                 func(item types.InstalledModInfo) string { return item.ID },
 			versionFn:            func(item types.InstalledModInfo) string { return item.Version },
 		},
-		availableArgs: availableVersionArgs[types.ModManifest]{
-			getManifestsFn: s.Registry.GetMods,
-			idFn:           func(item types.ModManifest) string { return item.ID },
-			updateTypeFn:   func(item types.ModManifest) string { return item.Update.Type },
-			updateSourceFn: func(item types.ModManifest) string { return item.Update.Source() },
-			getVersionsFn:  s.Registry.GetVersions,
+		availableArgs: availableVersionArgs{
+			getVersionsFn: s.installableVersionsResolver(types.AssetTypeMod),
 		},
 		install: func(assetID string, version string) types.AssetInstallResponse {
 			return s.Downloader.InstallAsset(types.InstallAssetRequest{
@@ -186,7 +174,7 @@ func (s *UserProfiles) buildModSyncArgs(profile types.UserProfile, isStale func(
 }
 
 // syncAssetSubscriptions is a generic type helper that performs the core logic of syncing subscriptions for a given asset type, with generic arguments corresponding to the asset's installed info type (T) and manifest type (U).
-func syncAssetSubscriptions[T any, U any](log logger.Logger, profileID string, args assetSyncArgs[T, U]) ([]types.SubscriptionOperation, []types.UserProfilesError, []assetPurgeArgs, bool) {
+func syncAssetSubscriptions[T any](log logger.Logger, profileID string, args assetSyncArgs[T]) ([]types.SubscriptionOperation, []types.UserProfilesError, []assetPurgeArgs, bool) {
 	errs := make([]types.UserProfilesError, 0)
 	operations := make([]types.SubscriptionOperation, 0)
 	assetsToPurge := make([]assetPurgeArgs, 0)
@@ -196,12 +184,11 @@ func syncAssetSubscriptions[T any, U any](log logger.Logger, profileID string, a
 	}
 	assetType := args.assetType
 	installedVersion := buildVersionIndexFromItems(args.installedArgs)
-	availableVersions := buildAvailableVersionIndex(args.availableArgs, profileID, args.subscriptions, assetType, &errs)
+	availableVersions := make(map[string]map[string]struct{})
 
 	log.Info("Built version indices for sync",
 		"asset_type", args.assetType,
 		"installed_count", len(installedVersion),
-		"available_count", len(availableVersions),
 	)
 
 	for assetID, version := range args.subscriptions {
@@ -217,6 +204,19 @@ func syncAssetSubscriptions[T any, U any](log logger.Logger, profileID string, a
 		}
 
 		// Check if desired version is available according to the registry before attempting installation.
+		if _, ok := availableVersions[assetID]; !ok {
+			versions, err := args.availableArgs.getVersionsFn(assetID)
+			if err != nil {
+				errs = append(errs, updateSubscriptionError(profileID, assetID, assetType, types.ErrorLookupFailed, fmt.Errorf("Failed to resolve available versions for %s %q: %w", assetType, assetID, err)))
+				continue
+			}
+
+			availableVersions[assetID] = make(map[string]struct{}, len(versions))
+			for _, availableVersion := range versions {
+				availableVersions[assetID][strings.TrimSpace(availableVersion.Version)] = struct{}{}
+			}
+		}
+
 		if !isVersionAvailable(availableVersions, assetID, versionText) {
 			availableForAsset := availableVersions[assetID]
 			availableKeys := make([]string, 0, len(availableForAsset))
@@ -381,48 +381,6 @@ func buildVersionIndexFromItems[T any](args installedVersionArgs[T]) map[string]
 		versions[args.idFn(item)] = args.versionFn(item)
 	}
 	return versions
-}
-
-// buildAvailableVersionIndex makes use of the registry to build an index of available versions for each asset to which the profile is subscribed.
-func buildAvailableVersionIndex[U any](
-	availableArgs availableVersionArgs[U],
-	profileID string,
-	subscriptions map[string]string,
-	assetType types.AssetType,
-	syncErrors *[]types.UserProfilesError,
-) map[string]map[string]struct{} {
-	available := make(map[string]map[string]struct{})
-	manifestByID := make(map[string]U)
-
-	// Collect all available manifests and index by assetID for lookup.
-	for _, manifest := range availableArgs.getManifestsFn() {
-		manifestByID[availableArgs.idFn(manifest)] = manifest
-	}
-
-	for assetID := range subscriptions {
-		// If a particular assetID is not found in the registry's available manifests, skip and consider it to be "unavailable".
-		manifest, ok := manifestByID[assetID]
-		if !ok {
-			continue
-		}
-
-		// Determine which versions are available for this asset, based on its update configuration.
-		versions, err := availableArgs.getVersionsFn(
-			availableArgs.updateTypeFn(manifest),
-			availableArgs.updateSourceFn(manifest),
-		)
-		if err != nil {
-			*syncErrors = append(*syncErrors, updateSubscriptionError(profileID, assetID, assetType, types.ErrorLookupFailed, fmt.Errorf("Failed to resolve available versions for %s %q: %w", assetType, assetID, err)))
-			continue
-		}
-
-		available[assetID] = make(map[string]struct{}, len(versions))
-		for _, version := range versions {
-			available[assetID][strings.TrimSpace(version.Version)] = struct{}{}
-		}
-	}
-
-	return available
 }
 
 func isVersionAvailable(available map[string]map[string]struct{}, assetID string, version string) bool {

--- a/railyard/internal/profiles/profiles_sync_test.go
+++ b/railyard/internal/profiles/profiles_sync_test.go
@@ -73,6 +73,7 @@ func TestSyncSubscriptions(t *testing.T) {
 		initialMaps []types.InstalledMapInfo
 
 		prepare             func(t *testing.T, cfg *config.Config, reg *registry.Registry) func()
+		configureSvc        func(*UserProfiles)
 		assertSubscriptions func(t *testing.T, svc *UserProfiles)
 
 		expectedStatus     types.Status
@@ -174,12 +175,44 @@ func TestSyncSubscriptions(t *testing.T) {
 			},
 			// Error occurs during attempt to install unavailable errors
 			expectedErrors: []string{
-				`Subscribe mod "mod-b" failed`,
-				`Subscribe map "map-b" failed`,
+				`Failed to resolve available versions for map "map-b"`,
+				`Failed to resolve available versions for mod "mod-b"`,
 			},
 			expectedState: expectedState{
 				mods: []types.InstalledModInfo{},
 				maps: []types.InstalledMapInfo{},
+			},
+		},
+		{
+			name: "Sync blocks incompatible map installs before downloader execution",
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Maps["map-b"] = "1.0.0"
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			prepare: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
+				t.Helper()
+				configureConfig(t, cfg)
+				return mockRegistry(t, reg, []registryFixture{
+					{assetID: "map-b", versions: []string{"1.0.0"}, assetType: types.AssetTypeMap, mapCode: "BBB"},
+				})
+			},
+			configureSvc: func(svc *UserProfiles) {
+				svc.Downloader.GetGameVersion = func() types.GameVersionResponse {
+					return types.GameVersionResponse{
+						GenericResponse: types.SuccessResponse("Game version loaded"),
+						Version:         "1.3.1",
+					}
+				}
+			},
+			expectedErrors: []string{
+				`Subscribe map "map-b" failed: version "1.0.0" is not available`,
+			},
+			expectedState: expectedState{
+				mods: nil,
+				maps: nil,
 			},
 		},
 		{
@@ -287,7 +320,7 @@ func TestSyncSubscriptions(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`Subscribe map "map-a" failed`,
+				`Failed to resolve available versions for map "map-a"`,
 			},
 			expectedState: expectedState{
 				mods: nil,
@@ -352,6 +385,9 @@ func TestSyncSubscriptions(t *testing.T) {
 			testutil.NewHarness(t)
 
 			svc, cfg, reg := loadedUserProfilesServiceWithDependencies(t, tc.state)
+			if tc.configureSvc != nil {
+				tc.configureSvc(svc)
+			}
 			configureConfig(t, cfg)
 			for _, mod := range tc.initialMods {
 				reg.AddInstalledMod(mod.ID, mod.Version, false, nil)

--- a/railyard/internal/profiles/profiles_test.go
+++ b/railyard/internal/profiles/profiles_test.go
@@ -52,6 +52,12 @@ func userProfilesServiceWithDependencies(t *testing.T) (*UserProfiles, *config.C
 	l := testUserProfilesLogger(t)
 	reg := registry.NewRegistry(l, cfg)
 	dl := downloader.NewDownloader(cfg, reg, l)
+	dl.GetGameVersion = func() types.GameVersionResponse {
+		return types.GameVersionResponse{
+			GenericResponse: types.SuccessResponse("Game version loaded"),
+			Version:         "1.3.0",
+		}
+	}
 	return NewUserProfiles(reg, dl, l, cfg), cfg, reg
 }
 
@@ -85,6 +91,7 @@ type registryFixture struct {
 	assetID            string
 	assetType          types.AssetType
 	versions           []string
+	gameVersion        string
 	mapCode            string
 	failVersions       bool
 	missingModManifest bool
@@ -129,6 +136,7 @@ func mockRegistry(t *testing.T, reg *registry.Registry, fixtures []registryFixtu
 			AssetID:            f.assetID,
 			AssetType:          f.assetType,
 			Versions:           f.versions,
+			GameVersion:        f.gameVersion,
 			MapCode:            f.mapCode,
 			FailVersions:       f.failVersions,
 			MissingModManifest: f.missingModManifest,
@@ -206,8 +214,8 @@ func orDefault[T comparable](value, fallback T) T {
 }
 
 // TODO: Let's make this a function within the profiles.go so that we don't have to invoke this both in the main file and the test file...
-func mockMapAssetSyncArgs(fixture assetSyncTestFixture, install func(string, string) types.AssetInstallResponse, uninstall func(string) types.AssetUninstallResponse) assetSyncArgs[types.InstalledMapInfo, types.MapManifest] {
-	return assetSyncArgs[types.InstalledMapInfo, types.MapManifest]{
+func mockMapAssetSyncArgs(fixture assetSyncTestFixture, install func(string, string) types.AssetInstallResponse, uninstall func(string) types.AssetUninstallResponse) assetSyncArgs[types.InstalledMapInfo] {
+	return assetSyncArgs[types.InstalledMapInfo]{
 		assetType:     types.AssetTypeMap,
 		subscriptions: fixture.subscriptions,
 		installedArgs: installedVersionArgs[types.InstalledMapInfo]{
@@ -221,21 +229,9 @@ func mockMapAssetSyncArgs(fixture assetSyncTestFixture, install func(string, str
 			idFn:      func(item types.InstalledMapInfo) string { return item.ID },
 			versionFn: func(item types.InstalledMapInfo) string { return item.Version },
 		},
-		availableArgs: availableVersionArgs[types.MapManifest]{
-			getManifestsFn: func() []types.MapManifest {
-				manifests := make([]types.MapManifest, 0, len(fixture.availableVersions))
-				for assetID := range fixture.availableVersions {
-					manifest := registrytest.MockMapManifestWithIDAndCode(assetID, "AAA")
-					manifest.Update = types.UpdateConfig{Type: "custom", URL: assetID}
-					manifests = append(manifests, manifest)
-				}
-				return manifests
-			},
-			idFn:           func(item types.MapManifest) string { return item.ID },
-			updateTypeFn:   func(item types.MapManifest) string { return item.Update.Type },
-			updateSourceFn: func(item types.MapManifest) string { return item.Update.URL },
-			getVersionsFn: func(_ string, repoOrURL string) ([]types.VersionInfo, error) {
-				versions := fixture.availableVersions[repoOrURL]
+		availableArgs: availableVersionArgs{
+			getVersionsFn: func(assetID string) ([]types.VersionInfo, error) {
+				versions := fixture.availableVersions[assetID]
 				list := make([]types.VersionInfo, 0, len(versions))
 				for version := range versions {
 					list = append(list, types.VersionInfo{Version: version})
@@ -249,8 +245,8 @@ func mockMapAssetSyncArgs(fixture assetSyncTestFixture, install func(string, str
 }
 
 // TODO: Let's make this a function within the profiles.go so that we don't have to invoke this both in the main file and the test file...
-func mockModAssetSyncArgs(fixture assetSyncTestFixture, install func(string, string) types.AssetInstallResponse, uninstall func(string) types.AssetUninstallResponse) assetSyncArgs[types.InstalledModInfo, types.ModManifest] {
-	return assetSyncArgs[types.InstalledModInfo, types.ModManifest]{
+func mockModAssetSyncArgs(fixture assetSyncTestFixture, install func(string, string) types.AssetInstallResponse, uninstall func(string) types.AssetUninstallResponse) assetSyncArgs[types.InstalledModInfo] {
+	return assetSyncArgs[types.InstalledModInfo]{
 		assetType:     types.AssetTypeMod,
 		subscriptions: fixture.subscriptions,
 		installedArgs: installedVersionArgs[types.InstalledModInfo]{
@@ -264,21 +260,9 @@ func mockModAssetSyncArgs(fixture assetSyncTestFixture, install func(string, str
 			idFn:      func(item types.InstalledModInfo) string { return item.ID },
 			versionFn: func(item types.InstalledModInfo) string { return item.Version },
 		},
-		availableArgs: availableVersionArgs[types.ModManifest]{
-			getManifestsFn: func() []types.ModManifest {
-				manifests := make([]types.ModManifest, 0, len(fixture.availableVersions))
-				for assetID := range fixture.availableVersions {
-					manifest := registrytest.MockModManifestWithID(assetID)
-					manifest.Update = types.UpdateConfig{Type: "custom", URL: assetID}
-					manifests = append(manifests, manifest)
-				}
-				return manifests
-			},
-			idFn:           func(item types.ModManifest) string { return item.ID },
-			updateTypeFn:   func(item types.ModManifest) string { return item.Update.Type },
-			updateSourceFn: func(item types.ModManifest) string { return item.Update.URL },
-			getVersionsFn: func(_ string, repoOrURL string) ([]types.VersionInfo, error) {
-				versions := fixture.availableVersions[repoOrURL]
+		availableArgs: availableVersionArgs{
+			getVersionsFn: func(assetID string) ([]types.VersionInfo, error) {
+				versions := fixture.availableVersions[assetID]
 				list := make([]types.VersionInfo, 0, len(versions))
 				for version := range versions {
 					list = append(list, types.VersionInfo{Version: version})

--- a/railyard/internal/profiles/profiles_update.go
+++ b/railyard/internal/profiles/profiles_update.go
@@ -340,68 +340,47 @@ func (s *UserProfiles) resolveLatestSubscriptionUpdates(
 	targetSet := makeTargetSet(targets)
 
 	latestAssetUpdates(
-		latestSubscriptionArgs[types.MapManifest]{
+		latestSubscriptionArgs{
 			assetType:     types.AssetTypeMap,
 			subscriptions: profile.Subscriptions.Maps,
-			getManifests:  s.Registry.GetMaps,
-			idFn:          func(m types.MapManifest) string { return m.ID },
-			updateFn:      func(m types.MapManifest) types.UpdateConfig { return m.Update },
+			getVersionsFn: s.installableVersionsResolver(types.AssetTypeMap),
 		},
-		profileID, targetSet, s.Registry.GetVersions, updates, &pendingUpdates, &warnings,
+		profileID, targetSet, updates, &pendingUpdates, &warnings,
 	)
 
 	latestAssetUpdates(
-		latestSubscriptionArgs[types.ModManifest]{
+		latestSubscriptionArgs{
 			assetType:     types.AssetTypeMod,
 			subscriptions: profile.Subscriptions.Mods,
-			getManifests:  s.Registry.GetMods,
-			idFn:          func(m types.ModManifest) string { return m.ID },
-			updateFn:      func(m types.ModManifest) types.UpdateConfig { return m.Update },
+			getVersionsFn: s.installableVersionsResolver(types.AssetTypeMod),
 		},
-		profileID, targetSet, s.Registry.GetVersions, updates, &pendingUpdates, &warnings,
+		profileID, targetSet, updates, &pendingUpdates, &warnings,
 	)
 
 	return updates, pendingUpdates, warnings
 }
 
-type latestSubscriptionArgs[T any] struct {
+type latestSubscriptionArgs struct {
 	assetType     types.AssetType
 	subscriptions map[string]string
-	getManifests  func() []T
-	idFn          func(T) string
-	updateFn      func(T) types.UpdateConfig
+	getVersionsFn installableVersionsFunc
 }
 
-func latestAssetUpdates[T any](
-	args latestSubscriptionArgs[T],
+func latestAssetUpdates(
+	args latestSubscriptionArgs,
 	profileID string,
 	targetSet map[assetVersionKey]struct{},
-	getVersionsFn func(string, string) ([]types.VersionInfo, error),
 	updates map[string]types.SubscriptionUpdateItem,
 	pendingUpdates *[]types.PendingSubscriptionUpdate,
 	errors *[]types.UserProfilesError,
 ) {
-	manifestUpdateByID := make(map[string]types.UpdateConfig)
-	for _, manifest := range args.getManifests() {
-		manifestUpdateByID[args.idFn(manifest)] = args.updateFn(manifest)
-	}
-
 	for assetID, currentVersion := range args.subscriptions {
 		// Check if the asset is within the requested update targets (if any were given)
 		if !shouldUpdate(targetSet, args.assetType, assetID) {
 			continue
 		}
 
-		update, ok := manifestUpdateByID[assetID]
-		if !ok {
-			*errors = append(*errors, updateSubscriptionError(
-				profileID, assetID, args.assetType, types.ErrorLookupFailed,
-				fmt.Errorf("Asset %q missing from registry manifests for %s", assetID, args.assetType),
-			))
-			continue
-		}
-
-		latestVersion, resolveErr := resolveLatestVersionForManifest(update, getVersionsFn)
+		latestVersion, resolveErr := resolveLatestVersion(assetID, args.getVersionsFn)
 		if resolveErr != nil {
 			*errors = append(*errors, updateSubscriptionError(
 				profileID, assetID, args.assetType, types.ErrorLookupFailed,
@@ -452,11 +431,11 @@ func shouldUpdate(targetSet map[assetVersionKey]struct{}, assetType types.AssetT
 	return ok
 }
 
-func resolveLatestVersionForManifest(
-	update types.UpdateConfig,
-	getVersionsFn func(string, string) ([]types.VersionInfo, error),
+func resolveLatestVersion(
+	assetID string,
+	getVersionsFn installableVersionsFunc,
 ) (string, error) {
-	versions, err := getVersionsFn(update.Type, update.Source())
+	versions, err := getVersionsFn(assetID)
 	if err != nil {
 		return "", fmt.Errorf("Failed to resolve versions: %w", err)
 	}

--- a/railyard/internal/profiles/profiles_update_test.go
+++ b/railyard/internal/profiles/profiles_update_test.go
@@ -452,6 +452,7 @@ func TestUpdateSubscriptionsToLatest(t *testing.T) {
 		targets      []types.SubscriptionUpdateTarget
 		state        types.UserProfilesState
 		setup        func(t *testing.T, cfg *config.Config, reg *registry.Registry) func()
+		configureSvc func(*UserProfiles)
 		expected     expectation
 		assertResult func(t *testing.T, svc *UserProfiles, reg *registry.Registry, result types.UpdateSubscriptionsResult)
 	}{
@@ -508,6 +509,60 @@ func TestUpdateSubscriptionsToLatest(t *testing.T) {
 				require.Len(t, reg.GetInstalledMods(), 1)
 				require.Equal(t, "mod-a", reg.GetInstalledMods()[0].ID)
 				require.Equal(t, "1.5.0", reg.GetInstalledMods()[0].Version)
+			},
+		},
+		{
+			name:      "Incompatible map updates are skipped during latest resolution",
+			profileID: types.DefaultProfileID,
+			apply:     false,
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Maps["map-a"] = "1.0.0"
+				profile.Subscriptions.Mods["mod-a"] = "1.0.0"
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			setup: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
+				t.Helper()
+				configureConfig(t, cfg)
+				return mockRegistry(t, reg, []registryFixture{
+					{
+						assetID:   "map-a",
+						assetType: types.AssetTypeMap,
+						versions:  []string{"1.0.0", "1.1.0"},
+						mapCode:   "AAA",
+					},
+					{
+						assetID:   "mod-a",
+						assetType: types.AssetTypeMod,
+						versions:  []string{"1.0.0", "1.5.0"},
+					},
+				})
+			},
+			configureSvc: func(svc *UserProfiles) {
+				svc.Downloader.GetGameVersion = func() types.GameVersionResponse {
+					return types.GameVersionResponse{
+						GenericResponse: types.SuccessResponse("Game version loaded"),
+						Version:         "1.3.1",
+					}
+				}
+			},
+			expected: expectation{
+				expectedStatus:       types.ResponseWarn,
+				expectedRequestType:  types.LatestCheck,
+				expectedHasUpdates:   true,
+				expectedPendingCount: 1,
+				expectedPendingByKey: map[string][2]string{
+					"mod:mod-a": {"1.0.0", "1.5.0"},
+				},
+				expectedApplied:         false,
+				expectedPersisted:       false,
+				expectedOperationByID:   map[string]string{},
+				expectedMapSubscription: "1.0.0",
+				expectedModID:           "mod-a",
+				expectedModSubscription: "1.0.0",
+				expectedWarnContains:    "Resolved update availability with 1 warning(s)",
 			},
 		},
 		{
@@ -807,6 +862,9 @@ func TestUpdateSubscriptionsToLatest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testutil.NewHarness(t)
 			svc, cfg, reg := loadedUserProfilesServiceWithDependencies(t, tc.state)
+			if tc.configureSvc != nil {
+				tc.configureSvc(svc)
+			}
 			var cleanup func()
 			if tc.setup != nil {
 				cleanup = tc.setup(t, cfg, reg)

--- a/railyard/internal/registry/installable_versions.go
+++ b/railyard/internal/registry/installable_versions.go
@@ -2,9 +2,14 @@ package registry
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
+	"railyard/internal/constants"
 	"railyard/internal/types"
 )
+
+var mapSchemaCompatibilityCutoff = time.Date(2026, time.May, 18, 0, 0, 0, 0, time.UTC)
 
 // getIntegrityListing returns the integrity entry for the requested asset.
 func (r *Registry) getIntegrityListing(assetType types.AssetType, assetID string) (types.IntegrityListing, bool) {
@@ -73,6 +78,57 @@ func (r *Registry) filterVersionsByIntegrity(
 	return filtered, nil
 }
 
+// applyMapGameVersionPolicy enforces map-specific compatibility defaults and cutoffs.
+func applyMapGameVersionPolicy(versions []types.VersionInfo) {
+	for i := range versions {
+		if strings.TrimSpace(versions[i].GameVersion) == "" {
+			versions[i].GameVersion = constants.DefaultMapGameVersionConstraint
+			continue
+		}
+
+		if !isOnOrBeforeMapSchemaCompatibilityCutoff(versions[i].Date) {
+			continue
+		}
+
+		// Subway Builder 1.3.1 introduces a schema-breaking map change. Keep the
+		// 2026-05-18 (Monday) cutoff hardcoded so any map published on or before
+		// that date stays capped at 1.3.0 unless the policy is intentionally
+		// revised here.
+		versions[i].GameVersion = strings.TrimSpace(versions[i].GameVersion + " " + constants.DefaultMapGameVersionConstraint)
+	}
+}
+
+// isOnOrBeforeMapSchemaCompatibilityCutoff reports whether the version date falls on or before the schema cutoff.
+func isOnOrBeforeMapSchemaCompatibilityCutoff(rawDate string) bool {
+	publishedAt, ok := parseMapPolicyVersionDate(rawDate)
+	return ok && !publishedAt.After(mapSchemaCompatibilityCutoff)
+}
+
+// parseMapPolicyVersionDate parses supported version date formats into a UTC day value.
+func parseMapPolicyVersionDate(rawDate string) (time.Time, bool) {
+	trimmed := strings.TrimSpace(rawDate)
+	if trimmed == "" {
+		return time.Time{}, false
+	}
+
+	layout := time.DateOnly
+	if strings.Contains(trimmed, "T") {
+		layout = time.RFC3339Nano
+	}
+
+	parsed, err := time.Parse(layout, trimmed)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	parsed = parsed.UTC()
+	if layout == time.DateOnly {
+		return parsed, true
+	}
+
+	return time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, time.UTC), true
+}
+
 // GetInstallableVersions returns the integrity-approved versions for an asset.
 func (r *Registry) GetInstallableVersions(assetType types.AssetType, assetID string) ([]types.VersionInfo, error) {
 	updateType, source, err := r.resolveAssetUpdateSource(assetType, assetID)
@@ -85,7 +141,16 @@ func (r *Registry) GetInstallableVersions(assetType types.AssetType, assetID str
 		return nil, err
 	}
 
-	return r.filterVersionsByIntegrity(assetType, assetID, versions)
+	filtered, err := r.filterVersionsByIntegrity(assetType, assetID, versions)
+	if err != nil {
+		return nil, err
+	}
+
+	if assetType == types.AssetTypeMap {
+		applyMapGameVersionPolicy(filtered)
+	}
+
+	return filtered, nil
 }
 
 // GetInstallableVersionsResponse returns installable versions with response metadata.

--- a/railyard/internal/registry/integrity_test.go
+++ b/railyard/internal/registry/integrity_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"testing"
+	"time"
 
 	"railyard/internal/config"
 	"railyard/internal/testutil"
@@ -50,6 +51,8 @@ func TestGetInstallableVersions(t *testing.T) {
 	require.Len(t, filtered, 2)
 	require.Equal(t, "1.1.0", filtered[0].Version)
 	require.Equal(t, "1.0.0", filtered[1].Version)
+	require.Equal(t, "<=1.3.0", filtered[0].GameVersion)
+	require.Equal(t, "<=1.3.0", filtered[1].GameVersion)
 }
 
 func TestGetInstallableVersionsRejectsMissingOrIncompleteListings(t *testing.T) {
@@ -91,4 +94,93 @@ func TestGetInstallableVersionsRejectsMissingOrIncompleteListings(t *testing.T) 
 
 	_, err = reg.GetInstallableVersions(types.AssetTypeMap, "map-a")
 	require.ErrorContains(t, err, "has no complete versions")
+}
+
+func TestGetInstallableVersionsPreservesExplicitMapGameVersion(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	registrytest.SetManifestsForTest(t, reg, nil, []types.MapManifest{
+		func() types.MapManifest {
+			manifest := registrytest.MockMapManifestWithIDAndCode("map-a", "AAA")
+			manifest.Update = types.UpdateConfig{
+				Type: "custom",
+				URL:  "https://example.com/update.json",
+			}
+			return manifest
+		}(),
+	})
+	reg.integrityMaps = types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings: map[string]types.IntegrityListing{
+			"map-a": {
+				HasCompleteVersion: true,
+				CompleteVersions:   []string{"1.1.0"},
+				Versions: map[string]types.IntegrityVersionStatus{
+					"1.1.0": {IsComplete: true},
+				},
+			},
+		},
+	}
+	reg.setCachedVersions("custom|https://example.com/update.json", []types.VersionInfo{
+		{Version: "1.1.0", GameVersion: ">=1.0.0 <=1.3.1", Date: "2026-05-19"},
+	})
+
+	filtered, err := reg.GetInstallableVersions(types.AssetTypeMap, "map-a")
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	require.Equal(t, ">=1.0.0 <=1.3.1", filtered[0].GameVersion)
+}
+
+func TestGetInstallableVersionsCapsExplicitMapGameVersionOnSchemaCutoffOrEarlier(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	registrytest.SetManifestsForTest(t, reg, nil, []types.MapManifest{
+		func() types.MapManifest {
+			manifest := registrytest.MockMapManifestWithIDAndCode("map-a", "AAA")
+			manifest.Update = types.UpdateConfig{
+				Type: "custom",
+				URL:  "https://example.com/update.json",
+			}
+			return manifest
+		}(),
+	})
+	reg.integrityMaps = types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings: map[string]types.IntegrityListing{
+			"map-a": {
+				HasCompleteVersion: true,
+				CompleteVersions:   []string{"1.1.0"},
+				Versions: map[string]types.IntegrityVersionStatus{
+					"1.1.0": {IsComplete: true},
+				},
+			},
+		},
+	}
+	reg.setCachedVersions("custom|https://example.com/update.json", []types.VersionInfo{
+		{Version: "1.1.0", GameVersion: ">=1.0.0 <=1.4.0", Date: "2026-05-18"},
+	})
+
+	filtered, err := reg.GetInstallableVersions(types.AssetTypeMap, "map-a")
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	require.Equal(t, ">=1.0.0 <=1.4.0 <=1.3.0", filtered[0].GameVersion)
+}
+
+func TestParseMapPolicyVersionDate(t *testing.T) {
+	t.Run("date only", func(t *testing.T) {
+		parsed, ok := parseMapPolicyVersionDate("2026-05-18")
+		require.True(t, ok)
+		require.Equal(t, time.Date(2026, time.May, 18, 0, 0, 0, 0, time.UTC), parsed)
+	})
+
+	t.Run("rfc3339", func(t *testing.T) {
+		parsed, ok := parseMapPolicyVersionDate("2026-05-18T22:30:00-04:00")
+		require.True(t, ok)
+		require.Equal(t, time.Date(2026, time.May, 19, 0, 0, 0, 0, time.UTC), parsed)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, ok := parseMapPolicyVersionDate("2026/05/12")
+		require.False(t, ok)
+	})
 }

--- a/railyard/internal/registry/manifests.go
+++ b/railyard/internal/registry/manifests.go
@@ -151,7 +151,7 @@ func (r *Registry) convertMapManifests(
 		return types.MapManifest{
 			AssetManifest:    manifest,
 			CityCode:         raw.CityCode,
-			Country:          raw.Country,
+			Country:          normalizeMapCountry(raw.Country),
 			Location:         raw.Location,
 			Population:       raw.Population,
 			DataSource:       raw.DataSource,

--- a/railyard/internal/registry/map_country.go
+++ b/railyard/internal/registry/map_country.go
@@ -1,0 +1,19 @@
+package registry
+
+import "strings"
+
+// normalizeMapCountry returns a canonical ISO-style country code or an empty string.
+func normalizeMapCountry(country string) string {
+	country = strings.TrimSpace(country)
+	if len(country) != 2 {
+		return ""
+	}
+
+	for _, ch := range country {
+		if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') {
+			return ""
+		}
+	}
+
+	return strings.ToUpper(country)
+}

--- a/railyard/internal/registry/map_country_test.go
+++ b/railyard/internal/registry/map_country_test.go
@@ -1,0 +1,39 @@
+package registry
+
+import "testing"
+
+func TestNormalizeMapCountry(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "uppercases and trims ISO codes",
+			input:    " cz ",
+			expected: "CZ",
+		},
+		{
+			name:     "discards non ISO labels",
+			input:    " Ukraine ",
+			expected: "",
+		},
+		{
+			name:     "discards invalid two-character labels",
+			input:    "1!",
+			expected: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if actual := normalizeMapCountry(testCase.input); actual != testCase.expected {
+				t.Fatalf("normalizeMapCountry(%q) = %q, expected %q", testCase.input, actual, testCase.expected)
+			}
+		})
+	}
+}

--- a/railyard/internal/testutil/registrytest/registry_mock_server.go
+++ b/railyard/internal/testutil/registrytest/registry_mock_server.go
@@ -19,6 +19,7 @@ type UpdateFixture struct {
 	AssetID      string
 	AssetType    types.AssetType
 	Versions     []string
+	GameVersion  string
 	MapCode      string
 	FailVersions bool
 	ArchiveBytes []byte
@@ -146,8 +147,9 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 			for _, version := range current.Versions {
 				downloadPath := "/downloads/" + current.AssetID + "-" + version + ".zip"
 				payload.Versions = append(payload.Versions, types.CustomUpdateVersion{
-					Version:  version,
-					Download: "http://" + r.Host + downloadPath,
+					Version:     version,
+					GameVersion: current.GameVersion,
+					Download:    "http://" + r.Host + downloadPath,
 				})
 			}
 

--- a/website/features/railyard/components/item-card.tsx
+++ b/website/features/railyard/components/item-card.tsx
@@ -41,7 +41,7 @@ export function ItemCard({
 }: ItemCardWrapperProps) {
   const isMap = isMapManifest(item);
   const mapItem = isMap ? (item as MapManifest) : null;
-  const CountryFlag = mapItem ? getCountryFlagIcon(mapItem.country) : null;
+  const CountryFlag = getCountryFlagIcon(mapItem?.country);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const formatDescription = useMemo(() => {
@@ -71,9 +71,7 @@ export function ItemCard({
       city_code={mapItem?.city_code}
       country={mapItem?.country}
       countryFlag={
-        CountryFlag ? (
-          <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
-        ) : undefined
+        CountryFlag && <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
       }
       location={mapItem?.location}
       source_quality={mapItem?.source_quality}

--- a/website/features/railyard/components/project-header.tsx
+++ b/website/features/railyard/components/project-header.tsx
@@ -46,10 +46,8 @@ export function ProjectHeader({
       ].filter((v): v is string => Boolean(v))
     : (item.tags ?? []);
 
-  const mapCountryCode = mapItem?.country?.trim().toUpperCase();
-  const CountryFlag = mapCountryCode
-    ? getCountryFlagIcon(mapCountryCode)
-    : null;
+  const mapCountry = mapItem?.country ?? '';
+  const CountryFlag = getCountryFlagIcon(mapCountry);
   const authorHref = getAuthorAttributionHref(item);
 
   const handleOpenInRailyard = () => {
@@ -97,7 +95,7 @@ export function ProjectHeader({
                         createElement(CountryFlag, {
                           className: 'h-3.5 w-5 rounded-[1px]',
                         })}
-                      <span>{mapItem.country.trim().toUpperCase()}</span>
+                      <span>{mapCountry}</span>
                     </span>
                   </>
                 )}

--- a/website/hooks/use-registry-item.ts
+++ b/website/hooks/use-registry-item.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { enrichAuthorIdentity } from '@/lib/authors';
+import { normalizeRegistryManifest } from '@/lib/railyard/manifest-normalization';
 import { getRegistryAuthorDirectory } from '@/lib/railyard/registry-author-directory';
 import { fetchRegistryJsonWithFallback } from '@/lib/railyard/registry-source';
 import type { ModManifest, MapManifest } from '@/types/registry';
@@ -32,7 +33,14 @@ export function useRegistryItem(
           ModManifest | MapManifest
         >(`${type}/${id}/manifest.json`);
         const authorDirectory = await getRegistryAuthorDirectory();
-        if (!cancelled) setItem(enrichAuthorIdentity(data, authorDirectory));
+        if (!cancelled) {
+          setItem(
+            enrichAuthorIdentity(
+              normalizeRegistryManifest(data),
+              authorDirectory,
+            ),
+          );
+        }
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Failed to load item');

--- a/website/hooks/use-registry.ts
+++ b/website/hooks/use-registry.ts
@@ -13,6 +13,7 @@ import {
   getRawRegistryUrls,
   getRegistryCdnUrls,
 } from '@/lib/railyard/registry-source';
+import { normalizeRegistryManifest } from '@/lib/railyard/manifest-normalization';
 import type {
   AssetDownloadCountsByVersion,
   ModManifest,
@@ -44,7 +45,10 @@ async function fetchIndex(type: 'mods' | 'maps'): Promise<string[]> {
 }
 
 async function fetchManifest<T>(type: 'mods' | 'maps', id: string): Promise<T> {
-  return fetchRegistryJsonWithFallback<T>(`${type}/${id}/manifest.json`);
+  const manifest = await fetchRegistryJsonWithFallback<T>(
+    `${type}/${id}/manifest.json`,
+  );
+  return normalizeRegistryManifest(manifest as ModManifest | MapManifest) as T;
 }
 
 async function fetchIntegrity(

--- a/website/lib/railyard/manifest-normalization.ts
+++ b/website/lib/railyard/manifest-normalization.ts
@@ -1,0 +1,22 @@
+import { normalizeMapCountry } from '@subway-builder-modded/asset-listings-state';
+
+import type { MapManifest, ModManifest } from '@/types/registry';
+
+type RegistryManifest = ModManifest | MapManifest;
+
+function isMapManifest(manifest: RegistryManifest): manifest is MapManifest {
+  return 'city_code' in manifest;
+}
+
+export function normalizeRegistryManifest<T extends RegistryManifest>(
+  manifest: T,
+): T {
+  if (!isMapManifest(manifest)) {
+    return manifest;
+  }
+
+  const country = normalizeMapCountry(manifest.country);
+  return country === (manifest.country ?? '')
+    ? manifest
+    : ({ ...manifest, country } as T);
+}

--- a/website/lib/railyard/registry.server.ts
+++ b/website/lib/railyard/registry.server.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { enrichAuthorIdentity } from '@/lib/authors';
+import { normalizeRegistryManifest } from '@/lib/railyard/manifest-normalization';
 import { getRegistryAuthorDirectory } from '@/lib/railyard/registry-author-directory';
 import { buildEmbedMetadata } from '@/config/site/metadata';
 import {
@@ -117,7 +118,10 @@ export async function getRegistryManifest(
   if (!manifest) return null;
 
   const authorDirectory = await getRegistryAuthorDirectory();
-  return enrichAuthorIdentity(manifest, authorDirectory);
+  return enrichAuthorIdentity(
+    normalizeRegistryManifest(manifest),
+    authorDirectory,
+  );
 }
 
 export async function buildRailyardProjectEmbedMetadata({


### PR DESCRIPTION
This PR does a few things

- Tighten map/game-version enforcement, with maps now default to a max compatible game version of <=1.3.0 if no explicit max game version override is given (due to the upcoming breaking schema changes)
  - ANY map published on or  before **2026-05-18** are additionally hard-capped to <=1.3.0 (date cap). 

- Install-time compatibility is also now strict: installs only proceed when either the detected game version satisfies a valid explicit constraint, or there is no explicit constraint and the detected game version is <=1.3.0.
  - Invalid detected game version, invalid constraints, and missing constraints on >1.3.0 all fail install.
  
- Lastly there's a cosmetic/QoL change so that ISO country codes can match country names. 
  - Each 2-letter ISO code is now mapped into  searchable exonym/endonym terms like CZ -> Czechia / Cesko. 