### PR TITLE
Fix thumbnail generation latSpan

### DIFF
--- a/railyard/internal/utils/thumbnail.go
+++ b/railyard/internal/utils/thumbnail.go
@@ -99,7 +99,7 @@ func GenerateThumbnail(cityCode string, cityConfig types.ConfigData, port int) (
 			return "", fmt.Errorf("no bounding box or initial view state found for city %s", cityCode)
 		}
 		// Approximate span based on zoom level
-		latSpan := 360.0 / math.Pow(2, zoom)
+		latSpan := 180.0 / math.Pow(2, zoom)
 		lngSpan := 360.0 / math.Pow(2, zoom)
 		derived := [4]float64{lng - lngSpan, lat - latSpan, lng + lngSpan, lat + latSpan}
 		bboxToUse = &derived


### PR DESCRIPTION
latSpan is currently set to 360, but there are only 180 degrees of latitude.  This results in the thumbnail bbox being twice as tall as it should be.