### PR TITLE
Standardize map country codes and add country-name search

### DIFF
--- a/packages/asset-listings-state/src/country-search.ts
+++ b/packages/asset-listings-state/src/country-search.ts
@@ -1,0 +1,128 @@
+const COUNTRY_CODE_PATTERN = /^[A-Za-z]{2}$/;
+const ENGLISH_REGION_NAMES = new Intl.DisplayNames(['en'], { type: 'region' });
+
+type CountrySearchOverride = {
+  exonym?: string;
+  endonym?: string;
+  aliases?: string[];
+};
+
+const COUNTRY_SEARCH_OVERRIDES: Record<string, CountrySearchOverride> = {
+  CI: {
+    aliases: ['Ivory Coast'],
+  },
+  CZ: {
+    aliases: ['Czech Republic'],
+  },
+  GB: {
+    aliases: ['UK', 'Britain', 'Great Britain'],
+  },
+  MK: {
+    aliases: ['Macedonia'],
+  },
+  MM: {
+    aliases: ['Burma'],
+  },
+  SZ: {
+    aliases: ['Swaziland'],
+  },
+  TL: {
+    aliases: ['East Timor'],
+  },
+  XK: {
+    exonym: 'Kosovo',
+    endonym: 'Kosove',
+  },
+};
+
+const countrySearchTermCache = new Map<string, string[]>();
+
+export function normalizeCountryCode(
+  code: string | null | undefined,
+): string | undefined {
+  const normalized = (code ?? '').trim().toUpperCase();
+  return COUNTRY_CODE_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+export function normalizeMapCountry(country: string | null | undefined): string {
+  return normalizeCountryCode(country) ?? '';
+}
+
+function uniqueTerms(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+
+  return result;
+}
+
+function toSearchTermVariants(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  const asciiFolded = trimmed.normalize('NFKD').replace(/\p{M}+/gu, '');
+  return uniqueTerms([trimmed, asciiFolded]);
+}
+
+function getRegionName(locale: string, code: string): string | undefined {
+  try {
+    const displayName =
+      locale === 'en'
+        ? ENGLISH_REGION_NAMES.of(code)
+        : new Intl.DisplayNames([locale], { type: 'region' }).of(code);
+    if (!displayName || displayName.toUpperCase() === code) {
+      return undefined;
+    }
+    return displayName;
+  } catch {
+    return undefined;
+  }
+}
+
+function getCountryEndonym(code: string): string | undefined {
+  try {
+    const locale = new Intl.Locale(`und-${code}`).maximize();
+    return getRegionName(locale.baseName, code);
+  } catch {
+    return undefined;
+  }
+}
+
+export function reverseIsoCountryCodeToNames(code: string): string[] {
+  const normalized = normalizeCountryCode(code);
+  if (!normalized) {
+    return [];
+  }
+
+  const cached = countrySearchTermCache.get(normalized);
+  if (cached) {
+    return cached;
+  }
+
+  const overrides = COUNTRY_SEARCH_OVERRIDES[normalized];
+  const terms = uniqueTerms([
+    normalized,
+    overrides?.exonym ?? getRegionName('en', normalized) ?? '',
+    overrides?.endonym ?? getCountryEndonym(normalized) ?? '',
+    ...(overrides?.aliases ?? []),
+  ]).flatMap(toSearchTermVariants);
+
+  const deduped = uniqueTerms(terms);
+  countrySearchTermCache.set(normalized, deduped);
+  return deduped;
+}
+
+export function buildCountryCodeSearchTerms(
+  country: string | null | undefined,
+): string[] {
+  const normalized = normalizeCountryCode(country);
+  return normalized ? reverseIsoCountryCodeToNames(normalized) : [];
+}

--- a/packages/asset-listings-state/src/filter-and-sort.test.ts
+++ b/packages/asset-listings-state/src/filter-and-sort.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildAssetSearchText,
   buildFilteredTaggedListingCounts,
   filterAndSortTaggedItems,
   matchesSingleValueFilter,
@@ -11,10 +12,17 @@ import {
   type TaggedListingAccessors,
   type TaggedListingItem,
 } from './filter-and-sort';
+import {
+  buildCountryCodeSearchTerms,
+  normalizeMapCountry,
+  reverseIsoCountryCodeToNames,
+} from './country-search';
 
 interface TestItem {
   id: string;
   name: string;
+  city_code?: string;
+  country?: string;
   tags?: string[];
   location?: string;
   quality?: string;
@@ -30,6 +38,15 @@ interface TestMapFilters {
 }
 
 type TestTaggedItem = TaggedListingItem<TestItem>;
+type SearchFilters = {
+  query: string;
+  type: 'mod' | 'map';
+  sort: { field: string; direction: 'asc' | 'desc' };
+  randomSeed: number;
+  perPage: number;
+  mod: { tags: string[] };
+  map: TestMapFilters;
+};
 
 const items: TestTaggedItem[] = [
   {
@@ -124,8 +141,78 @@ const accessors: TaggedListingAccessors<TestTaggedItem, TestMapFilters> = {
   dimensions: testDimensions,
 };
 
+const searchAccessors: TaggedListingAccessors<TestTaggedItem, TestMapFilters> = {
+  buildSearchText: (item) => buildAssetSearchText(item, () => ''),
+  dimensions: testDimensions,
+};
+
 const compareItems = (left: TestTaggedItem, right: TestTaggedItem) =>
   left.item.name.localeCompare(right.item.name);
+
+const searchFuseOptions = { keys: ['searchText'], threshold: 0.4 } as const;
+
+function getRegionEndonym(locale: string, code: string): string | undefined {
+  return new Intl.DisplayNames([locale], { type: 'region' }).of(code);
+}
+
+function foldAscii(value: string): string {
+  return value.normalize('NFKD').replace(/\p{M}+/gu, '');
+}
+
+function makeMapItem(overrides: Partial<TestItem> = {}): TestTaggedItem {
+  return {
+    type: 'map',
+    item: {
+      id: 'map-prague',
+      name: 'Prague Metro',
+      country: 'CZ',
+      city_code: 'PRG',
+      ...overrides,
+    },
+  };
+}
+
+function makeFilters(overrides: Partial<SearchFilters>): SearchFilters {
+  return {
+    query: '',
+    type: 'map',
+    sort: { field: 'name', direction: 'asc' },
+    randomSeed: 1,
+    perPage: 12,
+    mod: { tags: [] },
+    map: mapFilters,
+    ...overrides,
+  };
+}
+
+function runSearch(
+  searchItems: TestTaggedItem[],
+  filters: Partial<SearchFilters>,
+): TestTaggedItem[] {
+  return filterAndSortTaggedItems({
+    items: searchItems,
+    filters: makeFilters(filters),
+    modDownloadTotals: {},
+    mapDownloadTotals: {},
+    compareItems,
+    accessors: searchAccessors,
+    fuseOptions: searchFuseOptions,
+  });
+}
+
+function expectCountryAliasesPresent(
+  searchText: string,
+  code: string,
+  exonym: string,
+  endonym: string | undefined,
+) {
+  expect(searchText).toContain(code);
+  expect(searchText).toContain(exonym);
+  if (endonym) {
+    expect(searchText).toContain(endonym);
+    expect(searchText).toContain(foldAscii(endonym));
+  }
+}
 
 describe('filter helpers', () => {
   it('matches selected single values and many-values filters', () => {
@@ -133,6 +220,42 @@ describe('filter helpers', () => {
     expect(matchesSingleValueFilter('asia', ['europe'])).toBe(false);
     expect(matchesZeroOrManyValuesFilter(['ui', 'sim'], ['ui'])).toBe(true);
     expect(matchesZeroOrManyValuesFilter(['sim'], ['ui'])).toBe(false);
+  });
+});
+
+describe('country search helpers', () => {
+  it('normalizes ISO country codes once at the manifest boundary', () => {
+    expect(normalizeMapCountry(' cz ')).toBe('CZ');
+    expect(normalizeMapCountry(' Ukraine ')).toBe('');
+    expect(normalizeMapCountry('1!')).toBe('');
+    expect(normalizeMapCountry(undefined)).toBe('');
+  });
+
+  it('expands ISO country codes into exonym and endonym search terms', () => {
+    const czechEndonym = getRegionEndonym('cs-CZ', 'CZ');
+    const ukrainianEndonym = getRegionEndonym('uk-UA', 'UA');
+
+    expect(reverseIsoCountryCodeToNames('CZ')).toEqual(
+      expect.arrayContaining([
+        'CZ',
+        'Czechia',
+        'Czech Republic',
+        czechEndonym ?? '',
+      ]),
+    );
+    if (czechEndonym) {
+      expect(reverseIsoCountryCodeToNames('CZ')).toContain(foldAscii(czechEndonym));
+    }
+    expect(reverseIsoCountryCodeToNames('UA')).toEqual(
+      expect.arrayContaining(['UA', 'Ukraine', ukrainianEndonym ?? '']),
+    );
+    expect(reverseIsoCountryCodeToNames('GB')).toEqual(
+      expect.arrayContaining(['GB', 'United Kingdom', 'UK']),
+    );
+  });
+
+  it('keeps non-ISO country labels searchable without expansion', () => {
+    expect(buildCountryCodeSearchTerms('Czechia')).toEqual([]);
   });
 });
 
@@ -148,6 +271,13 @@ describe('seeded ordering', () => {
 });
 
 describe('filterAndSortTaggedItems', () => {
+  it('includes country aliases in map search text', () => {
+    const czechEndonym = getRegionEndonym('cs-CZ', 'CZ');
+    const searchText = buildAssetSearchText(makeMapItem(), () => '');
+
+    expectCountryAliasesPresent(searchText, 'CZ', 'Czechia', czechEndonym);
+  });
+
   it('filters by type, tags, and map attributes before sorting', () => {
     const result = filterAndSortTaggedItems({
       items,
@@ -169,7 +299,7 @@ describe('filterAndSortTaggedItems', () => {
       mapDownloadTotals: {},
       compareItems,
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(result.map((item) => item.item.id)).toEqual(['map-eu']);
@@ -178,23 +308,26 @@ describe('filterAndSortTaggedItems', () => {
   it('supports text search through Fuse', () => {
     const result = filterAndSortTaggedItems({
       items,
-      filters: {
+      filters: makeFilters({
         query: 'signal',
         type: 'mod',
-        sort: { field: 'name', direction: 'asc' },
-        randomSeed: 1,
-        perPage: 12,
-        mod: { tags: [] },
-        map: mapFilters,
-      },
+      }),
       modDownloadTotals: {},
       mapDownloadTotals: {},
       compareItems,
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(result.map((item) => item.item.id)).toEqual(['mod-sim']);
+  });
+
+  it('matches map queries against country exonyms and endonyms', () => {
+    const result = runSearch([makeMapItem()], {
+      query: 'cesko',
+    });
+
+    expect(result.map((item) => item.item.id)).toEqual(['map-prague']);
   });
 
   it('uses seeded random ordering when random sort is requested', () => {
@@ -213,7 +346,7 @@ describe('filterAndSortTaggedItems', () => {
       mapDownloadTotals: {},
       compareItems,
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(result.map((item) => item.item.id)).toEqual(
@@ -265,7 +398,7 @@ describe('filterAndSortTaggedItems', () => {
         },
       },
       accessors,
-      fuseOptions: { keys: ['searchText'], threshold: 0.4 },
+      fuseOptions: searchFuseOptions,
     });
 
     expect(counts.mapCount).toBe(1);

--- a/packages/asset-listings-state/src/filter-and-sort.ts
+++ b/packages/asset-listings-state/src/filter-and-sort.ts
@@ -9,12 +9,19 @@ import {
   type SortState,
 } from '@subway-builder-modded/config';
 
+import { buildCountryCodeSearchTerms } from './country-search';
+
 type SearchableItem<TItem> = {
   entry: TItem;
   searchText: string;
 };
 
-const normalizedSearchTextCache = new WeakMap<object, string>();
+type CachedSearchText = {
+  raw: string;
+  normalized: string;
+};
+
+const searchTextCache = new WeakMap<object, CachedSearchText>();
 
 export interface TaggedListingItem<TItem = { id: string }> {
   type: AssetType;
@@ -49,7 +56,7 @@ export function buildAssetSearchText<TItem extends AssetSearchable>(
   } else {
     values.push(
       item.city_code ?? '',
-      item.country ?? '',
+      ...buildCountryCodeSearchTerms(item.country),
       item.location ?? '',
       item.source_quality ?? '',
       item.level_of_detail ?? '',
@@ -60,19 +67,22 @@ export function buildAssetSearchText<TItem extends AssetSearchable>(
   return values.filter(Boolean).join(' ');
 }
 
-// Cache lowercased search text per tagged item to avoid rebuilding it on each query.
-function getNormalizedSearchText<TTaggedItem extends TaggedListingItem>(
+function getCachedSearchText<TTaggedItem extends TaggedListingItem>(
   item: TTaggedItem,
   buildSearchText: (item: TTaggedItem) => string,
-): string {
-  const cached = normalizedSearchTextCache.get(item as object);
+): CachedSearchText {
+  const cached = searchTextCache.get(item as object);
   if (cached) {
     return cached;
   }
 
-  const normalized = buildSearchText(item).toLowerCase();
-  normalizedSearchTextCache.set(item as object, normalized);
-  return normalized;
+  const raw = buildSearchText(item);
+  const next = {
+    raw,
+    normalized: raw.toLowerCase(),
+  };
+  searchTextCache.set(item as object, next);
+  return next;
 }
 
 // Prefer a cheap token-inclusion match before falling back to fuzzy search.
@@ -91,8 +101,8 @@ function filterByQueryFastPath<TTaggedItem extends TaggedListingItem>(
   }
 
   return items.filter((item) => {
-    const searchText = getNormalizedSearchText(item, buildSearchText);
-    return normalizedTerms.every((term) => searchText.includes(term));
+    const searchText = getCachedSearchText(item, buildSearchText);
+    return normalizedTerms.every((term) => searchText.normalized.includes(term));
   });
 }
 
@@ -265,7 +275,7 @@ function filterTaggedItems<
     } else {
       const searchable: SearchableItem<TTaggedItem>[] = result.map((entry) => ({
         entry,
-        searchText: accessors.buildSearchText(entry),
+        searchText: getCachedSearchText(entry, accessors.buildSearchText).raw,
       }));
 
       const fuse = new Fuse(

--- a/packages/asset-listings-state/src/index.ts
+++ b/packages/asset-listings-state/src/index.ts
@@ -14,6 +14,12 @@ export {
 	type TaggedListingItem,
 } from './filter-and-sort';
 export {
+	buildCountryCodeSearchTerms,
+	normalizeCountryCode,
+	normalizeMapCountry,
+	reverseIsoCountryCodeToNames,
+} from './country-search';
+export {
 	createDefaultSourceFilters,
 	createSourceFilterByAssetType,
 	type AssetQueryFilterStoreState,

--- a/packages/asset-listings-ui/src/components/item-card.tsx
+++ b/packages/asset-listings-ui/src/components/item-card.tsx
@@ -82,7 +82,7 @@ function buildItemCardPresentation(
     isMap,
     badges: mapBadges,
     mapCityCode: isMap ? (city_code ?? '').trim() : '',
-    mapCountry: isMap ? (country ?? '').trim().toUpperCase() : '',
+    mapCountry: isMap ? (country ?? '') : '',
     mapPopulation: isMap ? population : undefined,
     showDownloads: typeof totalDownloads === 'number',
   };

--- a/railyard/frontend/src/components/library/LibraryList.tsx
+++ b/railyard/frontend/src/components/library/LibraryList.tsx
@@ -253,8 +253,8 @@ function LibraryListRow({
   const map = isMap ? (entry.item as types.MapManifest) : null;
 
   const mapCityCode = map?.city_code?.trim().toUpperCase() ?? '';
-  const mapCountry = map?.country?.trim().toUpperCase() ?? '';
-  const CountryFlag = isMap ? getCountryFlagIcon(mapCountry) : null;
+  const mapCountry = map?.country ?? '';
+  const CountryFlag = getCountryFlagIcon(mapCountry);
 
   const badges = isMap
     ? [

--- a/railyard/frontend/src/components/project/ProjectHeader.tsx
+++ b/railyard/frontend/src/components/project/ProjectHeader.tsx
@@ -444,9 +444,8 @@ export function ProjectHeader({
       ].filter((v): v is string => Boolean(v))
     : (item.tags ?? []);
 
-  const CountryFlag = mapItem?.country
-    ? getCountryFlagIcon(mapItem.country.trim().toUpperCase())
-    : null;
+  const mapCountry = mapItem?.country ?? '';
+  const CountryFlag = getCountryFlagIcon(mapCountry);
 
   return (
     <>
@@ -479,7 +478,7 @@ export function ProjectHeader({
                         {CountryFlag && (
                           <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
                         )}
-                        <span>{mapItem.country.trim().toUpperCase()}</span>
+                        <span>{mapCountry}</span>
                       </span>
                     </>
                   )}

--- a/railyard/frontend/src/components/shared/ItemCard.tsx
+++ b/railyard/frontend/src/components/shared/ItemCard.tsx
@@ -38,7 +38,7 @@ export function ItemCard({
 }: ItemCardWrapperProps) {
   const isMap = isMapManifest(item);
   const mapItem = isMap ? (item as types.MapManifest) : null;
-  const CountryFlag = mapItem ? getCountryFlagIcon(mapItem.country) : null;
+  const CountryFlag = getCountryFlagIcon(mapItem?.country);
 
   const formatDescription = useMemo(() => {
     if (descriptionMode === 'preview') {
@@ -61,9 +61,7 @@ export function ItemCard({
       city_code={mapItem?.city_code}
       country={mapItem?.country}
       countryFlag={
-        CountryFlag ? (
-          <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
-        ) : undefined
+        CountryFlag && <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
       }
       location={mapItem?.location}
       source_quality={mapItem?.source_quality}

--- a/railyard/frontend/src/pages/LibraryPage.tsx
+++ b/railyard/frontend/src/pages/LibraryPage.tsx
@@ -1,3 +1,4 @@
+import { normalizeMapCountry } from '@subway-builder-modded/asset-listings-state';
 import {
   AssetSidebarPanel,
   EmptyState,
@@ -103,7 +104,7 @@ function localMapManifestFromInstalled(
       config.creator,
     ),
     city_code: config.code,
-    country: config.country ?? '',
+    country: normalizeMapCountry(config.country),
     location: '',
     population: config.population,
     data_source: '',

--- a/railyard/internal/registry/manifests.go
+++ b/railyard/internal/registry/manifests.go
@@ -151,7 +151,7 @@ func (r *Registry) convertMapManifests(
 		return types.MapManifest{
 			AssetManifest:    manifest,
 			CityCode:         raw.CityCode,
-			Country:          raw.Country,
+			Country:          normalizeMapCountry(raw.Country),
 			Location:         raw.Location,
 			Population:       raw.Population,
 			DataSource:       raw.DataSource,

--- a/railyard/internal/registry/map_country.go
+++ b/railyard/internal/registry/map_country.go
@@ -1,0 +1,19 @@
+package registry
+
+import "strings"
+
+// normalizeMapCountry returns a canonical ISO-style country code or an empty string.
+func normalizeMapCountry(country string) string {
+	country = strings.TrimSpace(country)
+	if len(country) != 2 {
+		return ""
+	}
+
+	for _, ch := range country {
+		if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') {
+			return ""
+		}
+	}
+
+	return strings.ToUpper(country)
+}

--- a/railyard/internal/registry/map_country_test.go
+++ b/railyard/internal/registry/map_country_test.go
@@ -1,0 +1,39 @@
+package registry
+
+import "testing"
+
+func TestNormalizeMapCountry(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "uppercases and trims ISO codes",
+			input:    " cz ",
+			expected: "CZ",
+		},
+		{
+			name:     "discards non ISO labels",
+			input:    " Ukraine ",
+			expected: "",
+		},
+		{
+			name:     "discards invalid two-character labels",
+			input:    "1!",
+			expected: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if actual := normalizeMapCountry(testCase.input); actual != testCase.expected {
+				t.Fatalf("normalizeMapCountry(%q) = %q, expected %q", testCase.input, actual, testCase.expected)
+			}
+		})
+	}
+}

--- a/website/features/railyard/components/item-card.tsx
+++ b/website/features/railyard/components/item-card.tsx
@@ -41,7 +41,7 @@ export function ItemCard({
 }: ItemCardWrapperProps) {
   const isMap = isMapManifest(item);
   const mapItem = isMap ? (item as MapManifest) : null;
-  const CountryFlag = mapItem ? getCountryFlagIcon(mapItem.country) : null;
+  const CountryFlag = getCountryFlagIcon(mapItem?.country);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const formatDescription = useMemo(() => {
@@ -71,9 +71,7 @@ export function ItemCard({
       city_code={mapItem?.city_code}
       country={mapItem?.country}
       countryFlag={
-        CountryFlag ? (
-          <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
-        ) : undefined
+        CountryFlag && <CountryFlag className="h-3.5 w-5 rounded-[1px]" />
       }
       location={mapItem?.location}
       source_quality={mapItem?.source_quality}

--- a/website/features/railyard/components/project-header.tsx
+++ b/website/features/railyard/components/project-header.tsx
@@ -46,10 +46,8 @@ export function ProjectHeader({
       ].filter((v): v is string => Boolean(v))
     : (item.tags ?? []);
 
-  const mapCountryCode = mapItem?.country?.trim().toUpperCase();
-  const CountryFlag = mapCountryCode
-    ? getCountryFlagIcon(mapCountryCode)
-    : null;
+  const mapCountry = mapItem?.country ?? '';
+  const CountryFlag = getCountryFlagIcon(mapCountry);
   const authorHref = getAuthorAttributionHref(item);
 
   const handleOpenInRailyard = () => {
@@ -97,7 +95,7 @@ export function ProjectHeader({
                         createElement(CountryFlag, {
                           className: 'h-3.5 w-5 rounded-[1px]',
                         })}
-                      <span>{mapItem.country.trim().toUpperCase()}</span>
+                      <span>{mapCountry}</span>
                     </span>
                   </>
                 )}

--- a/website/hooks/use-registry-item.ts
+++ b/website/hooks/use-registry-item.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { enrichAuthorIdentity } from '@/lib/authors';
+import { normalizeRegistryManifest } from '@/lib/railyard/manifest-normalization';
 import { getRegistryAuthorDirectory } from '@/lib/railyard/registry-author-directory';
 import { fetchRegistryJsonWithFallback } from '@/lib/railyard/registry-source';
 import type { ModManifest, MapManifest } from '@/types/registry';
@@ -32,7 +33,14 @@ export function useRegistryItem(
           ModManifest | MapManifest
         >(`${type}/${id}/manifest.json`);
         const authorDirectory = await getRegistryAuthorDirectory();
-        if (!cancelled) setItem(enrichAuthorIdentity(data, authorDirectory));
+        if (!cancelled) {
+          setItem(
+            enrichAuthorIdentity(
+              normalizeRegistryManifest(data),
+              authorDirectory,
+            ),
+          );
+        }
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Failed to load item');

--- a/website/hooks/use-registry.ts
+++ b/website/hooks/use-registry.ts
@@ -13,6 +13,7 @@ import {
   getRawRegistryUrls,
   getRegistryCdnUrls,
 } from '@/lib/railyard/registry-source';
+import { normalizeRegistryManifest } from '@/lib/railyard/manifest-normalization';
 import type {
   AssetDownloadCountsByVersion,
   ModManifest,
@@ -44,7 +45,10 @@ async function fetchIndex(type: 'mods' | 'maps'): Promise<string[]> {
 }
 
 async function fetchManifest<T>(type: 'mods' | 'maps', id: string): Promise<T> {
-  return fetchRegistryJsonWithFallback<T>(`${type}/${id}/manifest.json`);
+  const manifest = await fetchRegistryJsonWithFallback<T>(
+    `${type}/${id}/manifest.json`,
+  );
+  return normalizeRegistryManifest(manifest as ModManifest | MapManifest) as T;
 }
 
 async function fetchIntegrity(

--- a/website/lib/railyard/manifest-normalization.ts
+++ b/website/lib/railyard/manifest-normalization.ts
@@ -1,0 +1,22 @@
+import { normalizeMapCountry } from '@subway-builder-modded/asset-listings-state';
+
+import type { MapManifest, ModManifest } from '@/types/registry';
+
+type RegistryManifest = ModManifest | MapManifest;
+
+function isMapManifest(manifest: RegistryManifest): manifest is MapManifest {
+  return 'city_code' in manifest;
+}
+
+export function normalizeRegistryManifest<T extends RegistryManifest>(
+  manifest: T,
+): T {
+  if (!isMapManifest(manifest)) {
+    return manifest;
+  }
+
+  const country = normalizeMapCountry(manifest.country);
+  return country === (manifest.country ?? '')
+    ? manifest
+    : ({ ...manifest, country } as T);
+}

--- a/website/lib/railyard/registry.server.ts
+++ b/website/lib/railyard/registry.server.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { enrichAuthorIdentity } from '@/lib/authors';
+import { normalizeRegistryManifest } from '@/lib/railyard/manifest-normalization';
 import { getRegistryAuthorDirectory } from '@/lib/railyard/registry-author-directory';
 import { buildEmbedMetadata } from '@/config/site/metadata';
 import {
@@ -117,7 +118,10 @@ export async function getRegistryManifest(
   if (!manifest) return null;
 
   const authorDirectory = await getRegistryAuthorDirectory();
-  return enrichAuthorIdentity(manifest, authorDirectory);
+  return enrichAuthorIdentity(
+    normalizeRegistryManifest(manifest),
+    authorDirectory,
+  );
 }
 
 export async function buildRailyardProjectEmbedMetadata({


### PR DESCRIPTION
This PR does two things

(1) It normalizes map manifest country values to proper ISO codes (e.g. UA/HU) upon ingestion so that the frontend UI components no longer need to re-normalize (and can assume proper formatting)

(2) Adds country-name search (specifically reverse-map ISO codes to country names)
 - Includes exonym, endonym, and common aliases such as "UK" or "Ivory Coast"... This means that "Germany" will match country code "DE" as will Deutschland... 日本 will match JP and so on.
 
 

https://github.com/user-attachments/assets/525d7ec5-4270-481e-9f02-54c1cf1555b0

