### PR TITLE
[Backend] Persist upstream version cache with ETag conditional revalidation

### DIFF
--- a/railyard/internal/paths/paths.go
+++ b/railyard/internal/paths/paths.go
@@ -23,6 +23,8 @@ const (
 	InstalledMapsFileName = "installed_maps.json"
 	// UserProfilesFileName is the persisted user profiles file name.
 	UserProfilesFileName = "user_profiles.json"
+	// VersionsCacheFileName is the persisted upstream-release version cache file name.
+	VersionsCacheFileName = "versions_cache.json"
 	// LogFileName is the log file name.
 	LogFileName = "railyard.log"
 	// PrevLogFileName is the previous log file name.
@@ -64,6 +66,11 @@ func RegistryRepoPath() string {
 // ConfigPath returns the default filesystem path for persisted app config.
 func ConfigPath() string {
 	return filepath.Join(AppDataRoot(), ConfigFileName)
+}
+
+// VersionsCachePath returns the filesystem path for the persisted upstream-release version cache.
+func VersionsCachePath() string {
+	return filepath.Join(AppDataRoot(), VersionsCacheFileName)
 }
 
 // TilesPath returns the default filesystem path for cached map tiles.

--- a/railyard/internal/registry/integrity_test.go
+++ b/railyard/internal/registry/integrity_test.go
@@ -39,7 +39,7 @@ func TestGetInstallableVersions(t *testing.T) {
 		},
 	}
 
-	reg.setCachedVersions("custom|https://example.com/update.json", []types.VersionInfo{
+	reg.versions.set("custom|https://example.com/update.json", []types.VersionInfo{
 		{Version: "2.0.0"},
 		{Version: "1.1.0"},
 		{Version: "1.0.0"},
@@ -72,10 +72,10 @@ func TestGetInstallableVersionsRejectsMissingOrIncompleteListings(t *testing.T) 
 			return manifest
 		}(),
 	})
-	reg.setCachedVersions("custom|https://example.com/missing-update.json", []types.VersionInfo{
+	reg.versions.set("custom|https://example.com/missing-update.json", []types.VersionInfo{
 		{Version: "1.0.0"},
 	})
-	reg.setCachedVersions("custom|https://example.com/update.json", []types.VersionInfo{
+	reg.versions.set("custom|https://example.com/update.json", []types.VersionInfo{
 		{Version: "1.0.0"},
 	})
 	reg.integrityMaps = types.RegistryIntegrityReport{

--- a/railyard/internal/registry/registry.go
+++ b/railyard/internal/registry/registry.go
@@ -33,8 +33,7 @@ type Registry struct {
 	mods           []types.ModManifest
 	maps           []types.MapManifest
 	downloadCounts map[types.AssetType]map[string]map[string]int
-	versionsCache  map[string][]types.VersionInfo
-	versionsMu     sync.RWMutex
+	versions       *versionCache // upstream-release version cache with ETag conditional revalidation; see versions_cache.go
 	installedMods  []types.InstalledModInfo
 	installedMaps  []types.InstalledMapInfo
 	integrityMaps  types.RegistryIntegrityReport
@@ -72,7 +71,7 @@ func NewRegistry(l logSink, cfg *config.Config) *Registry {
 			types.AssetTypeMap: {},
 			types.AssetTypeMod: {},
 		},
-		versionsCache: map[string][]types.VersionInfo{},
+		versions: newVersionCache(l),
 	}
 }
 
@@ -83,7 +82,7 @@ func (r *Registry) SetContext(ctx context.Context) {
 // Initialize ensures a valid local registry repo exists.
 // It does not force a remote refresh.
 func (r *Registry) Initialize() error {
-	r.clearVersionsCache()
+	r.versions.load()
 	if err := r.openOrClone(); err != nil {
 		return err
 	}
@@ -109,7 +108,7 @@ func (r *Registry) Refresh() error {
 		Percent: -1,
 	})
 
-	r.clearVersionsCache() // Clear versions cache on refresh to ensure we fetch fresh version
+	r.versions.resetRevalidated()
 
 	// Fast exit path: Skip the full fetch when the local repo already matches latest commit SHA.
 	// Failures here intentionally fall through to the normal, slow path

--- a/railyard/internal/registry/versions.go
+++ b/railyard/internal/registry/versions.go
@@ -28,34 +28,23 @@ type modManifestDeps struct {
 // updateType must be "github" or "custom".
 // repoOrURL is "owner/repo" for github, or a URL for custom.
 func (r *Registry) GetVersions(updateType string, repoOrURL string) ([]types.VersionInfo, error) {
-	// Check cache first to avoid redundant network requests
 	cacheKey := updateType + "|" + repoOrURL
-	if cached, ok := r.getCachedVersions(cacheKey); ok {
+
+	// Fast path: a key already revalidated this session needs no request at all.
+	if cached, ok := r.versions.revalidatedLookup(cacheKey); ok {
 		return cached, nil
 	}
 
-	var (
-		versions []types.VersionInfo
-		err      error
-	)
-
+	// Otherwise issue a conditional fetch; the ETag carried on the persisted entry lets
+	// the helper short-circuit on a 304 instead of re-downloading the release list.
 	switch updateType {
 	case "github":
-		versions, err = r.getGitHubVersions(repoOrURL)
+		return r.getGitHubVersions(cacheKey, repoOrURL)
 	case "custom":
-		versions, err = r.getCustomVersions(repoOrURL)
+		return r.getCustomVersions(cacheKey, repoOrURL)
 	default:
 		return nil, fmt.Errorf("unsupported update type: %q", updateType)
 	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	// If version resolution succeeded, cache the results for future calls
-	r.setCachedVersions(cacheKey, versions)
-	// Return a copy of the versions to prevent external mutation by callers
-	return cloneVersionInfos(versions), nil
 }
 
 // GetVersionsResponse fetches available versions and reports status metadata.
@@ -74,7 +63,7 @@ func (r *Registry) GetVersionsResponse(updateType string, repoOrURL string) type
 	}
 }
 
-func (r *Registry) getGitHubVersions(repo string) ([]types.VersionInfo, error) {
+func (r *Registry) getGitHubVersions(cacheKey string, repo string) ([]types.VersionInfo, error) {
 	parts := strings.SplitN(repo, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return nil, fmt.Errorf("invalid GitHub repo format %q: expected \"owner/repo\"", repo)
@@ -87,9 +76,7 @@ func (r *Registry) getGitHubVersions(repo string) ([]types.VersionInfo, error) {
 		URL:              apiURL,
 		GitHubToken:      r.config.GetGithubToken(),
 		ForceAuthByToken: true,
-		Headers: map[string]string{
-			"Accept": "application/vnd.github+json",
-		},
+		Headers:          r.versions.conditionalHeaders(cacheKey, map[string]string{"Accept": "application/vnd.github+json"}),
 		OnTokenRejected: func(statusCode int) {
 			r.logger.Warn("GitHub token rejected; retrying unauthenticated request", "repo", repo, "status", statusCode)
 			requestErrType := types.GetErrorTypeForStatus(statusCode)
@@ -100,6 +87,11 @@ func (r *Registry) getGitHubVersions(repo string) ([]types.VersionInfo, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch GitHub releases for %q: %w", repo, err)
+	}
+
+	// The releases are unchanged since the cached ETag, so reuse the cached versions.
+	if cached, ok := r.versions.notModified(resp, cacheKey); ok {
+		return cached, nil
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -144,7 +136,8 @@ func (r *Registry) getGitHubVersions(repo string) ([]types.VersionInfo, error) {
 	// Fetch manifest.json assets in parallel to extract game_version
 	r.enrichVersions(versions)
 
-	return versions, nil
+	r.versions.store(cacheKey, resp.Header.Get("ETag"), versions)
+	return cloneVersionInfos(versions), nil
 }
 
 // enrichVersions fetches manifest.json URLs in parallel and populates GameVersion and dependencies
@@ -202,14 +195,15 @@ func (r *Registry) enrichVersions(versions []types.VersionInfo) {
 	wg.Wait()
 }
 
-func (r *Registry) getCustomVersions(updateURL string) ([]types.VersionInfo, error) {
+func (r *Registry) getCustomVersions(cacheKey string, updateURL string) ([]types.VersionInfo, error) {
 	parsed, err := url.Parse(updateURL)
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
 		return nil, fmt.Errorf("invalid custom update URL %q: must be http or https", updateURL)
 	}
 
 	resp, err := requests.GetWithGithubToken(r.httpClient, requests.GithubTokenRequestArgs{
-		URL: updateURL,
+		URL:     updateURL,
+		Headers: r.versions.conditionalHeaders(cacheKey, nil),
 		OnTokenRejected: func(statusCode int) {
 			r.logger.Warn("GitHub token rejected on custom update URL; retrying unauthenticated request", "url", updateURL, "status", statusCode)
 			requestErrType := types.GetErrorTypeForStatus(statusCode)
@@ -220,6 +214,11 @@ func (r *Registry) getCustomVersions(updateURL string) ([]types.VersionInfo, err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch custom update from %q: %w", updateURL, err)
+	}
+
+	// Custom URLs that support conditional requests (e.g. raw.githubusercontent.com) answer 304 when unchanged.
+	if cached, ok := r.versions.notModified(resp, cacheKey); ok {
+		return cached, nil
 	}
 	defer resp.Body.Close()
 
@@ -255,7 +254,9 @@ func (r *Registry) getCustomVersions(updateURL string) ([]types.VersionInfo, err
 	r.enrichVersions(versions)
 	filtered := r.filterSemverVersions(versions, "custom:"+updateURL)
 	sortSemverVersions(filtered)
-	return filtered, nil
+
+	r.versions.store(cacheKey, resp.Header.Get("ETag"), filtered)
+	return cloneVersionInfos(filtered), nil
 }
 
 func (r *Registry) filterSemverVersions(
@@ -288,26 +289,4 @@ func sortSemverVersions(versions []types.VersionInfo) {
 		right, _ := semver.NewVersion(rightVersion)
 		return left.GreaterThan(right)
 	})
-}
-
-func (r *Registry) getCachedVersions(key string) ([]types.VersionInfo, bool) {
-	r.versionsMu.RLock()
-	defer r.versionsMu.RUnlock()
-	versions, ok := r.versionsCache[key]
-	if !ok {
-		return nil, false
-	}
-	return cloneVersionInfos(versions), true
-}
-
-func (r *Registry) setCachedVersions(key string, versions []types.VersionInfo) {
-	r.versionsMu.Lock()
-	defer r.versionsMu.Unlock()
-	r.versionsCache[key] = cloneVersionInfos(versions)
-}
-
-func (r *Registry) clearVersionsCache() {
-	r.versionsMu.Lock()
-	defer r.versionsMu.Unlock()
-	r.versionsCache = map[string][]types.VersionInfo{}
 }

--- a/railyard/internal/registry/versions_cache.go
+++ b/railyard/internal/registry/versions_cache.go
@@ -1,0 +1,166 @@
+package registry
+
+import (
+	"net/http"
+	"sync"
+
+	"railyard/internal/files"
+	"railyard/internal/paths"
+	"railyard/internal/types"
+)
+
+// This file holds the upstream-release version cache and its HTTP conditional-request (ETag) revalidation.
+//
+// Rather than re-downloading and re-parsing a release list on every lookup, each entry stores the ETag returned with its versions and replays it as an If-None-Match header on the next fetch.
+// Unchanged upstreams answer 304 Not Modified, so we can reuse the cache when that occurs.
+//
+// Importantly, 304s do not count against the unauthenticated Github API rate limit, in contrast to the
+// previous unconditional GET.
+//
+// Links:
+//   - ETag / If-None-Match: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-None-Match
+//   - GitHub conditional requests (304s are free): https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate
+
+// versionCache is the persisted upstream-release version cache + revalidation state for ETags.
+type versionCache struct {
+	mu          sync.RWMutex
+	entries     map[string]types.VersionsCacheEntry // resolved versions + ETags, keyed by "<updateType>|<repoOrURL>"
+	revalidated map[string]struct{}                 // keys already revalidated this session, so repeat lookups skip the ETag check
+	persist     bool                                // set once loaded from disk; gates writes so caches never loaded (e.g. unit tests) don't touch the user data dir
+	logger      logSink
+}
+
+// newVersionCache returns an empty, in-memory-only cache. Persistence stays off until
+// load() reads the on-disk file.
+func newVersionCache(logger logSink) *versionCache {
+	return &versionCache{
+		entries:     map[string]types.VersionsCacheEntry{},
+		revalidated: map[string]struct{}{},
+		logger:      logger,
+	}
+}
+
+// conditionalHeaders augments base with an If-None-Match header when a cached ETag is known for the key
+func (c *versionCache) conditionalHeaders(key string, base map[string]string) map[string]string {
+	headers := make(map[string]string, len(base)+1)
+	for k, v := range base {
+		headers[k] = v
+	}
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if ok && entry.ETag != "" {
+		headers["If-None-Match"] = entry.ETag
+	}
+	return headers
+}
+
+// notModified returns the cached versions when resp is a 304 (Not Modified).
+func (c *versionCache) notModified(resp *http.Response, key string) ([]types.VersionInfo, bool) {
+	if resp.StatusCode != http.StatusNotModified {
+		return nil, false
+	}
+	resp.Body.Close()
+	// A 304 means the cached entry is still current, so tag it as revalidated for this session.
+	c.markRevalidated(key)
+	cached, _ := c.get(key)
+	return cached, true
+}
+
+// revalidatedLookup returns the cached versions for a key already validated this
+// session, allowing repeat lookups to skip the network entirely.
+func (c *versionCache) revalidatedLookup(key string) ([]types.VersionInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if _, ok := c.revalidated[key]; !ok {
+		return nil, false
+	}
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneVersionInfos(entry.Versions), true
+}
+
+func (c *versionCache) get(key string) ([]types.VersionInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneVersionInfos(entry.Versions), true
+}
+
+// set seeds the in-memory cache (with no ETag) and marks the key revalidated for this
+// session. Used by tests to prime the cache directly.
+func (c *versionCache) set(key string, versions []types.VersionInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = types.VersionsCacheEntry{Versions: cloneVersionInfos(versions)}
+	c.revalidated[key] = struct{}{}
+}
+
+// store records freshly fetched versions and their ETag for a key, marks the key
+// revalidated for this session, and persists the cache to disk.
+func (c *versionCache) store(key string, etag string, versions []types.VersionInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = types.VersionsCacheEntry{ETag: etag, Versions: cloneVersionInfos(versions)}
+	c.revalidated[key] = struct{}{}
+	c.persistLocked()
+}
+
+func (c *versionCache) markRevalidated(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.revalidated[key] = struct{}{}
+}
+
+func (c *versionCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = map[string]types.VersionsCacheEntry{}
+	c.revalidated = map[string]struct{}{}
+}
+
+// resetRevalidated drops the revalidation tags while keeping cached versions and ETags.
+// The next lookup therefore rechecks upstream releases cheaply via a conditional request,
+// rather than re-fetching them in full as clear() would force.
+func (c *versionCache) resetRevalidated() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.revalidated = map[string]struct{}{}
+}
+
+// load populates the cache from disk and enables persistence. A missing or unreadable
+// cache file starts empty rather than failing.
+func (c *versionCache) load() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.revalidated = map[string]struct{}{}
+	c.persist = true
+
+	file, err := files.ReadJSON[types.VersionsCacheFile](paths.VersionsCachePath(), "versions cache", files.JSONReadOptions{AllowMissing: true, AllowEmpty: true})
+	if err != nil {
+		c.logger.Warn("Failed to load versions cache; starting empty", "error", err)
+		c.entries = map[string]types.VersionsCacheEntry{}
+		return
+	}
+	if file.Entries == nil {
+		c.entries = map[string]types.VersionsCacheEntry{}
+		return
+	}
+	c.entries = file.Entries
+}
+
+// persistLocked writes the cache to disk best-effort. The caller must hold mu.
+func (c *versionCache) persistLocked() {
+	if !c.persist {
+		return
+	}
+	file := types.VersionsCacheFile{SchemaVersion: 1, Entries: c.entries}
+	if err := files.WriteJSON(paths.VersionsCachePath(), "versions cache", file); err != nil {
+		c.logger.Warn("Failed to persist versions cache", "error", err)
+	}
+}

--- a/railyard/internal/registry/versions_test.go
+++ b/railyard/internal/registry/versions_test.go
@@ -72,15 +72,75 @@ func TestGetGitHubVersionsAuthFallbackAndCache(t *testing.T) {
 
 func TestClearVersionsCache(t *testing.T) {
 	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
-	reg.setCachedVersions("github|owner/repo", []types.VersionInfo{{Version: "v1.0.0"}})
+	reg.versions.set("github|owner/repo", []types.VersionInfo{{Version: "v1.0.0"}})
 
-	_, ok := reg.getCachedVersions("github|owner/repo")
+	_, ok := reg.versions.get("github|owner/repo")
 	require.True(t, ok)
 
-	reg.clearVersionsCache()
+	reg.versions.clear()
 
-	_, ok = reg.getCachedVersions("github|owner/repo")
+	_, ok = reg.versions.get("github|owner/repo")
 	require.False(t, ok)
+}
+
+func TestGetVersionsRevalidatesWithETag(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	reg.SetContext(context.WithValue(context.Background(), "test", "true"))
+
+	var requestCount int32
+	server := testutil.NewLocalhostServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		if r.Header.Get("If-None-Match") == "etag-1" {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", "etag-1")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"tag_name":"v1.2.3","name":"v1.2.3","prerelease":false,"published_at":"2026-01-01T00:00:00Z","assets":[]}]`)
+	}))
+	defer server.Close()
+	reg.gitHubAPIBaseURL = server.URL
+
+	// First lookup fetches and caches the ETag.
+	versions, err := reg.GetVersions("github", "owner/repo")
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	require.EqualValues(t, 1, atomic.LoadInt32(&requestCount))
+
+	// Same session: served from memory with no request.
+	_, err = reg.GetVersions("github", "owner/repo")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, atomic.LoadInt32(&requestCount))
+
+	// After a refresh the session marks are cleared but the ETag is kept, so the
+	// next lookup revalidates with If-None-Match and reuses cached versions on 304.
+	reg.versions.resetRevalidated()
+	versions, err = reg.GetVersions("github", "owner/repo")
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	require.Equal(t, "v1.2.3", versions[0].Version)
+	require.EqualValues(t, 2, atomic.LoadInt32(&requestCount))
+}
+
+func TestVersionsCachePersistsAcrossInstances(t *testing.T) {
+	testutil.NewHarness(t)
+
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	reg.versions.load() // enables persistence against the temp data dir
+	reg.versions.store("github|owner/repo", "etag-9", []types.VersionInfo{{Version: "v2.0.0"}})
+
+	// A fresh instance loads the persisted entry (versions + ETag) from disk.
+	reg2 := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	reg2.versions.load()
+
+	cached, ok := reg2.versions.get("github|owner/repo")
+	require.True(t, ok)
+	require.Len(t, cached, 1)
+	require.Equal(t, "v2.0.0", cached[0].Version)
+
+	reg2.versions.mu.RLock()
+	defer reg2.versions.mu.RUnlock()
+	require.Equal(t, "etag-9", reg2.versions.entries["github|owner/repo"].ETag)
 }
 
 // Explicit regression test for Custom JSON versions to ensure that semver sorting is working and that higher semver versions are recorded as "higher" than lower ones, even if they are recorded after in the JSON file.

--- a/railyard/internal/types/registry_types.go
+++ b/railyard/internal/types/registry_types.go
@@ -155,6 +155,19 @@ type VersionInfo struct {
 	Dependencies map[string]string `json:"dependencies,omitempty"` // Map of dependency mod IDs to version constraints
 }
 
+// VersionsCacheEntry is a persisted upstream-release lookup: the resolved versions plus the HTTP ETag used to revalidate them with a conditional request.
+type VersionsCacheEntry struct {
+	ETag     string        `json:"etag"`
+	Versions []VersionInfo `json:"versions"`
+}
+
+// VersionsCacheFile is the on-disk shape of the version cache, keyed by
+// "<updateType>|<repoOrURL>".
+type VersionsCacheFile struct {
+	SchemaVersion int                           `json:"schema_version"`
+	Entries       map[string]VersionsCacheEntry `json:"entries"`
+}
+
 // GithubRelease maps fields from the GitHub Releases API response.
 type GithubRelease struct {
 	TagName     string        `json:"tag_name"`


### PR DESCRIPTION
On-demand version lookups (listing detail / install) hit each asset's upstream GitHub releases API or custom update URL. The existing cache we had was only in memory and wiped on every registry refresh, so the same sources were refetched every session and after each refresh


This PR fixes this by persisting resolved versions + their HTTP ETags to disk and revalidating with conditional requests:

- `versionsCache` now stores `{ETag, Versions}` per `"<updateType>|<repoOrURL>"`, persisted to `AppData/versions_cache.json` and reloaded on `Initialize`.
- `getGitHubVersions`/`getCustomVersions` send `If-None-Match` when an ETag is known; a **304 reuses the cached versions and does not count against the rate limit**.
- A per-session `revalidated` set serves repeat lookups from memory with no request; `Refresh` resets it (cheap recheck) instead of wiping the cache.
- Persistence is gated to instances that loaded the cache via `Initialize`, so unit-test registries never touch the user data dir.
