### PR TITLE
[Backend] Guard subscriptions against non-installable versions

### DIFF
--- a/railyard/app.go
+++ b/railyard/app.go
@@ -269,6 +269,16 @@ func runNonBlockingStartupRoutines(a *App, activeProfile types.UserProfile) {
 		}
 	}
 
+	// Run before sync, and independently of the auto-update preference, so a single stuck
+	// subscription cannot fail the startup sync for every other asset.
+	reconcileResult := a.Profiles.ReconcileSubscriptionVersions(activeProfile.ID)
+	switch reconcileResult.Status {
+	case types.ResponseWarn:
+		a.Logger.Warn("Reconciled non-installable subscription versions on startup", "profile_id", activeProfile.ID, "message", reconcileResult.Message, "operation_count", len(reconcileResult.Operations))
+	case types.ResponseError:
+		a.Logger.MultipleError("Failed to reconcile subscription versions on startup", logger.AsErrors(reconcileResult.Errors), "profile_id", activeProfile.ID)
+	}
+
 	// Sync subscriptions for active profile on startup
 	syncResult := a.Profiles.SyncSubscriptions(activeProfile.ID, false, false)
 	shouldRunAutoUpdate := activeProfile.SystemPreferences.AutoUpdateSubscriptions && syncResult.Status != types.ResponseError

--- a/railyard/internal/profiles/profiles_state.go
+++ b/railyard/internal/profiles/profiles_state.go
@@ -647,6 +647,19 @@ func (s *UserProfiles) SwapProfile(req types.SwapProfileRequest) types.UserProfi
 		swappedProfile = reconcileResult.Profile
 	}
 
+	// Run before sync so a stuck subscription from the target profile does not fail the post-swap sync for every other asset.
+	versionReconcileResult := s.ReconcileSubscriptionVersions(targetProfile.ID)
+	if versionReconcileResult.Status == types.ResponseError {
+		return types.UserProfileResult{
+			GenericResponse: types.ErrorResponse("Active profile changed, but failed to reconcile subscription versions"),
+			Profile:         swappedProfile,
+			Errors:          versionReconcileResult.Errors,
+		}
+	}
+	if versionReconcileResult.Profile.ID != "" {
+		swappedProfile = versionReconcileResult.Profile
+	}
+
 	syncResult := s.SyncSubscriptions(targetProfile.ID, false, false)
 	if syncResult.Status == types.ResponseError {
 		return types.UserProfileResult{
@@ -655,8 +668,9 @@ func (s *UserProfiles) SwapProfile(req types.SwapProfileRequest) types.UserProfi
 			Errors:          syncResult.Errors,
 		}
 	}
-	if syncResult.Status == types.ResponseWarn || reconcileResult.Status == types.ResponseWarn {
+	if syncResult.Status == types.ResponseWarn || reconcileResult.Status == types.ResponseWarn || versionReconcileResult.Status == types.ResponseWarn {
 		warnErrors := append([]types.UserProfilesError{}, reconcileResult.Errors...)
+		warnErrors = append(warnErrors, versionReconcileResult.Errors...)
 		warnErrors = append(warnErrors, syncResult.Errors...)
 		return types.UserProfileResult{
 			GenericResponse: types.WarnResponse("Profile swapped with reconciliation or sync warnings"),

--- a/railyard/internal/profiles/profiles_sync_test.go
+++ b/railyard/internal/profiles/profiles_sync_test.go
@@ -579,6 +579,42 @@ func TestSyncAssetSubscriptionsChecksumFailureProducesPurgeCandidate(t *testing.
 	require.Equal(t, types.InstallErrorChecksumFailed, assetsToPurge[0].errorCode)
 }
 
+func TestSyncAssetSubscriptionsVersionNotFoundProducesPurgeCandidate(t *testing.T) {
+	fixture := assetSyncTestFixture{
+		subscriptions: map[string]string{
+			"map-a": "1.0.1",
+		},
+		installedVersion: map[string]string{
+			"map-a": "1.0.0",
+		},
+		availableVersions: map[string]map[string]struct{}{
+			"map-a": {
+				"1.0.1": {},
+			},
+		},
+	}
+
+	// A version that passes the upstream availability pre-check but is rejected by the downloader as not installable (e.g. removed from the integrity cache) must be queued for purge so failure does not block syncing other assets, rather than recorded as a hard error.
+	_, errs, assetsToPurge, _ := syncAssetSubscriptions(testUserProfilesLogger(t), types.DefaultProfileID, mockMapAssetSyncArgs(
+		fixture,
+		mockInstallResponse(types.AssetTypeMap, nil, map[string]types.AssetInstallResponse{
+			"map-a": {
+				GenericResponse: types.GenericResponse{
+					Status:  types.ResponseError,
+					Message: "version not found",
+				},
+				ErrorType: types.InstallErrorVersionNotFound,
+			},
+		}),
+		mockUninstallResponse(types.AssetTypeMap, nil, nil),
+	))
+
+	require.Empty(t, errs)
+	require.Len(t, assetsToPurge, 1)
+	require.Equal(t, "map-a", assetsToPurge[0].assetID)
+	require.Equal(t, types.InstallErrorVersionNotFound, assetsToPurge[0].errorCode)
+}
+
 func TestApplyPurgeOperations(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/railyard/internal/profiles/profiles_test.go
+++ b/railyard/internal/profiles/profiles_test.go
@@ -88,6 +88,7 @@ type registryFixture struct {
 	mapCode            string
 	failVersions       bool
 	missingModManifest bool
+	incompleteVersions []string
 }
 
 func configureConfig(t *testing.T, cfg *config.Config) {
@@ -132,6 +133,7 @@ func mockRegistry(t *testing.T, reg *registry.Registry, fixtures []registryFixtu
 			MapCode:            f.mapCode,
 			FailVersions:       f.failVersions,
 			MissingModManifest: f.missingModManifest,
+			IncompleteVersions: f.incompleteVersions,
 		})
 	}
 	return registrytest.MockRegistryServer(t, reg, sharedFixtures)

--- a/railyard/internal/profiles/profiles_update.go
+++ b/railyard/internal/profiles/profiles_update.go
@@ -231,6 +231,61 @@ func (s *UserProfiles) resolveLatestUpdatesForProfile(
 
 // ===== Registry Helpers ===== //
 
+type reconcileResponse struct {
+	noChangeMessage string
+	persistMessage  string
+	summary         func(count int) string
+	notice          func(profileID string, operation types.SubscriptionOperation) types.UserProfilesError
+}
+
+// finalizeReconcile persists the profile mutations from a reconciliation pass and passes back a summary result.
+func (s *UserProfiles) finalizeReconcile(
+	stateCopy types.UserProfilesState,
+	profileID string,
+	profile types.UserProfile,
+	operations []types.SubscriptionOperation,
+	response reconcileResponse,
+) types.UpdateSubscriptionsResult {
+	// Nothing to persist when no operations were applied, so skip directly to a success.
+	if len(operations) == 0 {
+		s.Logger.Info("Subscription reconciliation completed with no changes", "profile_id", profileID)
+		result := updateResultBase(types.UpdateSubscriptions, types.ResponseSuccess, response.noChangeMessage)
+		result.Profile = profile
+		return result
+	}
+
+	// Otherwise, commit the mutations to the store and return a summary of the applied operations with any persistence errors.
+	if err := s.commitProfileMutation(&stateCopy, profileID, profile, true); err != nil {
+		persistErr := updateSubscriptionError(profileID, "", "", types.ErrorPersistFailed, fmt.Errorf("%s: %w", response.persistMessage, err))
+		return subscriptionErrorResult(types.UpdateSubscriptions, profile, operations, response.persistMessage, persistErr)
+	}
+
+	result := updateResultBase(types.UpdateSubscriptions, types.ResponseWarn, response.summary(len(operations)))
+	result.Applied = true
+	result.Profile = profile
+	result.Persisted = true
+	result.Operations = operations
+	for _, operation := range operations {
+		result.Errors = append(result.Errors, response.notice(profileID, operation))
+	}
+	return result
+}
+
+// subscriptionErrorResult builds an error UpdateSubscriptionsResult for the given request type, carrying any operations applied so far and the supplied error.
+func subscriptionErrorResult(
+	requestType types.UpdateSubscriptionRequestType,
+	profile types.UserProfile,
+	operations []types.SubscriptionOperation,
+	message string,
+	err types.UserProfilesError,
+) types.UpdateSubscriptionsResult {
+	result := updateResultBase(requestType, types.ResponseError, message)
+	result.Profile = profile
+	result.Operations = operations
+	result.Errors = []types.UserProfilesError{err}
+	return result
+}
+
 // ReconcileLocalMapSubscriptions removes local-map subscriptions that are no longer recoverable from installed state.
 // Primarily used after bootstrap/swap fallback paths where local maps cannot be restored from archive.
 func (s *UserProfiles) ReconcileLocalMapSubscriptions(profileID string) types.UpdateSubscriptionsResult {
@@ -267,62 +322,199 @@ func (s *UserProfiles) ReconcileLocalMapSubscriptions(profileID string) types.Up
 		}
 	}
 
-	if len(assetsToRemove) == 0 {
-		s.Logger.Info("Local map subscription reconciliation completed with no removals", "profile_id", profileID)
-		result := updateResultBase(types.UpdateSubscriptions, types.ResponseSuccess, "Local map subscriptions reconciled")
-		result.Profile = profile
-		return result
-	}
-
 	// Apply mutations to remove unrecoverable local map subscriptions from the profile state so that it no longer erroneously references missing installed data
 	operations := make([]types.SubscriptionOperation, 0, len(assetsToRemove))
 	for assetID, item := range assetsToRemove {
 		operation, opErr := applySubscriptionMutation(&profile, types.SubscriptionActionUnsubscribe, strings.TrimSpace(assetID), item)
 		if opErr != nil {
 			s.Logger.Error("Failed to reconcile local map subscription", *opErr, "asset_id", assetID, "profile_id", profileID)
-			result := updateResultBase(types.UpdateSubscriptions, types.ResponseError, "Failed to reconcile local map subscriptions")
-			result.Profile = profile
-			result.Errors = []types.UserProfilesError{*opErr}
-			return result
+			return subscriptionErrorResult(types.UpdateSubscriptions, profile, nil, "Failed to reconcile local map subscriptions", *opErr)
 		}
 		operations = appendOperation(operations, operation)
 	}
 
-	if err := s.commitProfileMutation(&stateCopy, profileID, profile, true); err != nil {
-		persistErr := updateSubscriptionError(
-			profileID,
-			"",
-			types.AssetTypeMap,
-			types.ErrorPersistFailed,
-			fmt.Errorf("failed to persist reconciled local map subscriptions: %w", err),
-		)
-		result := updateResultBase(types.UpdateSubscriptions, types.ResponseError, "Failed to persist local map subscription reconciliation")
-		result.Profile = profile
-		result.Operations = operations
-		result.Errors = []types.UserProfilesError{persistErr}
-		return result
+	return s.finalizeReconcile(stateCopy, profileID, profile, operations, reconcileResponse{
+		noChangeMessage: "Local map subscriptions reconciled",
+		persistMessage:  "Failed to persist local map subscription reconciliation",
+		summary: func(count int) string {
+			return fmt.Sprintf("Removed %d unrecoverable local map subscription(s)", count)
+		},
+		notice: func(profileID string, operation types.SubscriptionOperation) types.UserProfilesError {
+			return userProfilesError(
+				profileID,
+				operation.AssetID,
+				types.AssetTypeMap,
+				types.ErrorArchiveMissing,
+				"",
+				fmt.Sprintf("Removed local map subscription %q because installed data is unavailable", operation.AssetID),
+			)
+		},
+	})
+}
+
+// ReconcileSubscriptionVersions repairs remote map and mod subscriptions set to a version that is not installable (not in the integrity-complete set), which can be:
+// - an asset version that never passed integrity
+// - an asset version that originally passed integrity, but was later removed upstream.
+// Such subscriptions can be invisible in the library if no version was ever installed and fail every subsequent sync, so they must be reconciled before sync runs.
+func (s *UserProfiles) ReconcileSubscriptionVersions(profileID string) types.UpdateSubscriptionsResult {
+	s.logRequest("ReconcileSubscriptionVersions", "profile_id", profileID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stateCopy, profile, profileErr := s.resolveProfileFromCopy(profileID)
+	if profileErr != nil {
+		s.Logger.Error("Profile not found", profileErr, "profile_id", profileID)
+		return profileNotFoundUpdateResult(profileErr, types.UpdateSubscriptions, "profile not found")
 	}
 
-	result := updateResultBase(
-		types.UpdateSubscriptions,
-		types.ResponseWarn,
-		fmt.Sprintf("Removed %d unrecoverable local map subscription(s)", len(operations)),
+	cloneProfileSubscriptions(&profile)
+
+	operations := make([]types.SubscriptionOperation, 0)
+	// Reconcile every remote subscription type
+	for _, bucket := range profile.Subscriptions.RemoteSubscriptions() {
+		for assetID, pinnedVersion := range bucket.Entries {
+			operation, opErr := s.reconcileSubscriptionVersion(&profile, profileID, bucket.AssetType, assetID, pinnedVersion)
+			if opErr != nil {
+				s.Logger.Error("Failed to reconcile subscription version", *opErr, "asset_type", bucket.AssetType, "asset_id", assetID, "profile_id", profileID)
+				return subscriptionErrorResult(types.UpdateSubscriptions, profile, nil, "Failed to reconcile subscription versions", *opErr)
+			}
+			if operation != nil {
+				operations = appendOperation(operations, operation)
+			}
+		}
+	}
+
+	return s.finalizeReconcile(stateCopy, profileID, profile, operations, reconcileResponse{
+		noChangeMessage: "Subscription versions reconciled",
+		persistMessage:  "Failed to persist subscription version reconciliation",
+		summary: func(count int) string {
+			return fmt.Sprintf("Reconciled %d subscription(s) pinned to non-installable versions", count)
+		},
+		notice: subscriptionReconcileNotice,
+	})
+}
+
+// reconcileSubscriptionVersion repairs a single subscription version that is not installable.
+// It returns the applied subscription operation, or nil when no change is needed or the lookup could not be completed.
+func (s *UserProfiles) reconcileSubscriptionVersion(
+	profile *types.UserProfile,
+	profileID string,
+	assetType types.AssetType,
+	assetID string,
+	pinnedVersion string,
+) (*types.SubscriptionOperation, *types.UserProfilesError) {
+	pinned := strings.TrimSpace(pinnedVersion)
+
+	installable, lookupErr := s.Registry.GetInstallableVersions(assetType, assetID)
+	if lookupErr == nil {
+		for _, version := range installable {
+			if strings.TrimSpace(version.Version) == pinned {
+				return nil, nil // still installable; nothing to reconcile
+			}
+		}
+		// Downgrade to the latest installable version, or purge when none remain installable.
+		if len(installable) > 0 {
+			return s.downgradeSubscriptionToInstallable(profile, profileID, assetType, assetID, pinned, installable)
+		}
+		return s.purgeNonInstallableSubscription(profile, profileID, assetType, assetID, pinned)
+	}
+
+	// Lookup failed: only purge when the loaded integrity report definitively has no installable version, so a transient or unloaded registry never purges a valid subscription.
+	if s.assetHasNoInstallableVersions(assetType, assetID) {
+		return s.purgeNonInstallableSubscription(profile, profileID, assetType, assetID, pinned)
+	}
+	return s.skipVersionReconcile("Skipping subscription version reconciliation; installable versions unavailable", assetType, assetID, profileID, lookupErr)
+}
+
+// skipVersionReconcile logs that a subscription was left unchanged during version reconciliation and
+// returns a no-op result (nil operation, nil error).
+func (s *UserProfiles) skipVersionReconcile(message string, assetType types.AssetType, assetID, profileID string, cause error) (*types.SubscriptionOperation, *types.UserProfilesError) {
+	s.Logger.Warn(message, "asset_type", assetType, "asset_id", assetID, "profile_id", profileID, "error", cause.Error())
+	return nil, nil
+}
+
+// downgradeSubscriptionToInstallable rewrites the subscription to the latest installable version.
+func (s *UserProfiles) downgradeSubscriptionToInstallable(
+	profile *types.UserProfile,
+	profileID string,
+	assetType types.AssetType,
+	assetID string,
+	pinned string,
+	installable []types.VersionInfo,
+) (*types.SubscriptionOperation, *types.UserProfilesError) {
+	latest, err := latestSemverVersion(installable)
+	if err != nil {
+		return s.skipVersionReconcile("Skipping subscription version reconciliation; failed to resolve latest installable version", assetType, assetID, profileID, err)
+	}
+	s.Logger.Warn(
+		"Downgrading subscription pinned to non-installable version",
+		"asset_type", assetType,
+		"asset_id", assetID,
+		"profile_id", profileID,
+		"pinned_version", pinned,
+		"installable_version", latest,
 	)
-	result.Applied = true
-	result.Profile = profile
-	result.Persisted = true
-	result.Operations = operations
-	for _, operation := range operations {
-		result.Errors = append(result.Errors, userProfilesError(
+	return applySubscriptionMutation(profile, types.SubscriptionActionSubscribe, assetID, types.SubscriptionUpdateItem{
+		Type:    assetType,
+		Version: types.Version(latest),
+	})
+}
+
+// purgeNonInstallableSubscription removes a subscription that has no installable version available.
+func (s *UserProfiles) purgeNonInstallableSubscription(
+	profile *types.UserProfile,
+	profileID string,
+	assetType types.AssetType,
+	assetID string,
+	pinned string,
+) (*types.SubscriptionOperation, *types.UserProfilesError) {
+	s.Logger.Warn(
+		"Purging subscription pinned to non-installable version with no installable alternative",
+		"asset_type", assetType,
+		"asset_id", assetID,
+		"profile_id", profileID,
+		"pinned_version", pinned,
+	)
+	return applySubscriptionMutation(profile, types.SubscriptionActionUnsubscribe, assetID, types.SubscriptionUpdateItem{
+		Type: assetType,
+	})
+}
+
+// assetHasNoInstallableVersions reports whether the registry's integrity set is available and undeniably lists no complete version for the asset (delisted or never approved).
+func (s *UserProfiles) assetHasNoInstallableVersions(assetType types.AssetType, assetID string) bool {
+	report, err := s.Registry.GetIntegrityReport(assetType)
+	if err != nil || len(report.Listings) == 0 {
+		// Returns false when the report is not loaded, so a missing or unreadable registry never triggers a purge.
+		return false
+	}
+	listing, ok := report.Listings[assetID]
+	if !ok {
+		return true
+	}
+	return !listing.HasCompleteVersion
+}
+
+// subscriptionReconcileNotice builds an informational error describing a reconciliation operation.
+func subscriptionReconcileNotice(profileID string, operation types.SubscriptionOperation) types.UserProfilesError {
+	if operation.Action == types.SubscriptionActionUnsubscribe {
+		return userProfilesError(
 			profileID,
 			operation.AssetID,
-			types.AssetTypeMap,
-			types.ErrorArchiveMissing,
+			operation.Type,
+			types.ErrorLookupFailed,
 			"",
-			fmt.Sprintf("Removed local map subscription %q because installed data is unavailable", operation.AssetID),
-		))
+			fmt.Sprintf("Purged subscription %q because no installable version is available", operation.AssetID),
+		)
 	}
-	return result
+	return userProfilesError(
+		profileID,
+		operation.AssetID,
+		operation.Type,
+		types.ErrorLookupFailed,
+		"",
+		fmt.Sprintf("Downgraded subscription %q to installable version %q", operation.AssetID, strings.TrimSpace(string(operation.Version))),
+	)
 }
 
 func (s *UserProfiles) resolveLatestSubscriptionUpdates(
@@ -345,9 +537,8 @@ func (s *UserProfiles) resolveLatestSubscriptionUpdates(
 			subscriptions: profile.Subscriptions.Maps,
 			getManifests:  s.Registry.GetMaps,
 			idFn:          func(m types.MapManifest) string { return m.ID },
-			updateFn:      func(m types.MapManifest) types.UpdateConfig { return m.Update },
 		},
-		profileID, targetSet, s.Registry.GetVersions, updates, &pendingUpdates, &warnings,
+		profileID, targetSet, s.Registry.GetInstallableVersions, updates, &pendingUpdates, &warnings,
 	)
 
 	latestAssetUpdates(
@@ -356,9 +547,8 @@ func (s *UserProfiles) resolveLatestSubscriptionUpdates(
 			subscriptions: profile.Subscriptions.Mods,
 			getManifests:  s.Registry.GetMods,
 			idFn:          func(m types.ModManifest) string { return m.ID },
-			updateFn:      func(m types.ModManifest) types.UpdateConfig { return m.Update },
 		},
-		profileID, targetSet, s.Registry.GetVersions, updates, &pendingUpdates, &warnings,
+		profileID, targetSet, s.Registry.GetInstallableVersions, updates, &pendingUpdates, &warnings,
 	)
 
 	return updates, pendingUpdates, warnings
@@ -369,21 +559,20 @@ type latestSubscriptionArgs[T any] struct {
 	subscriptions map[string]string
 	getManifests  func() []T
 	idFn          func(T) string
-	updateFn      func(T) types.UpdateConfig
 }
 
 func latestAssetUpdates[T any](
 	args latestSubscriptionArgs[T],
 	profileID string,
 	targetSet map[assetVersionKey]struct{},
-	getVersionsFn func(string, string) ([]types.VersionInfo, error),
+	getInstallableVersionsFn func(types.AssetType, string) ([]types.VersionInfo, error),
 	updates map[string]types.SubscriptionUpdateItem,
 	pendingUpdates *[]types.PendingSubscriptionUpdate,
 	errors *[]types.UserProfilesError,
 ) {
-	manifestUpdateByID := make(map[string]types.UpdateConfig)
+	manifestIDs := make(map[string]struct{})
 	for _, manifest := range args.getManifests() {
-		manifestUpdateByID[args.idFn(manifest)] = args.updateFn(manifest)
+		manifestIDs[args.idFn(manifest)] = struct{}{}
 	}
 
 	for assetID, currentVersion := range args.subscriptions {
@@ -392,8 +581,7 @@ func latestAssetUpdates[T any](
 			continue
 		}
 
-		update, ok := manifestUpdateByID[assetID]
-		if !ok {
+		if _, ok := manifestIDs[assetID]; !ok {
 			*errors = append(*errors, updateSubscriptionError(
 				profileID, assetID, args.assetType, types.ErrorLookupFailed,
 				fmt.Errorf("Asset %q missing from registry manifests for %s", assetID, args.assetType),
@@ -401,7 +589,7 @@ func latestAssetUpdates[T any](
 			continue
 		}
 
-		latestVersion, resolveErr := resolveLatestVersionForManifest(update, getVersionsFn)
+		latestVersion, resolveErr := resolveLatestInstallableVersion(args.assetType, assetID, getInstallableVersionsFn)
 		if resolveErr != nil {
 			*errors = append(*errors, updateSubscriptionError(
 				profileID, assetID, args.assetType, types.ErrorLookupFailed,
@@ -452,14 +640,22 @@ func shouldUpdate(targetSet map[assetVersionKey]struct{}, assetType types.AssetT
 	return ok
 }
 
-func resolveLatestVersionForManifest(
-	update types.UpdateConfig,
-	getVersionsFn func(string, string) ([]types.VersionInfo, error),
+// resolveLatestInstallableVersion returns the latest integrity-complete version for the asset.
+// Resolving against the installable set rather than the raw upstream release list ensures auto-update (and other consumers of this function) never advance a subscription to a version the downloader would reject.
+func resolveLatestInstallableVersion(
+	assetType types.AssetType,
+	assetID string,
+	getInstallableVersionsFn func(types.AssetType, string) ([]types.VersionInfo, error),
 ) (string, error) {
-	versions, err := getVersionsFn(update.Type, update.Source())
+	versions, err := getInstallableVersionsFn(assetType, assetID)
 	if err != nil {
-		return "", fmt.Errorf("Failed to resolve versions: %w", err)
+		return "", fmt.Errorf("Failed to resolve installable versions: %w", err)
 	}
+	return latestSemverVersion(versions)
+}
+
+// latestSemverVersion returns the highest semver version from the provided list.
+func latestSemverVersion(versions []types.VersionInfo) (string, error) {
 	if len(versions) == 0 {
 		return "", errors.New("No versions found")
 	}
@@ -523,22 +719,14 @@ func (s *UserProfiles) updateProfileSubscriptions(req types.UpdateSubscriptionsR
 		operation, opErr := applySubscriptionMutation(&profile, req.Action, strings.TrimSpace(assetID), item)
 		if opErr != nil {
 			s.Logger.Error("Failed to apply subscription mutation", *opErr, "asset_id", assetID, "asset_type", item.Type, "action", req.Action)
-			result := updateResultBase(types.UpdateSubscriptions, types.ResponseError, "Failed to apply subscription mutation")
-			result.Profile = profile
-			result.Errors = []types.UserProfilesError{*opErr}
-			return result
+			return subscriptionErrorResult(types.UpdateSubscriptions, profile, nil, "Failed to apply subscription mutation", *opErr)
 		}
 		operations = appendOperation(operations, operation)
 	}
 
 	if err := s.commitProfileMutation(&stateCopy, req.ProfileID, profile, shouldPersist(req.ApplyMode)); err != nil {
-		result := updateResultBase(types.UpdateSubscriptions, types.ResponseError, "Failed to persist subscriptions")
-		result.Profile = profile
-		result.Operations = operations
-		result.Errors = []types.UserProfilesError{
-			updateSubscriptionError(req.ProfileID, "", "", types.ErrorPersistFailed, fmt.Errorf("Failed to persist subscriptions: %w", err)),
-		}
-		return result
+		persistErr := updateSubscriptionError(req.ProfileID, "", "", types.ErrorPersistFailed, fmt.Errorf("Failed to persist subscriptions: %w", err))
+		return subscriptionErrorResult(types.UpdateSubscriptions, profile, operations, "Failed to persist subscriptions", persistErr)
 	}
 
 	result := updateResultBase(types.UpdateSubscriptions, types.ResponseSuccess, "Subscriptions updated")
@@ -660,11 +848,7 @@ func (s *UserProfiles) ImportAsset(req types.ImportAssetRequest) types.UpdateSub
 			types.ErrorPersistFailed,
 			fmt.Errorf("failed to persist imported asset subscriptions: %w", err),
 		)
-		result := updateResultBase(types.ImportAsset, types.ResponseError, "Failed to persist imported asset subscriptions")
-		result.Profile = nextProfile
-		result.Operations = operations
-		result.Errors = []types.UserProfilesError{persistErr}
-		return result
+		return subscriptionErrorResult(types.ImportAsset, nextProfile, operations, "Failed to persist imported asset subscriptions", persistErr)
 	}
 
 	status := types.ResponseSuccess

--- a/railyard/internal/profiles/profiles_update_test.go
+++ b/railyard/internal/profiles/profiles_update_test.go
@@ -511,6 +511,52 @@ func TestUpdateSubscriptionsToLatest(t *testing.T) {
 			},
 		},
 		{
+			name:      "Stops at latest integrity-approved version and ignores newer upstream-only release",
+			profileID: types.DefaultProfileID,
+			apply:     true,
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Maps["map-a"] = "1.0.0"
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			setup: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
+				t.Helper()
+				configureConfig(t, cfg)
+				return mockRegistry(t, reg, []registryFixture{
+					{
+						assetID:   "map-a",
+						assetType: types.AssetTypeMap,
+						versions:  []string{"1.0.0", "2.0.0"}, // integrity-approved versions
+						// 3.0.0 exists upstream but has not been integrity-approved yet; auto-update
+						// must not advance the subscription to it.
+						incompleteVersions: []string{"3.0.0"},
+						mapCode:            "AAA",
+					},
+				})
+			},
+			expected: expectation{
+				expectedStatus:       types.ResponseSuccess,
+				expectedRequestType:  types.LatestApply,
+				expectedHasUpdates:   true,
+				expectedPendingCount: 1,
+				expectedPendingByKey: map[string][2]string{
+					"map:map-a": {"1.0.0", "2.0.0"},
+				},
+				expectedApplied:         true,
+				expectedPersisted:       true,
+				expectedOperationByID:   map[string]string{"map-a": "2.0.0"},
+				expectedMapSubscription: "2.0.0", // upstream-only 3.0.0 is ignored
+			},
+			assertResult: func(t *testing.T, _ *UserProfiles, reg *registry.Registry, _ types.UpdateSubscriptionsResult) {
+				t.Helper()
+				require.Len(t, reg.GetInstalledMaps(), 1)
+				require.Equal(t, "map-a", reg.GetInstalledMaps()[0].ID)
+				require.Equal(t, "2.0.0", reg.GetInstalledMaps()[0].Version)
+			},
+		},
+		{
 			name:      "No-op when all subscriptions are up-to-date",
 			profileID: types.DefaultProfileID,
 			apply:     true,
@@ -878,6 +924,168 @@ func TestUpdateSubscriptionsToLatest(t *testing.T) {
 			if tc.expected.expectedModSubscription != "" && tc.expected.expectedModID != "" {
 				require.Equal(t, tc.expected.expectedModSubscription, persistedProfile.Subscriptions.Mods[tc.expected.expectedModID])
 			}
+		})
+	}
+}
+
+func TestReconcileSubscriptionVersions(t *testing.T) {
+	testCases := []struct {
+		name         string
+		state        types.UserProfilesState
+		setup        func(t *testing.T, cfg *config.Config, reg *registry.Registry) func()
+		expectStatus types.Status
+		assertResult func(t *testing.T, result types.UpdateSubscriptionsResult, persisted types.UserProfile)
+	}{
+		{
+			name: "Downgrades a map subscription set to an upstream-only version",
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Maps["map-a"] = "3.0.0" // upstream-only, not integrity-approved
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			setup: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
+				t.Helper()
+				configureConfig(t, cfg)
+				return mockRegistry(t, reg, []registryFixture{
+					{
+						assetID:            "map-a",
+						assetType:          types.AssetTypeMap,
+						versions:           []string{"1.0.0", "2.0.0"},
+						incompleteVersions: []string{"3.0.0"},
+						mapCode:            "AAA",
+					},
+				})
+			},
+			expectStatus: types.ResponseWarn, // User should be warned that their version was not valid and has been downgraded
+			assertResult: func(t *testing.T, result types.UpdateSubscriptionsResult, persisted types.UserProfile) {
+				t.Helper()
+				require.Equal(t, "2.0.0", result.Profile.Subscriptions.Maps["map-a"]) // 2.0.0 is the latest integrity-complete version
+				require.Equal(t, "2.0.0", persisted.Subscriptions.Maps["map-a"])
+			},
+		},
+		{
+			name: "Downgrades a mod subscription set to an upstream-only version",
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Mods["mod-a"] = "0.8.6" // upstream-only, not integrity-approved
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			setup: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
+				t.Helper()
+				configureConfig(t, cfg)
+				return mockRegistry(t, reg, []registryFixture{
+					{
+						assetID:            "mod-a",
+						assetType:          types.AssetTypeMod,
+						versions:           []string{"0.8.4", "0.8.5"},
+						incompleteVersions: []string{"0.8.6"},
+					},
+				})
+			},
+			expectStatus: types.ResponseWarn,
+			assertResult: func(t *testing.T, result types.UpdateSubscriptionsResult, persisted types.UserProfile) {
+				t.Helper()
+				require.Equal(t, "0.8.5", result.Profile.Subscriptions.Mods["mod-a"]) // latest integrity-complete mod version
+				require.Equal(t, "0.8.5", persisted.Subscriptions.Mods["mod-a"])
+			},
+		},
+		{
+			name: "No change when current version is installable",
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Maps["map-a"] = "2.0.0"
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			setup: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
+				t.Helper()
+				configureConfig(t, cfg)
+				return mockRegistry(t, reg, []registryFixture{
+					{
+						assetID:   "map-a",
+						assetType: types.AssetTypeMap,
+						versions:  []string{"1.0.0", "2.0.0"},
+						mapCode:   "AAA",
+					},
+				})
+			},
+			expectStatus: types.ResponseSuccess,
+			assertResult: func(t *testing.T, result types.UpdateSubscriptionsResult, persisted types.UserProfile) {
+				t.Helper()
+				require.Empty(t, result.Operations)
+				require.Equal(t, "2.0.0", persisted.Subscriptions.Maps["map-a"])
+			},
+		},
+		{
+			name: "Purges subscription when asset has no complete version",
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Maps["map-a"] = "1.0.0"
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			setup: func(t *testing.T, cfg *config.Config, reg *registry.Registry) func() {
+				t.Helper()
+				configureConfig(t, cfg)
+				return mockRegistry(t, reg, []registryFixture{
+					{
+						assetID:   "map-a",
+						assetType: types.AssetTypeMap,
+						// No integrity-approved versions; only an upstream-only release exists.
+						incompleteVersions: []string{"1.0.0"},
+						mapCode:            "AAA",
+					},
+				})
+			},
+			expectStatus: types.ResponseWarn,
+			assertResult: func(t *testing.T, result types.UpdateSubscriptionsResult, persisted types.UserProfile) {
+				t.Helper()
+				_, exists := result.Profile.Subscriptions.Maps["map-a"] // Map subscription is removed from result profile
+				require.False(t, exists)
+				_, persistedExists := persisted.Subscriptions.Maps["map-a"]
+				require.False(t, persistedExists)
+			},
+		},
+		{
+			name: "Skips reconciliation when registry is not loaded",
+			state: func() types.UserProfilesState {
+				state := types.InitialProfilesState()
+				profile := state.Profiles[types.DefaultProfileID]
+				profile.Subscriptions.Maps["map-a"] = "1.0.0"
+				state.Profiles[types.DefaultProfileID] = profile
+				return state
+			}(),
+			// No registry fixtures: integrity report is empty, so a missing asset must not be purged.
+			expectStatus: types.ResponseSuccess,
+			assertResult: func(t *testing.T, result types.UpdateSubscriptionsResult, persisted types.UserProfile) {
+				t.Helper()
+				require.Empty(t, result.Operations)
+				require.Equal(t, "1.0.0", persisted.Subscriptions.Maps["map-a"])
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, cfg, reg := loadedUserProfilesServiceWithDependencies(t, tc.state)
+			if tc.setup != nil {
+				if cleanup := tc.setup(t, cfg, reg); cleanup != nil {
+					defer cleanup()
+				}
+			}
+
+			result := svc.ReconcileSubscriptionVersions(types.DefaultProfileID)
+			require.Equal(t, tc.expectStatus, result.Status)
+
+			persisted, readErr := ReadUserProfilesState()
+			require.NoError(t, readErr)
+			tc.assertResult(t, result, persisted.Profiles[types.DefaultProfileID])
 		})
 	}
 }

--- a/railyard/internal/testutil/registrytest/registry_mock_server.go
+++ b/railyard/internal/testutil/registrytest/registry_mock_server.go
@@ -24,6 +24,14 @@ type UpdateFixture struct {
 	ArchiveBytes []byte
 	// MissingModManifest serves a mod zip without manifest.json to exercise invalid-archive paths.
 	MissingModManifest bool
+	// IncompleteVersions are available upstream via Github API (so GetVersions sees them) but are not complete within integrity (so GetInstallableVersions excludes them). This test asset set directly targets this upstream/integrity gap.
+	IncompleteVersions []string
+}
+
+// remoteVersions returns every version the upstream releases endpoint returns
+func (f UpdateFixture) remoteVersions() []string {
+	served := append([]string{}, f.Versions...)
+	return append(served, f.IncompleteVersions...)
 }
 
 func MockZip(t *testing.T, files map[string][]byte) []byte {
@@ -138,12 +146,13 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 				return
 			}
 
+			remoteVersions := current.remoteVersions()
 			payload := types.CustomUpdateFile{
 				SchemaVersion: 1,
-				Versions:      make([]types.CustomUpdateVersion, 0, len(current.Versions)),
+				Versions:      make([]types.CustomUpdateVersion, 0, len(remoteVersions)),
 			}
 
-			for _, version := range current.Versions {
+			for _, version := range remoteVersions {
 				downloadPath := "/downloads/" + current.AssetID + "-" + version + ".zip"
 				payload.Versions = append(payload.Versions, types.CustomUpdateVersion{
 					Version:  version,
@@ -161,7 +170,7 @@ func MockRegistryServer(t *testing.T, reg any, fixtures []UpdateFixture) func() 
 		if current.FailVersions {
 			continue
 		}
-		for _, version := range current.Versions {
+		for _, version := range current.remoteVersions() {
 			downloadPath := "/downloads/" + current.AssetID + "-" + version + ".zip"
 			if current.ArchiveBytes != nil {
 				zipByDownloadPath[downloadPath] = current.ArchiveBytes
@@ -217,9 +226,13 @@ func integrityListingFromFixture(fixture UpdateFixture) types.IntegrityListing {
 	hasComplete := len(fixture.Versions) > 0 && !fixture.FailVersions
 	latestComplete := hasComplete
 	completeVersions := append([]string{}, fixture.Versions...)
-	versions := make(map[string]types.IntegrityVersionStatus, len(fixture.Versions))
+	incompleteVersions := append([]string{}, fixture.IncompleteVersions...)
+	versions := make(map[string]types.IntegrityVersionStatus, len(fixture.Versions)+len(fixture.IncompleteVersions))
 	for _, version := range fixture.Versions {
 		versions[version] = types.IntegrityVersionStatus{IsComplete: hasComplete}
+	}
+	for _, version := range fixture.IncompleteVersions {
+		versions[version] = types.IntegrityVersionStatus{IsComplete: false}
 	}
 
 	return types.IntegrityListing{
@@ -227,7 +240,7 @@ func integrityListingFromFixture(fixture UpdateFixture) types.IntegrityListing {
 		LatestSemverVersion:  nil,
 		LatestSemverComplete: &latestComplete,
 		CompleteVersions:     completeVersions,
-		IncompleteVersions:   []string{},
+		IncompleteVersions:   incompleteVersions,
 		Versions:             versions,
 	}
 }

--- a/railyard/internal/types/common.go
+++ b/railyard/internal/types/common.go
@@ -94,6 +94,8 @@ var autoPurgeDownloadErrorTypes = map[DownloaderErrorType]struct{}{
 	InstallErrorInvalidManifest: {},
 	InstallErrorInvalidArchive:  {},
 	InstallErrorChecksumFailed:  {},
+	// Error for a version removed from the installable set while the app is running; ReconcileSubscriptionVersions repairs the same condition before sync at startup.
+	InstallErrorVersionNotFound: {},
 	// TODO: Add another error if the map/mod salt is not present in the installed folder
 }
 

--- a/railyard/internal/types/common_test.go
+++ b/railyard/internal/types/common_test.go
@@ -45,6 +45,7 @@ func TestAutoPurgeDownloadErrors(t *testing.T) {
 	require.True(t, AutoPurgeDownloadErrors(InstallErrorInvalidManifest))
 	require.True(t, AutoPurgeDownloadErrors(InstallErrorInvalidArchive))
 	require.True(t, AutoPurgeDownloadErrors(InstallErrorChecksumFailed))
+	require.True(t, AutoPurgeDownloadErrors(InstallErrorVersionNotFound))
 	require.False(t, AutoPurgeDownloadErrors(InstallErrorVersionLookup))
 }
 

--- a/railyard/internal/types/profile_types.go
+++ b/railyard/internal/types/profile_types.go
@@ -70,6 +70,24 @@ type Subscriptions struct {
 	Mods      map[string]string `json:"mods"`
 }
 
+// RemoteSubscriptionBucket pairs a non-local subscription map with the asset type it holds.
+type RemoteSubscriptionBucket struct {
+	AssetType AssetType
+	Entries   map[string]string
+}
+
+// RemoteSubscriptions returns each non-local subscription map paired with its asset type. Local
+// subscriptions are excluded because they are reconciled against installed state rather than
+// registry versions. This is the single source of truth for asset-type-agnostic operations over
+// remote subscriptions (e.g. version reconciliation); a new remote asset class is picked up
+// everywhere once it is added here.
+func (s Subscriptions) RemoteSubscriptions() []RemoteSubscriptionBucket {
+	return []RemoteSubscriptionBucket{
+		{AssetType: AssetTypeMap, Entries: s.Maps},
+		{AssetType: AssetTypeMod, Entries: s.Mods},
+	}
+}
+
 // ForEachSubscriptionType iterates over all map[string]string fields on Subscriptions.
 // It uses the field's JSON name as the subscription type key when available.
 func (s Subscriptions) ForEachSubscriptionType(fn func(subscriptionType string, entries map[string]string) bool) {

--- a/railyard/internal/types/profile_types_test.go
+++ b/railyard/internal/types/profile_types_test.go
@@ -211,6 +211,24 @@ func TestSubscriptionsForEachSubscriptionTypeUsesJSONNames(t *testing.T) {
 	require.Equal(t, []string{"localMaps", "maps", "mods"}, buckets)
 }
 
+func TestSubscriptionsRemoteSubscriptionsExcludesLocal(t *testing.T) {
+	subscriptions := Subscriptions{
+		Maps:      map[string]string{"map-a": "1.0.0"},
+		LocalMaps: map[string]string{"local-map-a": "1.0.0"},
+		Mods:      map[string]string{"mod-a": "2.0.0"},
+	}
+
+	byAssetType := map[AssetType]map[string]string{}
+	for _, bucket := range subscriptions.RemoteSubscriptions() {
+		byAssetType[bucket.AssetType] = bucket.Entries
+	}
+
+	require.Equal(t, map[AssetType]map[string]string{
+		AssetTypeMap: {"map-a": "1.0.0"},
+		AssetTypeMod: {"mod-a": "2.0.0"},
+	}, byAssetType)
+}
+
 func TestSubscriptionsHasAny(t *testing.T) {
 	require.False(t, Subscriptions{
 		Maps:      map[string]string{},


### PR DESCRIPTION
Right now map/mod subscription can get set (via auto-update or any update path) to a version that exists upstream (via Github API checks) but isn't installable (because it hasn't passed integrity)

This leaves profile statepermanently broken and blocking all other installs :/

This PR therefore does a few different things;

- Gate auto-update to integrity-completeversions..... latest resolution now uses `GetInstallableVersions` like everything else, so auto-update can never set subscription to something that we wouldn't download due to interity failure. I already gated Browse at some point in the past and this should close the only blind spot.
- Reconcile non-installable versions before sync (this is a newbootstrap). Downgrades a stuck subscription to the latest installable (or purge if no installble). Runs at startup (post-refresh, but pre-sync) and on profile swap.
- Runtime bootstrap/self-heal. Auto-purge on `install_version_not_found` 