### PR TITLE
[Backend] game_version: source-provided precedence + read github values from integrity

### DIFF
--- a/railyard/internal/registry/game_version.go
+++ b/railyard/internal/registry/game_version.go
@@ -1,0 +1,121 @@
+package registry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"railyard/internal/constants"
+	"railyard/internal/requests"
+	"railyard/internal/types"
+
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// modManifestDeps is the minimal schema needed to extract dependencies from a mod's manifest.json.
+type modManifestDeps struct {
+	Dependencies map[string]string `json:"dependencies"`
+}
+
+// applyIntegrityGameMeta fills GameVersion/Dependencies from the integrity report,
+// matched by the github release's repo+tag (the integrity version source carries
+// both, so no asset ID is needed). Source-provided values are left untouched.
+func (r *Registry) applyIntegrityGameMeta(repo string, versions []types.VersionInfo) {
+	repoLower := strings.ToLower(repo)
+	byTag := make(map[string]types.IntegrityVersionStatus)
+	for _, report := range []types.RegistryIntegrityReport{r.integrityMaps, r.integrityMods} {
+		for _, listing := range report.Listings {
+			for tag, status := range listing.Versions {
+				if status.GameVersion == "" || status.Source.UpdateType != "github" {
+					continue
+				}
+				// Integrity stores lowercased repos; match case-insensitively.
+				if strings.ToLower(status.Source.Repo) == repoLower {
+					byTag[tag] = status
+				}
+			}
+		}
+	}
+	if len(byTag) == 0 {
+		return
+	}
+	for i := range versions {
+		if versions[i].GameVersion != "" {
+			continue
+		}
+		if status, ok := byTag[versions[i].Version]; ok {
+			versions[i].GameVersion = status.GameVersion
+			if len(status.Dependencies) > 0 {
+				versions[i].Dependencies = status.Dependencies
+			}
+		}
+	}
+}
+
+// enrichVersions fills GameVersion/dependencies from each version's manifest.json,
+// in parallel, as a fallback when the source/integrity did not already provide them.
+func (r *Registry) enrichVersions(versions []types.VersionInfo) {
+	var wg sync.WaitGroup
+	for i := range versions {
+		if versions[i].Manifest == "" {
+			continue
+		}
+		// Already supplied by the source (custom JSON) or the integrity report
+		// (github) — skip the manifest fetch entirely.
+		if versions[i].GameVersion != "" {
+			continue
+		}
+		wg.Add(1)
+		go func(v *types.VersionInfo) {
+			defer wg.Done()
+			resp, err := requests.GetWithGithubToken(r.httpClient, requests.GithubTokenRequestArgs{
+				URL: v.Manifest,
+				Headers: map[string]string{
+					"Accept": "application/octet-stream",
+				},
+				OnTokenRejected: func(statusCode int) {
+					r.logger.Warn("GitHub token rejected; retrying unauthenticated request", "status", statusCode)
+					requestErrType := types.GetErrorTypeForStatus(statusCode)
+					if r.context.Value("test") != "true" {
+						wailsruntime.EventsEmit(r.context, "requests:request-error", requestErrType)
+					}
+				},
+			})
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return
+			}
+			body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+			if err != nil {
+				return
+			}
+			var manifest modManifestDeps
+			if err := json.Unmarshal(body, &manifest); err != nil {
+				return
+			}
+			// GameVersion is empty here (set ones are skipped above).
+			if sbRange, ok := manifest.Dependencies[constants.GameDependencyKey]; ok {
+				v.GameVersion = sbRange
+			}
+			// Keep source-provided dependencies; otherwise take the manifest's.
+			if len(v.Dependencies) == 0 {
+				newDeps := make(map[string]string)
+				for depID, depRange := range manifest.Dependencies {
+					if depID == constants.GameDependencyKey {
+						continue
+					}
+					newDeps[depID] = depRange
+				}
+				if len(newDeps) > 0 {
+					v.Dependencies = newDeps
+				}
+			}
+		}(&versions[i])
+	}
+	wg.Wait()
+}

--- a/railyard/internal/registry/versions.go
+++ b/railyard/internal/registry/versions.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"sync"
 
 	"railyard/internal/constants"
 	"railyard/internal/requests"
@@ -18,11 +17,6 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
-
-// modManifestDeps is the minimal schema needed to extract dependencies from a mod's manifest.json.
-type modManifestDeps struct {
-	Dependencies map[string]string `json:"dependencies"`
-}
 
 // GetVersions fetches available versions for a mod or map.
 // updateType must be "github" or "custom".
@@ -141,113 +135,6 @@ func (r *Registry) getGitHubVersions(cacheKey string, repo string) ([]types.Vers
 
 	r.versions.store(cacheKey, resp.Header.Get("ETag"), versions)
 	return cloneVersionInfos(versions), nil
-}
-
-// applyIntegrityGameMeta fills GameVersion/Dependencies on each version from the
-// integrity report, matched by the github release's repo and tag. The integrity
-// version source carries repo+tag, so this works without the listing's asset ID.
-// Source-provided values (already set) are left untouched.
-func (r *Registry) applyIntegrityGameMeta(repo string, versions []types.VersionInfo) {
-	repoLower := strings.ToLower(repo)
-	byTag := make(map[string]types.IntegrityVersionStatus)
-	for _, report := range []types.RegistryIntegrityReport{r.integrityMaps, r.integrityMods} {
-		for _, listing := range report.Listings {
-			for tag, status := range listing.Versions {
-				if status.GameVersion == "" || status.Source.UpdateType != "github" {
-					continue
-				}
-				if strings.ToLower(status.Source.Repo) == repoLower {
-					byTag[tag] = status
-				}
-			}
-		}
-	}
-	if len(byTag) == 0 {
-		return
-	}
-	for i := range versions {
-		if versions[i].GameVersion != "" {
-			continue
-		}
-		if status, ok := byTag[versions[i].Version]; ok {
-			versions[i].GameVersion = status.GameVersion
-			if len(status.Dependencies) > 0 {
-				versions[i].Dependencies = status.Dependencies
-			}
-		}
-	}
-}
-
-// enrichVersions fetches manifest.json URLs in parallel and fills in GameVersion
-// and dependencies from the game dependency key in the manifest. Values already
-// supplied by the version source (e.g. a custom update JSON's game_version,
-// which may be an author-authored range like "<=1.3.0") take precedence and are
-// never overwritten by the manifest. Errors are silently ignored per-version.
-func (r *Registry) enrichVersions(versions []types.VersionInfo) {
-	var wg sync.WaitGroup
-	for i := range versions {
-		if versions[i].Manifest == "" {
-			continue
-		}
-		// game_version (and deps) already supplied by the source or the integrity
-		// report — skip the manifest fetch entirely.
-		if versions[i].GameVersion != "" {
-			continue
-		}
-		wg.Add(1)
-		go func(v *types.VersionInfo) {
-			defer wg.Done()
-			resp, err := requests.GetWithGithubToken(r.httpClient, requests.GithubTokenRequestArgs{
-				URL: v.Manifest,
-				Headers: map[string]string{
-					"Accept": "application/octet-stream",
-				},
-				OnTokenRejected: func(statusCode int) {
-					r.logger.Warn("GitHub token rejected; retrying unauthenticated request", "status", statusCode)
-					requestErrType := types.GetErrorTypeForStatus(statusCode)
-					if r.context.Value("test") != "true" {
-						wailsruntime.EventsEmit(r.context, "requests:request-error", requestErrType)
-					}
-				},
-			})
-			if err != nil {
-				return
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				return
-			}
-			body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
-			if err != nil {
-				return
-			}
-			var manifest modManifestDeps
-			if err := json.Unmarshal(body, &manifest); err != nil {
-				return
-			}
-			// Only fill GameVersion from the manifest when the source did not
-			// already provide it, so a custom JSON's game_version wins.
-			if v.GameVersion == "" {
-				if sbRange, ok := manifest.Dependencies[constants.GameDependencyKey]; ok {
-					v.GameVersion = sbRange
-				}
-			}
-			// Likewise, keep source-provided dependencies over the manifest's.
-			if len(v.Dependencies) == 0 {
-				newDeps := make(map[string]string)
-				for depID, depRange := range manifest.Dependencies {
-					if depID == constants.GameDependencyKey {
-						continue
-					}
-					newDeps[depID] = depRange
-				}
-				if len(newDeps) > 0 {
-					v.Dependencies = newDeps
-				}
-			}
-		}(&versions[i])
-	}
-	wg.Wait()
 }
 
 func (r *Registry) getCustomVersions(cacheKey string, updateURL string) ([]types.VersionInfo, error) {

--- a/railyard/internal/registry/versions.go
+++ b/railyard/internal/registry/versions.go
@@ -140,8 +140,11 @@ func (r *Registry) getGitHubVersions(cacheKey string, repo string) ([]types.Vers
 	return cloneVersionInfos(versions), nil
 }
 
-// enrichVersions fetches manifest.json URLs in parallel and populates GameVersion and dependencies
-// from the game dependency key in the manifest. Errors are silently ignored per-version.
+// enrichVersions fetches manifest.json URLs in parallel and fills in GameVersion
+// and dependencies from the game dependency key in the manifest. Values already
+// supplied by the version source (e.g. a custom update JSON's game_version,
+// which may be an author-authored range like "<=1.3.0") take precedence and are
+// never overwritten by the manifest. Errors are silently ignored per-version.
 func (r *Registry) enrichVersions(versions []types.VersionInfo) {
 	var wg sync.WaitGroup
 	for i := range versions {
@@ -179,17 +182,26 @@ func (r *Registry) enrichVersions(versions []types.VersionInfo) {
 			if err := json.Unmarshal(body, &manifest); err != nil {
 				return
 			}
-			if sbRange, ok := manifest.Dependencies[constants.GameDependencyKey]; ok {
-				v.GameVersion = sbRange
-			}
-			newDeps := make(map[string]string)
-			for depID, depRange := range manifest.Dependencies {
-				if depID == constants.GameDependencyKey {
-					continue
+			// Only fill GameVersion from the manifest when the source did not
+			// already provide it, so a custom JSON's game_version wins.
+			if v.GameVersion == "" {
+				if sbRange, ok := manifest.Dependencies[constants.GameDependencyKey]; ok {
+					v.GameVersion = sbRange
 				}
-				newDeps[depID] = depRange
 			}
-			v.Dependencies = newDeps
+			// Likewise, keep source-provided dependencies over the manifest's.
+			if len(v.Dependencies) == 0 {
+				newDeps := make(map[string]string)
+				for depID, depRange := range manifest.Dependencies {
+					if depID == constants.GameDependencyKey {
+						continue
+					}
+					newDeps[depID] = depRange
+				}
+				if len(newDeps) > 0 {
+					v.Dependencies = newDeps
+				}
+			}
 		}(&versions[i])
 	}
 	wg.Wait()

--- a/railyard/internal/registry/versions.go
+++ b/railyard/internal/registry/versions.go
@@ -133,11 +133,49 @@ func (r *Registry) getGitHubVersions(cacheKey string, repo string) ([]types.Vers
 	}
 
 	versions = r.filterSemverVersions(versions, "github:"+repo)
-	// Fetch manifest.json assets in parallel to extract game_version
+	// Prefer game_version/deps already recorded in the integrity report (parsed
+	// from the release manifest asset by the registry pipeline). enrichVersions
+	// then only fetches manifests for versions still missing it.
+	r.applyIntegrityGameMeta(repo, versions)
 	r.enrichVersions(versions)
 
 	r.versions.store(cacheKey, resp.Header.Get("ETag"), versions)
 	return cloneVersionInfos(versions), nil
+}
+
+// applyIntegrityGameMeta fills GameVersion/Dependencies on each version from the
+// integrity report, matched by the github release's repo and tag. The integrity
+// version source carries repo+tag, so this works without the listing's asset ID.
+// Source-provided values (already set) are left untouched.
+func (r *Registry) applyIntegrityGameMeta(repo string, versions []types.VersionInfo) {
+	repoLower := strings.ToLower(repo)
+	byTag := make(map[string]types.IntegrityVersionStatus)
+	for _, report := range []types.RegistryIntegrityReport{r.integrityMaps, r.integrityMods} {
+		for _, listing := range report.Listings {
+			for tag, status := range listing.Versions {
+				if status.GameVersion == "" || status.Source.UpdateType != "github" {
+					continue
+				}
+				if strings.ToLower(status.Source.Repo) == repoLower {
+					byTag[tag] = status
+				}
+			}
+		}
+	}
+	if len(byTag) == 0 {
+		return
+	}
+	for i := range versions {
+		if versions[i].GameVersion != "" {
+			continue
+		}
+		if status, ok := byTag[versions[i].Version]; ok {
+			versions[i].GameVersion = status.GameVersion
+			if len(status.Dependencies) > 0 {
+				versions[i].Dependencies = status.Dependencies
+			}
+		}
+	}
 }
 
 // enrichVersions fetches manifest.json URLs in parallel and fills in GameVersion
@@ -149,6 +187,11 @@ func (r *Registry) enrichVersions(versions []types.VersionInfo) {
 	var wg sync.WaitGroup
 	for i := range versions {
 		if versions[i].Manifest == "" {
+			continue
+		}
+		// game_version (and deps) already supplied by the source or the integrity
+		// report — skip the manifest fetch entirely.
+		if versions[i].GameVersion != "" {
 			continue
 		}
 		wg.Add(1)

--- a/railyard/internal/registry/versions_test.go
+++ b/railyard/internal/registry/versions_test.go
@@ -179,3 +179,31 @@ func TestGetCustomVersionsSortsSemverDescending(t *testing.T) {
 	require.Equal(t, "v1.0.1", versions[0].Version)
 	require.Equal(t, "v1.0.0", versions[1].Version)
 }
+
+func TestEnrichVersionsPreservesSourceProvidedGameVersionAndDeps(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+	reg.SetContext(context.WithValue(context.Background(), "test", "true"))
+
+	server := testutil.NewLocalhostServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"dependencies":{"subway-builder":"1.0.0","other-mod":"^2.0.0"}}`)
+	}))
+	defer server.Close()
+	manifestURL := server.URL + "/manifest.json"
+
+	versions := []types.VersionInfo{
+		// Source (custom JSON) provided a game_version range — must be preserved.
+		{Version: "0.3.0", GameVersion: "<=1.3.0", Manifest: manifestURL},
+		// Source provided dependencies — must be preserved over the manifest's.
+		{Version: "0.2.0", Dependencies: map[string]string{"foo": "1.0.0"}, Manifest: manifestURL},
+		// Source provided neither — both filled from the manifest.
+		{Version: "0.1.0", Manifest: manifestURL},
+	}
+
+	reg.enrichVersions(versions)
+
+	require.Equal(t, "<=1.3.0", versions[0].GameVersion)
+	require.Equal(t, map[string]string{"foo": "1.0.0"}, versions[1].Dependencies)
+	require.Equal(t, "1.0.0", versions[2].GameVersion)
+	require.Equal(t, map[string]string{"other-mod": "^2.0.0"}, versions[2].Dependencies)
+}

--- a/railyard/internal/registry/versions_test.go
+++ b/railyard/internal/registry/versions_test.go
@@ -207,3 +207,31 @@ func TestEnrichVersionsPreservesSourceProvidedGameVersionAndDeps(t *testing.T) {
 	require.Equal(t, "1.0.0", versions[2].GameVersion)
 	require.Equal(t, map[string]string{"other-mod": "^2.0.0"}, versions[2].Dependencies)
 }
+
+func TestApplyIntegrityGameMetaFillsGithubVersionsFromIntegrity(t *testing.T) {
+	reg := newTestRegistry(t)
+	reg.integrityMaps = types.RegistryIntegrityReport{
+		Listings: map[string]types.IntegrityListing{
+			"map-a": {Versions: map[string]types.IntegrityVersionStatus{
+				"v1.2.3": {
+					GameVersion:  "<=1.3.0",
+					Dependencies: map[string]string{"dep": "^1.0.0"},
+					Source:       types.IntegrityVersionSource{UpdateType: "github", Repo: "owner/repo", Tag: "v1.2.3"},
+				},
+			}},
+		},
+	}
+
+	versions := []types.VersionInfo{
+		{Version: "v1.2.3"},                          // filled from integrity
+		{Version: "v9.9.9"},                          // not in integrity -> untouched
+		{Version: "v1.0.0", GameVersion: "preset"},   // source-provided -> not overwritten
+	}
+	// Repo match is case-insensitive (integrity stores lowercased repos).
+	reg.applyIntegrityGameMeta("Owner/Repo", versions)
+
+	require.Equal(t, "<=1.3.0", versions[0].GameVersion)
+	require.Equal(t, map[string]string{"dep": "^1.0.0"}, versions[0].Dependencies)
+	require.Equal(t, "", versions[1].GameVersion)
+	require.Equal(t, "preset", versions[2].GameVersion)
+}

--- a/railyard/internal/registry/versions_test.go
+++ b/railyard/internal/registry/versions_test.go
@@ -223,9 +223,9 @@ func TestApplyIntegrityGameMetaFillsGithubVersionsFromIntegrity(t *testing.T) {
 	}
 
 	versions := []types.VersionInfo{
-		{Version: "v1.2.3"},                          // filled from integrity
-		{Version: "v9.9.9"},                          // not in integrity -> untouched
-		{Version: "v1.0.0", GameVersion: "preset"},   // source-provided -> not overwritten
+		{Version: "v1.2.3"},                        // filled from integrity
+		{Version: "v9.9.9"},                        // not in integrity -> untouched
+		{Version: "v1.0.0", GameVersion: "preset"}, // source-provided -> not overwritten
 	}
 	// Repo match is case-insensitive (integrity stores lowercased repos).
 	reg.applyIntegrityGameMeta("Owner/Repo", versions)

--- a/railyard/internal/types/registry_types.go
+++ b/railyard/internal/types/registry_types.go
@@ -225,13 +225,18 @@ type IntegrityListing struct {
 
 // IntegrityVersionStatus represents the status of a specific version
 type IntegrityVersionStatus struct {
-	IsComplete     bool                   `json:"is_complete"`
-	Errors         []string               `json:"errors"`
-	RequiredChecks map[string]bool        `json:"required_checks"`
-	MatchedFiles   map[string]string      `json:"matched_files"`
-	Source         IntegrityVersionSource `json:"source"`
-	Fingerprint    string                 `json:"fingerprint"`
-	CheckedAt      string                 `json:"checked_at"`
+	IsComplete     bool              `json:"is_complete"`
+	Errors         []string          `json:"errors"`
+	RequiredChecks map[string]bool   `json:"required_checks"`
+	MatchedFiles   map[string]string `json:"matched_files"`
+	// GameVersion and Dependencies are parsed from the release manifest asset by
+	// the registry analytics pipeline (github sources only). When present, the
+	// app uses them instead of fetching each release's manifest.json.
+	GameVersion  string                 `json:"game_version,omitempty"`
+	Dependencies map[string]string      `json:"dependencies,omitempty"`
+	Source       IntegrityVersionSource `json:"source"`
+	Fingerprint  string                 `json:"fingerprint"`
+	CheckedAt    string                 `json:"checked_at"`
 }
 
 // IntegrityVersionSource represents the source information for a version


### PR DESCRIPTION
Two related changes to how the app resolves a version's `game_version`/dependencies, avoiding per-release `manifest.json` fetches and respecting author intent.

## 1. Source-provided precedence (was the original PR)

`enrichVersions` fetched each version's `manifest.json` and **unconditionally** set `GameVersion`/`Dependencies`. For **custom** update sources that ship a `manifest` URL, this clobbered the author-declared `game_version` from the custom JSON — often an intentional semver **range** (e.g. `"<=1.3.0"`). Now the version **source** wins: the manifest only fills values the source didn't provide.

## 2. Read github game_version from the integrity report

The registry analytics pipeline now records each github release's `game_version`/`dependencies` (parsed from the release **manifest asset**) into the integrity report (registry-side A2b). The app reads those directly:

- `IntegrityVersionStatus` gains `game_version`/`dependencies`.
- `getGitHubVersions` fills them from the integrity report, matched by **repo+tag** (the integrity version `source` carries both — no asset ID needed), before `enrichVersions`.
- `enrichVersions` now **skips the manifest fetch entirely** when `GameVersion` is already set — from integrity (github) or the source's own update JSON (custom).

## Source partitioning (no conflict)

- **github** → `game_version` from integrity (manifest asset).
- **custom** → `game_version` from the custom update JSON; custom listings never get an integrity `game_version`, so the JSON always wins.
- github releases without a manifest asset, or versions not yet rechecked, fall back to fetching (gradual population).

## Tests
Precedence (range preserved / deps preserved / empty-source fill) + integrity fill (repo+tag match, case-insensitive, no-overwrite).

> Depends on the registry-side A2b/A2a changes landing so integrity carries `game_version`/`last_updated`; until then the app falls back to fetching (no behavior regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)