### PR TITLE
[Backend] Hygiene: move integrity check to registry, reuse swap error helper

### DIFF
--- a/railyard/internal/profiles/profiles_state.go
+++ b/railyard/internal/profiles/profiles_state.go
@@ -637,11 +637,7 @@ func (s *UserProfiles) SwapProfile(req types.SwapProfileRequest) types.UserProfi
 	// After bootstrapping the registry state from the profile, we should attempt to reconcile any local map subscriptions that may be out of sync due to the profile swap before running a full sync to update any remaining subscriptions
 	reconcileResult := s.ReconcileLocalMapSubscriptions(targetProfile.ID)
 	if reconcileResult.Status == types.ResponseError {
-		return types.UserProfileResult{
-			GenericResponse: types.ErrorResponse("Active profile changed, but failed to reconcile local map subscriptions"),
-			Profile:         swappedProfile,
-			Errors:          reconcileResult.Errors,
-		}
+		return profileStateErrorResult("Active profile changed, but failed to reconcile local map subscriptions", swappedProfile, reconcileResult.Errors...)
 	}
 	if reconcileResult.Profile.ID != "" {
 		swappedProfile = reconcileResult.Profile
@@ -650,11 +646,7 @@ func (s *UserProfiles) SwapProfile(req types.SwapProfileRequest) types.UserProfi
 	// Run before sync so a stuck subscription from the target profile does not fail the post-swap sync for every other asset.
 	versionReconcileResult := s.ReconcileSubscriptionVersions(targetProfile.ID)
 	if versionReconcileResult.Status == types.ResponseError {
-		return types.UserProfileResult{
-			GenericResponse: types.ErrorResponse("Active profile changed, but failed to reconcile subscription versions"),
-			Profile:         swappedProfile,
-			Errors:          versionReconcileResult.Errors,
-		}
+		return profileStateErrorResult("Active profile changed, but failed to reconcile subscription versions", swappedProfile, versionReconcileResult.Errors...)
 	}
 	if versionReconcileResult.Profile.ID != "" {
 		swappedProfile = versionReconcileResult.Profile
@@ -662,11 +654,7 @@ func (s *UserProfiles) SwapProfile(req types.SwapProfileRequest) types.UserProfi
 
 	syncResult := s.SyncSubscriptions(targetProfile.ID, false, false)
 	if syncResult.Status == types.ResponseError {
-		return types.UserProfileResult{
-			GenericResponse: types.ErrorResponse("Profile swapped, but failed to sync subscriptions"),
-			Profile:         swappedProfile,
-			Errors:          syncResult.Errors,
-		}
+		return profileStateErrorResult("Profile swapped, but failed to sync subscriptions", swappedProfile, syncResult.Errors...)
 	}
 	if syncResult.Status == types.ResponseWarn || reconcileResult.Status == types.ResponseWarn || versionReconcileResult.Status == types.ResponseWarn {
 		warnErrors := append([]types.UserProfilesError{}, reconcileResult.Errors...)

--- a/railyard/internal/profiles/profiles_update.go
+++ b/railyard/internal/profiles/profiles_update.go
@@ -421,7 +421,7 @@ func (s *UserProfiles) reconcileSubscriptionVersion(
 	}
 
 	// Lookup failed: only purge when the loaded integrity report definitively has no installable version, so a transient or unloaded registry never purges a valid subscription.
-	if s.assetHasNoInstallableVersions(assetType, assetID) {
+	if s.Registry.AssetMissingInstallableVersion(assetType, assetID) {
 		return s.purgeNonInstallableSubscription(profile, profileID, assetType, assetID, pinned)
 	}
 	return s.skipVersionReconcile("Skipping subscription version reconciliation; installable versions unavailable", assetType, assetID, profileID, lookupErr)
@@ -479,20 +479,6 @@ func (s *UserProfiles) purgeNonInstallableSubscription(
 	return applySubscriptionMutation(profile, types.SubscriptionActionUnsubscribe, assetID, types.SubscriptionUpdateItem{
 		Type: assetType,
 	})
-}
-
-// assetHasNoInstallableVersions reports whether the registry's integrity set is available and undeniably lists no complete version for the asset (delisted or never approved).
-func (s *UserProfiles) assetHasNoInstallableVersions(assetType types.AssetType, assetID string) bool {
-	report, err := s.Registry.GetIntegrityReport(assetType)
-	if err != nil || len(report.Listings) == 0 {
-		// Returns false when the report is not loaded, so a missing or unreadable registry never triggers a purge.
-		return false
-	}
-	listing, ok := report.Listings[assetID]
-	if !ok {
-		return true
-	}
-	return !listing.HasCompleteVersion
 }
 
 // subscriptionReconcileNotice builds an informational error describing a reconciliation operation.

--- a/railyard/internal/registry/installable_versions.go
+++ b/railyard/internal/registry/installable_versions.go
@@ -20,6 +20,19 @@ func (r *Registry) getIntegrityListing(assetType types.AssetType, assetID string
 	}
 }
 
+// AssetMissingInstallableVersion reports whether the loaded integrity report definitively lists no
+// installable (complete) version for the asset (delisted or never approved). It returns false when no
+// integrity report is loaded for the asset type, so an unloaded or unreachable registry is never
+// treated as "definitively none".
+func (r *Registry) AssetMissingInstallableVersion(assetType types.AssetType, assetID string) bool {
+	report, err := r.GetIntegrityReport(assetType)
+	if err != nil || len(report.Listings) == 0 {
+		return false
+	}
+	listing, ok := r.getIntegrityListing(assetType, assetID)
+	return !ok || !listing.HasCompleteVersion
+}
+
 // resolveAssetUpdateSource resolves the raw update source for an asset manifest.
 func (r *Registry) resolveAssetUpdateSource(assetType types.AssetType, assetID string) (string, string, error) {
 	switch assetType {

--- a/railyard/internal/registry/integrity_test.go
+++ b/railyard/internal/registry/integrity_test.go
@@ -92,3 +92,23 @@ func TestGetInstallableVersionsRejectsMissingOrIncompleteListings(t *testing.T) 
 	_, err = reg.GetInstallableVersions(types.AssetTypeMap, "map-a")
 	require.ErrorContains(t, err, "has no complete versions")
 }
+
+func TestAssetMissingInstallableVersion(t *testing.T) {
+	reg := NewRegistry(testutil.TestLogSink{}, config.NewConfig(testutil.TestLogSink{}))
+
+	// No integrity report loaded: never reported as definitively missing (would be unsafe to purge).
+	require.False(t, reg.AssetMissingInstallableVersion(types.AssetTypeMap, "map-a"))
+
+	reg.integrityMaps = types.RegistryIntegrityReport{
+		SchemaVersion: 1,
+		GeneratedAt:   "1970-01-01T00:00:00Z",
+		Listings: map[string]types.IntegrityListing{
+			"map-complete":   {HasCompleteVersion: true},
+			"map-incomplete": {HasCompleteVersion: false},
+		},
+	}
+
+	require.False(t, reg.AssetMissingInstallableVersion(types.AssetTypeMap, "map-complete"))  // has a complete version
+	require.True(t, reg.AssetMissingInstallableVersion(types.AssetTypeMap, "map-incomplete")) // listed but no complete version
+	require.True(t, reg.AssetMissingInstallableVersion(types.AssetTypeMap, "map-delisted"))   // absent from a loaded report
+}


### PR DESCRIPTION
Two small cleanups