### PR TITLE
[Website] Read map grids from map-data branch, fall back to main

### DIFF
--- a/website/scripts/generate-map-data-cache.mjs
+++ b/website/scripts/generate-map-data-cache.mjs
@@ -10,8 +10,16 @@ const REPO_OWNER = 'Subway-Builder-Modded';
 const REPO_NAME = 'registry';
 const REPO_NAME_FALLBACK = 'The-Railyard';
 const REPO_BRANCH = 'main';
+// Large per-map artifacts (grid.geojson, basemap.svg) are relocated off main to
+// the map-data branch to keep the app's registry clone small. Read them from
+// there first, falling back to main during the transition.
+const MAP_DATA_BRANCH = 'map-data';
 const RAW_BASE = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${REPO_BRANCH}`;
 const RAW_BASE_FALLBACK = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME_FALLBACK}/${REPO_BRANCH}`;
+const MAP_DATA_BASE = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${MAP_DATA_BRANCH}`;
+const MAP_DATA_BASE_FALLBACK = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME_FALLBACK}/${MAP_DATA_BRANCH}`;
+// Grid lives on map-data post-relocation; try it before main.
+const GRID_BASES = [MAP_DATA_BASE, MAP_DATA_BASE_FALLBACK, RAW_BASE, RAW_BASE_FALLBACK];
 
 const TOKEN =
   process.env['RAILYARD_GITHUB_TOKEN']?.trim() ||
@@ -70,8 +78,7 @@ function buildHeaders() {
   return headers;
 }
 
-async function fetchJson(pathname) {
-  const bases = [RAW_BASE, RAW_BASE_FALLBACK];
+async function fetchJson(pathname, bases = [RAW_BASE, RAW_BASE_FALLBACK]) {
   let lastError;
   for (const base of bases) {
     const url = `${base}/${pathname}`;
@@ -281,7 +288,7 @@ async function main() {
 
   for (const mapId of mapIds) {
     try {
-      const grid = await fetchJson(`maps/${encodeURIComponent(mapId)}/grid.geojson`);
+      const grid = await fetchJson(`maps/${encodeURIComponent(mapId)}/grid.geojson`, GRID_BASES);
       const normalized = normalizeMapGrid(mapId, grid);
       const outputPath = path.join(OUTPUT_DIR, `${mapId}.json`);
       writeJson(outputPath, normalized);


### PR DESCRIPTION
## Why

Large per-map registry artifacts (`grid.geojson`, `basemap.svg`) are being relocated off the registry's `main` branch to a dedicated **`map-data`** branch, so the Railyard app's depth-1 registry clone stays small (these are ~179 MB + ~392 MB of data the app never reads).

## What

The map-grid cache generator (`website/scripts/generate-map-data-cache.mjs`) now resolves `grid.geojson` from `map-data` first, then falls back to `main`:
- `GRID_BASES = [map-data, map-data(The-Railyard), main, main(The-Railyard)]`
- `fetchJson` takes an optional `bases` arg; only the grid fetch uses `GRID_BASES` (`index.json` etc. stay on `main`).

**Tolerant of both states** — before relocation `map-data` 404s and it falls back to `main`; after relocation it's served from `map-data`. Lands **ahead of** the registry-side relocation so prod never loses grids mid-migration.

## Notes
- `map-data` is the agreed relocation branch name (shared contract with the registry relocation/CI and the in-progress basemap consumption work).
- website-dev mirrors `maps/` generically but does not *read* grid/basemap today, so it needs no change for grid; basemap consumption (separate in-progress work) should source from `map-data` per the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)