### PR TITLE
[Backend] Ingest binary buildings index and accept either form

### DIFF
--- a/railyard/app.go
+++ b/railyard/app.go
@@ -848,13 +848,13 @@ func (a *App) generateMod(port int) error {
 	maps := a.Registry.GetInstalledMaps()
 	a.Logger.Info("Generating mod with maps", "count", len(maps))
 
-	preferBinary := gameSupportsBinaryBuildings(a.GetGameVersion())
+	preferBinary := preferBinaryBuildingsIndex(a.GetGameVersion())
 	mapDataRoot := paths.MetroMakerMapsDataPath(a.Config.Cfg.MetroMakerDataPath)
-	places := make([]types.MetroMakerModPlace, 0, len(maps))
+	places := make([]types.MetroMakerPlace, 0, len(maps))
 	for _, m := range maps {
-		places = append(places, types.MetroMakerModPlace{
+		places = append(places, types.MetroMakerPlace{
 			ConfigData:         m.MapConfig,
-			BuildingsIndexFile: chooseBuildingsIndexStem(mapDataRoot, m.MapConfig.Code, preferBinary),
+			BuildingsIndexFile: setBuildingsIndexStem(mapDataRoot, m.MapConfig.Code, preferBinary),
 		})
 	}
 	config := types.MetroMakerModConfig{

--- a/railyard/app.go
+++ b/railyard/app.go
@@ -31,17 +31,10 @@ import (
 	"railyard/internal/updater"
 	"railyard/internal/utils"
 
-	semver "github.com/Masterminds/semver/v3"
 	"github.com/beescuit/asar"
 	"github.com/protomaps/go-pmtiles/pmtiles"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
-
-// binaryBuildingsIndexGameFloor is the game-version boundary for the buildings
-// index format: builds strictly newer than this read the packed binary
-// (buildings_index.bin); this version and older read the JSON form. Mirrors the
-// registry/jp-data 1.3.0 split.
-var binaryBuildingsIndexGameFloor = semver.MustParse("1.3.0")
 
 func panik(message string) {
 	panic(message)
@@ -906,35 +899,6 @@ func (a *App) generateMod(port int) error {
 		return fmt.Errorf("failed to write mod manifest.json: %w", err)
 	}
 	return nil
-}
-
-// gameSupportsBinaryBuildings reports whether the detected game version reads the
-// binary buildings index (game version strictly newer than the 1.3.0 floor). An
-// undetected or unparseable version falls back to false, i.e. the JSON form every
-// map ships and which older builds require.
-func gameSupportsBinaryBuildings(gv types.GameVersionResponse) bool {
-	if gv.Status != types.ResponseSuccess || gv.Version == "" {
-		return false
-	}
-	version, err := semver.NewVersion(strings.TrimPrefix(gv.Version, "v"))
-	if err != nil {
-		return false
-	}
-	return version.GreaterThan(binaryBuildingsIndexGameFloor)
-}
-
-// chooseBuildingsIndexStem picks the buildings-index filename stem the game should
-// load for a map. Binary-capable games use the .bin form when the installed map
-// actually has it; everything else uses the JSON form. The game API appends .gz, so
-// the stem resolves to buildings_index.bin.gz / buildings_index.json.gz on disk.
-func chooseBuildingsIndexStem(mapDataRoot string, code string, preferBinary bool) string {
-	if preferBinary {
-		binPath := paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz")
-		if _, err := os.Stat(binPath); err == nil {
-			return files.MapBuildingsBinFileName
-		}
-	}
-	return files.MapBuildingsFileName
 }
 
 func (a *App) addSaltsOnFirstRun() error {

--- a/railyard/app.go
+++ b/railyard/app.go
@@ -31,10 +31,17 @@ import (
 	"railyard/internal/updater"
 	"railyard/internal/utils"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/beescuit/asar"
 	"github.com/protomaps/go-pmtiles/pmtiles"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
+
+// binaryBuildingsIndexGameFloor is the game-version boundary for the buildings
+// index format: builds strictly newer than this read the packed binary
+// (buildings_index.bin); this version and older read the JSON form. Mirrors the
+// registry/jp-data 1.3.0 split.
+var binaryBuildingsIndexGameFloor = semver.MustParse("1.3.0")
 
 func panik(message string) {
 	panic(message)
@@ -847,9 +854,15 @@ func (a *App) generateMissingThumbnails(port int) {
 func (a *App) generateMod(port int) error {
 	maps := a.Registry.GetInstalledMaps()
 	a.Logger.Info("Generating mod with maps", "count", len(maps))
-	places := make([]types.ConfigData, 0, len(maps))
+
+	preferBinary := gameSupportsBinaryBuildings(a.GetGameVersion())
+	mapDataRoot := paths.MetroMakerMapsDataPath(a.Config.Cfg.MetroMakerDataPath)
+	places := make([]types.MetroMakerModPlace, 0, len(maps))
 	for _, m := range maps {
-		places = append(places, m.MapConfig)
+		places = append(places, types.MetroMakerModPlace{
+			ConfigData:         m.MapConfig,
+			BuildingsIndexFile: chooseBuildingsIndexStem(mapDataRoot, m.MapConfig.Code, preferBinary),
+		})
 	}
 	config := types.MetroMakerModConfig{
 		Port:          port,
@@ -893,6 +906,35 @@ func (a *App) generateMod(port int) error {
 		return fmt.Errorf("failed to write mod manifest.json: %w", err)
 	}
 	return nil
+}
+
+// gameSupportsBinaryBuildings reports whether the detected game version reads the
+// binary buildings index (game version strictly newer than the 1.3.0 floor). An
+// undetected or unparseable version falls back to false, i.e. the JSON form every
+// map ships and which older builds require.
+func gameSupportsBinaryBuildings(gv types.GameVersionResponse) bool {
+	if gv.Status != types.ResponseSuccess || gv.Version == "" {
+		return false
+	}
+	version, err := semver.NewVersion(strings.TrimPrefix(gv.Version, "v"))
+	if err != nil {
+		return false
+	}
+	return version.GreaterThan(binaryBuildingsIndexGameFloor)
+}
+
+// chooseBuildingsIndexStem picks the buildings-index filename stem the game should
+// load for a map. Binary-capable games use the .bin form when the installed map
+// actually has it; everything else uses the JSON form. The game API appends .gz, so
+// the stem resolves to buildings_index.bin.gz / buildings_index.json.gz on disk.
+func chooseBuildingsIndexStem(mapDataRoot string, code string, preferBinary bool) string {
+	if preferBinary {
+		binPath := paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz")
+		if _, err := os.Stat(binPath); err == nil {
+			return files.MapBuildingsBinFileName
+		}
+	}
+	return files.MapBuildingsFileName
 }
 
 func (a *App) addSaltsOnFirstRun() error {

--- a/railyard/app_mod_test.go
+++ b/railyard/app_mod_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"railyard/internal/files"
+	"railyard/internal/paths"
+	"railyard/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGameSupportsBinaryBuildings(t *testing.T) {
+	success := func(version string) types.GameVersionResponse {
+		return types.GameVersionResponse{GenericResponse: types.SuccessResponse("ok"), Version: version}
+	}
+
+	tests := []struct {
+		name string
+		resp types.GameVersionResponse
+		want bool
+	}{
+		{"newer than floor", success("1.4.0"), true},
+		{"newer with v prefix", success("v1.4.0"), true},
+		{"much newer", success("2.0.0"), true},
+		{"exactly the floor is json", success("1.3.0"), false},
+		{"older than floor", success("1.2.0"), false},
+		{"undetected version", types.GameVersionResponse{GenericResponse: types.WarnResponse("not detected"), Version: ""}, false},
+		{"success but empty version", success(""), false},
+		{"unparseable version", success("not-a-version"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, gameSupportsBinaryBuildings(tt.resp))
+		})
+	}
+}
+
+func TestChooseBuildingsIndexStem(t *testing.T) {
+	const code = "AAA"
+
+	writeBin := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		dir := paths.JoinLocalPath(root, code)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(paths.JoinLocalPath(dir, files.MapBuildingsBinFileName+".gz"), []byte("bin"), 0o644))
+		return root
+	}
+
+	t.Run("binary-capable game with the binary present loads the binary", func(t *testing.T) {
+		root := writeBin(t)
+		require.Equal(t, files.MapBuildingsBinFileName, chooseBuildingsIndexStem(root, code, true))
+	})
+
+	t.Run("binary-capable game without the binary falls back to json", func(t *testing.T) {
+		root := t.TempDir() // no bin written
+		require.Equal(t, files.MapBuildingsFileName, chooseBuildingsIndexStem(root, code, true))
+	})
+
+	t.Run("older game ignores an available binary and loads json", func(t *testing.T) {
+		root := writeBin(t)
+		require.Equal(t, files.MapBuildingsFileName, chooseBuildingsIndexStem(root, code, false))
+	})
+}

--- a/railyard/app_mod_test.go
+++ b/railyard/app_mod_test.go
@@ -32,7 +32,7 @@ func TestGameSupportsBinaryBuildings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, gameSupportsBinaryBuildings(tt.resp))
+			require.Equal(t, tt.want, preferBinaryBuildingsIndex(tt.resp))
 		})
 	}
 }
@@ -51,16 +51,16 @@ func TestChooseBuildingsIndexStem(t *testing.T) {
 
 	t.Run("binary-capable game with the binary present loads the binary", func(t *testing.T) {
 		root := writeBin(t)
-		require.Equal(t, files.MapBuildingsBinFileName, chooseBuildingsIndexStem(root, code, true))
+		require.Equal(t, files.MapBuildingsBinFileName, setBuildingsIndexStem(root, code, true))
 	})
 
 	t.Run("binary-capable game without the binary falls back to json", func(t *testing.T) {
 		root := t.TempDir() // no bin written
-		require.Equal(t, files.MapBuildingsFileName, chooseBuildingsIndexStem(root, code, true))
+		require.Equal(t, files.MapBuildingsFileName, setBuildingsIndexStem(root, code, true))
 	})
 
 	t.Run("older game ignores an available binary and loads json", func(t *testing.T) {
 		root := writeBin(t)
-		require.Equal(t, files.MapBuildingsFileName, chooseBuildingsIndexStem(root, code, false))
+		require.Equal(t, files.MapBuildingsFileName, setBuildingsIndexStem(root, code, false))
 	})
 }

--- a/railyard/app_mod_test.go
+++ b/railyard/app_mod_test.go
@@ -28,7 +28,6 @@ func TestGameSupportsBinaryBuildings(t *testing.T) {
 		{"older than floor", success("1.2.0"), false},
 		{"undetected version", types.GameVersionResponse{GenericResponse: types.WarnResponse("not detected"), Version: ""}, false},
 		{"success but empty version", success(""), false},
-		{"unparseable version", success("not-a-version"), false},
 	}
 
 	for _, tt := range tests {

--- a/railyard/internal/constants/mod_template.js
+++ b/railyard/internal/constants/mod_template.js
@@ -86,8 +86,9 @@ function generateTabs(places) {
         maxZoom: config.tileZoomLevel,
       });
       window.SubwayBuilderAPI.cities.setCityDataFiles(place.code, {
-        // auto appends .gz, is this intended? if it is then its fine if not then that has to be removed so we can manually set the .gz file extension
-        buildingsIndex: "/data/" + place.code + "/buildings_index.json",
+        // The game API appends .gz, so we pass the stem; Railyard picks the .bin or
+        // .json form per the installed game version (binary on builds > 1.3.0).
+        buildingsIndex: "/data/" + place.code + "/" + place.buildingsIndexFile,
         demandData: "/data/" + place.code + "/demand_data.json", // drivingPaths supplied in demand_data.json.gz still aren't used
         roads: "/data/" + place.code + "/roads.geojson",
         runwaysTaxiways: "/data/" + place.code + "/runways_taxiways.geojson",

--- a/railyard/internal/constants/mod_template.js
+++ b/railyard/internal/constants/mod_template.js
@@ -1,4 +1,5 @@
 const config = $CONFIG;
+const baseURL = "http://127.0.0.1:" + config.port;
 function getFlagEmoji(countryCode) {
   let codePoints = countryCode
     .toUpperCase()
@@ -35,17 +36,14 @@ function generateTabs(places) {
 (async () => {
   await Promise.all(
     config.places.map(async (place) => {
+      const tilesURL = baseURL + "/" + place.code + "/{z}/{x}/{y}.mvt";
+      const mapImageURL = baseURL + "/thumbnails/" + place.code + ".svg";
       let newPlace = {
         code: place.code,
         name: place.name,
         population: place.population,
         description: place.description,
-        mapImageUrl:
-          "http://127.0.0.1:" +
-          config.port +
-          "/thumbnails/" +
-          place.code +
-          ".svg",
+        mapImageUrl: mapImageURL,
       };
       if (place.initialViewState) {
         newPlace.initialViewState = place.initialViewState;
@@ -75,14 +73,8 @@ function generateTabs(places) {
       });
       window.SubwayBuilderAPI.map.setTileURLOverride({
         cityCode: place.code,
-        tilesUrl:
-          "http://127.0.0.1:" +
-          config.port +
-          "/" +
-          place.code +
-          "/{z}/{x}/{y}.mvt",
-        foundationTilesUrl:
-          "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+        tilesUrl: tilesURL,
+        foundationTilesUrl: tilesURL,
         maxZoom: config.tileZoomLevel,
       });
       window.SubwayBuilderAPI.cities.setCityDataFiles(place.code, {

--- a/railyard/internal/downloader/downloader.go
+++ b/railyard/internal/downloader/downloader.go
@@ -899,14 +899,14 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 func (d *Downloader) ensureModDependencies(ctx context.Context, modID string, version string, versionInfo types.VersionInfo, skipDependencies bool) *types.AssetInstallResponse {
 	if d.GetGameVersion != nil {
 		gameVersionResp := d.GetGameVersion()
-		if gameVersionResp.Status == types.ResponseSuccess {
+		if gameVersion, ok := gameVersionResp.DetectedVersion(); ok {
 			if subwayBuilderDep, ok := versionInfo.Dependencies["subway-builder"]; ok {
 				constraint, err := semver.NewConstraint(strings.TrimPrefix(subwayBuilderDep, "v"))
 				if err != nil {
 					resp := d.installError(types.AssetTypeMod, modID, version, types.ConfigData{}, types.InstallErrorDependencyResolutionFailed, "Failed to parse mod dependency version constraint", err, "mod_id", modID, "dependency", "subway-builder", "constraint", subwayBuilderDep)
 					return &resp
 				}
-				if !constraint.Check(semver.MustParse(strings.TrimPrefix(gameVersionResp.Version, "v"))) {
+				if !constraint.Check(gameVersion) {
 					resp := d.installError(types.AssetTypeMod, modID, version, types.ConfigData{}, types.InstallErrorDependencyResolutionFailed, "Mod is not compatible with current game version", nil, "mod_id", modID, "dependency", "subway-builder", "constraint", subwayBuilderDep, "game_version", gameVersionResp.Version)
 					return &resp
 				}

--- a/railyard/internal/downloader/extractor.go
+++ b/railyard/internal/downloader/extractor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -41,6 +42,24 @@ func reportExtractProgress(fn ExtractProgressFunc, itemID string, extracted int6
 		return
 	}
 	fn(itemID, extracted, total)
+}
+
+// mapEntryStagedTarget resolves where a map archive entry is written in the staging
+// folder and whether it must be gzip-compressed on the way in. Installed map data
+// files live gzipped (<name>.gz), so uncompressed entries are gzipped; entries already
+// gzipped in the archive (e.g. buildings_index.bin.gz) are stored verbatim to avoid a
+// double-gzip. config.json is the exception: it is kept uncompressed for installed-state
+// bootstrapping, in particular for local maps.
+func mapEntryStagedTarget(key string, entryName string, stagingFolder string) (destinationPath string, gzipStream bool) {
+	base := path.Base(entryName)
+	switch {
+	case key == files.MapArchiveKeyConfig:
+		return paths.JoinLocalPath(stagingFolder, files.MapConfigFileName), false
+	case strings.HasSuffix(base, ".gz"):
+		return paths.JoinLocalPath(stagingFolder, base), false
+	default:
+		return paths.JoinLocalPath(stagingFolder, base+".gz"), true
+	}
 }
 
 // countSharedAssetPayloadFiles counts optional shared payload files that are copied into an asset directory.
@@ -340,14 +359,7 @@ func extractMap(d *Downloader, filePath string, mapId string, version string, sk
 						}
 						defer srcFile.Close()
 
-						outputFileName := path.Base(fileStruct.FileObject.Name)
-						destinationPath := paths.JoinLocalPath(stagingFolder, outputFileName+".gz")
-						shouldArchive := true
-						// Extract out config.json for future bootstrapping from installed state, in particular for local maps.
-						if key == files.MapArchiveKeyConfig {
-							destinationPath = paths.JoinLocalPath(stagingFolder, files.MapConfigFileName)
-							shouldArchive = false
-						}
+						destinationPath, shouldArchive := mapEntryStagedTarget(key, fileStruct.FileObject.Name, stagingFolder)
 
 						if err := files.WriteArchiveStream(destinationPath, srcFile, shouldArchive); err != nil {
 							errChan <- err

--- a/railyard/internal/downloader/extractor.go
+++ b/railyard/internal/downloader/extractor.go
@@ -44,20 +44,18 @@ func reportExtractProgress(fn ExtractProgressFunc, itemID string, extracted int6
 	fn(itemID, extracted, total)
 }
 
-// mapEntryStagedTarget resolves where a map archive entry is written in the staging
-// folder and whether it must be gzip-compressed on the way in. Installed map data
-// files live gzipped (<name>.gz), so uncompressed entries are gzipped; entries already
-// gzipped in the archive (e.g. buildings_index.bin.gz) are stored verbatim to avoid a
-// double-gzip. config.json is the exception: it is kept uncompressed for installed-state
-// bootstrapping, in particular for local maps.
+// mapEntryStagedTarget resolves a map entry's staging path and whether to gzip it.
 func mapEntryStagedTarget(key string, entryName string, stagingFolder string) (destinationPath string, gzipStream bool) {
 	base := path.Base(entryName)
 	switch {
 	case key == files.MapArchiveKeyConfig:
+		// Kept uncompressed for installed-state bootstrapping, esp. local maps.
 		return paths.JoinLocalPath(stagingFolder, files.MapConfigFileName), false
 	case strings.HasSuffix(base, ".gz"):
+		// Already gzipped in the archive (e.g. buildings_index.bin.gz) — store verbatim.
 		return paths.JoinLocalPath(stagingFolder, base), false
 	default:
+		// Installed data files live gzipped as <name>.gz.
 		return paths.JoinLocalPath(stagingFolder, base+".gz"), true
 	}
 }

--- a/railyard/internal/downloader/extractor_test.go
+++ b/railyard/internal/downloader/extractor_test.go
@@ -1,0 +1,66 @@
+package downloader
+
+import (
+	"testing"
+
+	"railyard/internal/files"
+	"railyard/internal/paths"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapEntryStagedTarget(t *testing.T) {
+	const staging = "staging"
+
+	tests := []struct {
+		name      string
+		key       string
+		entryName string
+		wantBase  string
+		wantGzip  bool
+	}{
+		{
+			name:      "config kept uncompressed for bootstrapping",
+			key:       files.MapArchiveKeyConfig,
+			entryName: files.MapConfigFileName,
+			wantBase:  files.MapConfigFileName,
+			wantGzip:  false,
+		},
+		{
+			name:      "uncompressed json is gzipped on the way in",
+			key:       files.MapArchiveKeyBuildings,
+			entryName: files.MapBuildingsFileName,
+			wantBase:  files.MapBuildingsFileName + ".gz",
+			wantGzip:  true,
+		},
+		{
+			name:      "already-gzipped binary is stored verbatim",
+			key:       files.MapArchiveKeyBuildingsBin,
+			entryName: files.MapBuildingsBinFileName + ".gz",
+			wantBase:  files.MapBuildingsBinFileName + ".gz",
+			wantGzip:  false,
+		},
+		{
+			name:      "already-gzipped json is stored verbatim (no double-gzip)",
+			key:       files.MapArchiveKeyBuildings,
+			entryName: files.MapBuildingsFileName + ".gz",
+			wantBase:  files.MapBuildingsFileName + ".gz",
+			wantGzip:  false,
+		},
+		{
+			name:      "uncompressed demand data is gzipped",
+			key:       files.MapArchiveKeyDemandData,
+			entryName: files.MapDemandFileName,
+			wantBase:  files.MapDemandFileName + ".gz",
+			wantGzip:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest, gzipStream := mapEntryStagedTarget(tt.key, tt.entryName, staging)
+			require.Equal(t, tt.wantGzip, gzipStream)
+			require.Equal(t, paths.JoinLocalPath(staging, tt.wantBase), dest)
+		})
+	}
+}

--- a/railyard/internal/files/installed_size.go
+++ b/railyard/internal/files/installed_size.go
@@ -52,8 +52,7 @@ func statIfExists(filePath string) (os.FileInfo, bool, error) {
 	return info, true, nil
 }
 
-// FileExists reports whether filePath exists. A missing file is (false, nil); only a
-// genuine stat failure returns an error.
+// FileExists reports whether filePath exists. 
 func FileExists(filePath string) (bool, error) {
 	_, exists, err := statIfExists(filePath)
 	return exists, err

--- a/railyard/internal/files/installed_size.go
+++ b/railyard/internal/files/installed_size.go
@@ -52,7 +52,7 @@ func statIfExists(filePath string) (os.FileInfo, bool, error) {
 	return info, true, nil
 }
 
-// FileExists reports whether filePath exists. 
+// FileExists reports whether filePath exists.
 func FileExists(filePath string) (bool, error) {
 	_, exists, err := statIfExists(filePath)
 	return exists, err

--- a/railyard/internal/files/installed_size.go
+++ b/railyard/internal/files/installed_size.go
@@ -39,19 +39,35 @@ func InstalledMapSize(mapsRoot string, tilesRoot string, cityCode string, marker
 	return size + tileSize, nil
 }
 
+// statIfExists stats filePath, treating a missing file as (nil, false, nil) and
+// surfacing only genuine stat failures.
+func statIfExists(filePath string) (os.FileInfo, bool, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return info, true, nil
+}
+
+// FileExists reports whether filePath exists. A missing file is (false, nil); only a
+// genuine stat failure returns an error.
+func FileExists(filePath string) (bool, error) {
+	_, exists, err := statIfExists(filePath)
+	return exists, err
+}
+
 // FileSizeIfExists returns the size of the target file when it exists.
 // Missing files are treated as zero-size and non-fatal to the method.
 func FileSizeIfExists(filePath string) (int64, error) {
 	if strings.TrimSpace(filePath) == "" {
 		return 0, nil
 	}
-
-	info, err := os.Stat(filePath)
-	if err == nil {
-		return info.Size(), nil
+	info, exists, err := statIfExists(filePath)
+	if err != nil || !exists {
+		return 0, err
 	}
-	if errors.Is(err, fs.ErrNotExist) {
-		return 0, nil
-	}
-	return 0, err
+	return info.Size(), nil
 }

--- a/railyard/internal/files/map_validation.go
+++ b/railyard/internal/files/map_validation.go
@@ -14,24 +14,26 @@ import (
 )
 
 const (
-	MapConfigFileName     = "config.json"
-	MapDemandFileName     = "demand_data.json"
-	MapRoadsFileName      = "roads.geojson"
-	MapRunwaysFileName    = "runways_taxiways.geojson"
-	MapBuildingsFileName  = "buildings_index.json"
-	MapOceanDepthFileName = "ocean_depth_index.json"
+	MapConfigFileName       = "config.json"
+	MapDemandFileName       = "demand_data.json"
+	MapRoadsFileName        = "roads.geojson"
+	MapRunwaysFileName      = "runways_taxiways.geojson"
+	MapBuildingsFileName    = "buildings_index.json" // legacy (pre 1.3.0) buildings index format
+	MapBuildingsBinFileName = "buildings_index.bin"  // newer (1.3.0+) buildings index format
+	MapOceanDepthFileName   = "ocean_depth_index.json"
 
 	MapTileFileExt      = ".pmtiles"
 	MapThumbnailFileExt = ".svg"
 
-	MapArchiveKeyConfig     = "config"
-	MapArchiveKeyDemandData = "demandData"
-	MapArchiveKeyRoads      = "roads"
-	MapArchiveKeyRunways    = "runways"
-	MapArchiveKeyBuildings  = "buildings"
-	MapArchiveKeyTiles      = "tiles"
-	MapArchiveKeyThumbnail  = "thumbnail"
-	MapArchiveKeyOceanDepth = "oceanDepth"
+	MapArchiveKeyConfig       = "config"
+	MapArchiveKeyDemandData   = "demandData"
+	MapArchiveKeyRoads        = "roads"
+	MapArchiveKeyRunways      = "runways"
+	MapArchiveKeyBuildings    = "buildings"
+	MapArchiveKeyBuildingsBin = "buildingsBin"
+	MapArchiveKeyTiles        = "tiles"
+	MapArchiveKeyThumbnail    = "thumbnail"
+	MapArchiveKeyOceanDepth   = "oceanDepth"
 )
 
 // BuildMapArchiveFileIndex builds an index of expected map archive files for validation, returning a map of file keys to their presence and file objects in the archive
@@ -41,10 +43,13 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 		MapArchiveKeyDemandData: {Found: false, FileObject: nil, Required: true},
 		MapArchiveKeyRoads:      {Found: false, FileObject: nil, Required: true},
 		MapArchiveKeyRunways:    {Found: false, FileObject: nil, Required: true},
-		MapArchiveKeyBuildings:  {Found: false, FileObject: nil, Required: true},
-		MapArchiveKeyTiles:      {Found: false, FileObject: nil, Required: true},
-		MapArchiveKeyThumbnail:  {Found: false, FileObject: nil, Required: false},
-		MapArchiveKeyOceanDepth: {Found: false, FileObject: nil, Required: false},
+		// Buildings index: neither form is individually required; ValidateMapArchive
+		// enforces that at least one of the two is present (buildingsIndexPresent).
+		MapArchiveKeyBuildings:    {Found: false, FileObject: nil, Required: false},
+		MapArchiveKeyBuildingsBin: {Found: false, FileObject: nil, Required: false},
+		MapArchiveKeyTiles:        {Found: false, FileObject: nil, Required: true},
+		MapArchiveKeyThumbnail:    {Found: false, FileObject: nil, Required: false},
+		MapArchiveKeyOceanDepth:   {Found: false, FileObject: nil, Required: false},
 	}
 
 	for _, file := range zipFiles {
@@ -66,8 +71,12 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 			filesFound[MapArchiveKeyRoads] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
 		case MapRunwaysFileName:
 			filesFound[MapArchiveKeyRunways] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		case MapBuildingsFileName:
-			filesFound[MapArchiveKeyBuildings] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		// Buildings index ships uncompressed (.json) or gzipped (.bin.gz); accept either
+		// compression for either form so both can be ingested.
+		case MapBuildingsFileName, MapBuildingsFileName + ".gz":
+			filesFound[MapArchiveKeyBuildings] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
+		case MapBuildingsBinFileName, MapBuildingsBinFileName + ".gz":
+			filesFound[MapArchiveKeyBuildingsBin] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
 		case MapOceanDepthFileName:
 			filesFound[MapArchiveKeyOceanDepth] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
 		}
@@ -95,6 +104,10 @@ func ValidateMapArchive(filePath string) (types.ConfigData, types.DownloaderErro
 
 	if !requiredFilesPresent(filesFound) {
 		return configData, types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{"The map archive is missing one or more required files."}}
+	}
+
+	if !buildingsIndexPresent(filesFound) {
+		return configData, types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{"The map archive is missing a buildings index (need buildings_index.json/.json.gz or buildings_index.bin/.bin.gz)."}}
 	}
 
 	for _, file := range reader.File {
@@ -182,12 +195,17 @@ func requiredFilesPresent(filesFound map[string]types.FileFoundStruct) bool {
 	return true
 }
 
+// buildingsIndexPresent reports whether the archive carries a buildings index in
+// either form. A map needs the JSON form, the binary form, or both.
+func buildingsIndexPresent(filesFound map[string]types.FileFoundStruct) bool {
+	return filesFound[MapArchiveKeyBuildings].Found || filesFound[MapArchiveKeyBuildingsBin].Found
+}
+
 func validateRequiredInstalledMapFiles(mapInstallRoot string, mapTilesRoot string, cityCode string) (types.DownloaderErrorType, error) {
 	requiredPaths := []string{
 		paths.JoinLocalPath(mapInstallRoot, cityCode, MapDemandFileName+".gz"),
 		paths.JoinLocalPath(mapInstallRoot, cityCode, MapRoadsFileName+".gz"),
 		paths.JoinLocalPath(mapInstallRoot, cityCode, MapRunwaysFileName+".gz"),
-		paths.JoinLocalPath(mapInstallRoot, cityCode, MapBuildingsFileName+".gz"),
 		paths.JoinLocalPath(mapTilesRoot, cityCode+MapTileFileExt),
 	}
 
@@ -199,5 +217,33 @@ func validateRequiredInstalledMapFiles(mapInstallRoot string, mapTilesRoot strin
 			return types.InstallErrorFilesystem, fmt.Errorf("failed to stat installed map file %q: %w", filePath, err)
 		}
 	}
+
+	// The buildings index is installed gzipped in either form; require at least one.
+	buildingsJSON := paths.JoinLocalPath(mapInstallRoot, cityCode, MapBuildingsFileName+".gz")
+	buildingsBin := paths.JoinLocalPath(mapInstallRoot, cityCode, MapBuildingsBinFileName+".gz")
+	jsonOK, errorType, err := installedMapFileExists(buildingsJSON)
+	if err != nil {
+		return errorType, err
+	}
+	binOK, errorType, err := installedMapFileExists(buildingsBin)
+	if err != nil {
+		return errorType, err
+	}
+	if !jsonOK && !binOK {
+		return types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{fmt.Sprintf("missing installed buildings index for %q: need %s or %s", cityCode, MapBuildingsFileName+".gz", MapBuildingsBinFileName+".gz")}}
+	}
+
 	return "", nil
+}
+
+// installedMapFileExists reports whether filePath exists, distinguishing a missing
+// file (false, no error) from a genuine filesystem failure (returned).
+func installedMapFileExists(filePath string) (bool, types.DownloaderErrorType, error) {
+	if _, err := os.Stat(filePath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, "", nil
+		}
+		return false, types.InstallErrorFilesystem, fmt.Errorf("failed to stat installed map file %q: %w", filePath, err)
+	}
+	return true, "", nil
 }

--- a/railyard/internal/files/map_validation.go
+++ b/railyard/internal/files/map_validation.go
@@ -43,8 +43,7 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 		MapArchiveKeyDemandData: {Found: false, FileObject: nil, Required: true},
 		MapArchiveKeyRoads:      {Found: false, FileObject: nil, Required: true},
 		MapArchiveKeyRunways:    {Found: false, FileObject: nil, Required: true},
-		// Buildings index: neither form is individually required; ValidateMapArchive
-		// enforces that at least one of the two is present (buildingsIndexPresent).
+		// ValidateMapArchive enforces that at least one buildings index is present; neither is strictly required on its own.
 		MapArchiveKeyBuildings:    {Found: false, FileObject: nil, Required: false},
 		MapArchiveKeyBuildingsBin: {Found: false, FileObject: nil, Required: false},
 		MapArchiveKeyTiles:        {Found: false, FileObject: nil, Required: true},
@@ -71,8 +70,7 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 			filesFound[MapArchiveKeyRoads] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
 		case MapRunwaysFileName:
 			filesFound[MapArchiveKeyRunways] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		// Buildings index ships uncompressed (.json) or gzipped (.bin.gz); accept either
-		// compression for either form so both can be ingested.
+		// Authors should be able to submit either uncompressed (.json/.bin) or gzipped (.json.gz/.bin.gz); accept either compression for either form so both can be ingested.
 		case MapBuildingsFileName, MapBuildingsFileName + ".gz":
 			filesFound[MapArchiveKeyBuildings] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
 		case MapBuildingsBinFileName, MapBuildingsBinFileName + ".gz":
@@ -220,8 +218,7 @@ func validateRequiredInstalledMapFiles(mapInstallRoot string, mapTilesRoot strin
 	return installedBuildingsIndexPresent(mapInstallRoot, cityCode)
 }
 
-// installedBuildingsIndexPresent verifies at least one installed buildings-index form
-// (JSON or binary, both gzipped) exists for the city.
+// installedBuildingsIndexPresent verifies at least one installed buildings-index form exists for the city.
 func installedBuildingsIndexPresent(mapInstallRoot string, cityCode string) (types.DownloaderErrorType, error) {
 	for _, name := range []string{MapBuildingsFileName + ".gz", MapBuildingsBinFileName + ".gz"} {
 		exists, err := FileExists(paths.JoinLocalPath(mapInstallRoot, cityCode, name))

--- a/railyard/internal/files/map_validation.go
+++ b/railyard/internal/files/map_validation.go
@@ -195,8 +195,7 @@ func requiredFilesPresent(filesFound map[string]types.FileFoundStruct) bool {
 	return true
 }
 
-// buildingsIndexPresent reports whether the archive carries a buildings index in
-// either form. A map needs the JSON form, the binary form, or both.
+// buildingsIndexPresent reports whether the archive carries a buildings index in either form.
 func buildingsIndexPresent(filesFound map[string]types.FileFoundStruct) bool {
 	return filesFound[MapArchiveKeyBuildings].Found || filesFound[MapArchiveKeyBuildingsBin].Found
 }
@@ -218,32 +217,20 @@ func validateRequiredInstalledMapFiles(mapInstallRoot string, mapTilesRoot strin
 		}
 	}
 
-	// The buildings index is installed gzipped in either form; require at least one.
-	buildingsJSON := paths.JoinLocalPath(mapInstallRoot, cityCode, MapBuildingsFileName+".gz")
-	buildingsBin := paths.JoinLocalPath(mapInstallRoot, cityCode, MapBuildingsBinFileName+".gz")
-	jsonOK, errorType, err := installedMapFileExists(buildingsJSON)
-	if err != nil {
-		return errorType, err
-	}
-	binOK, errorType, err := installedMapFileExists(buildingsBin)
-	if err != nil {
-		return errorType, err
-	}
-	if !jsonOK && !binOK {
-		return types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{fmt.Sprintf("missing installed buildings index for %q: need %s or %s", cityCode, MapBuildingsFileName+".gz", MapBuildingsBinFileName+".gz")}}
-	}
-
-	return "", nil
+	return installedBuildingsIndexPresent(mapInstallRoot, cityCode)
 }
 
-// installedMapFileExists reports whether filePath exists, distinguishing a missing
-// file (false, no error) from a genuine filesystem failure (returned).
-func installedMapFileExists(filePath string) (bool, types.DownloaderErrorType, error) {
-	if _, err := os.Stat(filePath); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return false, "", nil
+// installedBuildingsIndexPresent verifies at least one installed buildings-index form
+// (JSON or binary, both gzipped) exists for the city.
+func installedBuildingsIndexPresent(mapInstallRoot string, cityCode string) (types.DownloaderErrorType, error) {
+	for _, name := range []string{MapBuildingsFileName + ".gz", MapBuildingsBinFileName + ".gz"} {
+		exists, err := FileExists(paths.JoinLocalPath(mapInstallRoot, cityCode, name))
+		if err != nil {
+			return types.InstallErrorFilesystem, fmt.Errorf("failed to stat installed map file %q: %w", name, err)
 		}
-		return false, types.InstallErrorFilesystem, fmt.Errorf("failed to stat installed map file %q: %w", filePath, err)
+		if exists {
+			return "", nil
+		}
 	}
-	return true, "", nil
+	return types.InstallErrorInvalidArchive, &types.MissingFilesError{Files: []string{fmt.Sprintf("missing installed buildings index for %q: need %s or %s", cityCode, MapBuildingsFileName+".gz", MapBuildingsBinFileName+".gz")}}
 }

--- a/railyard/internal/files/map_validation.go
+++ b/railyard/internal/files/map_validation.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 
 	"railyard/internal/paths"
 	"railyard/internal/types"
@@ -61,19 +62,24 @@ func BuildMapArchiveFileIndex(zipFiles []*zip.File) map[string]types.FileFoundSt
 			continue
 		}
 
-		switch normalizedName {
-		case MapConfigFileName:
+		// config.json is never compressed; it is stored verbatim for installed-state bootstrapping.
+		if normalizedName == MapConfigFileName {
 			filesFound[MapArchiveKeyConfig] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
+		}
+
+		// Payload files may be submitted compressed (<name>.gz) or not; match on the
+		// decompressed name so either form maps to the same key. The extractor
+		// normalizes them all to <name>.gz on install regardless.
+		switch strings.TrimSuffix(normalizedName, ".gz") {
 		case MapDemandFileName:
 			filesFound[MapArchiveKeyDemandData] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
 		case MapRoadsFileName:
 			filesFound[MapArchiveKeyRoads] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
 		case MapRunwaysFileName:
 			filesFound[MapArchiveKeyRunways] = types.FileFoundStruct{Found: true, FileObject: file, Required: true}
-		// Authors should be able to submit either uncompressed (.json/.bin) or gzipped (.json.gz/.bin.gz); accept either compression for either form so both can be ingested.
-		case MapBuildingsFileName, MapBuildingsFileName + ".gz":
+		case MapBuildingsFileName:
 			filesFound[MapArchiveKeyBuildings] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
-		case MapBuildingsBinFileName, MapBuildingsBinFileName + ".gz":
+		case MapBuildingsBinFileName:
 			filesFound[MapArchiveKeyBuildingsBin] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}
 		case MapOceanDepthFileName:
 			filesFound[MapArchiveKeyOceanDepth] = types.FileFoundStruct{Found: true, FileObject: file, Required: false}

--- a/railyard/internal/files/map_validation_test.go
+++ b/railyard/internal/files/map_validation_test.go
@@ -61,6 +61,39 @@ func TestValidateMapArchive(t *testing.T) {
 			wantErr:     true,
 		},
 		{
+			name: "valid archive with binary buildings index only",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				delete(f, MapBuildingsFileName)
+				f[MapBuildingsBinFileName+".gz"] = []byte("bin")
+				return f
+			}(),
+			wantErrType: "",
+			wantErr:     false,
+			wantCode:    "AAA",
+		},
+		{
+			name: "valid archive with both buildings index forms",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				f[MapBuildingsBinFileName+".gz"] = []byte("bin")
+				return f
+			}(),
+			wantErrType: "",
+			wantErr:     false,
+			wantCode:    "AAA",
+		},
+		{
+			name: "missing both buildings index forms",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				delete(f, MapBuildingsFileName)
+				return f
+			}(),
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
 			name: "invalid config json",
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")
@@ -263,6 +296,25 @@ func TestValidateInstalledMapDataDownloaded(t *testing.T) {
 				writeInstalledDownloadedMapFixture(t, mapRoot, tilesRoot, cityCode)
 				demandPath := paths.JoinLocalPath(mapRoot, cityCode, MapDemandFileName+".gz")
 				require.NoError(t, os.Remove(demandPath))
+			},
+			wantErrType: types.InstallErrorInvalidArchive,
+			wantErr:     true,
+		},
+		{
+			name: "valid with binary buildings index only",
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledDownloadedMapFixture(t, mapRoot, tilesRoot, cityCode)
+				require.NoError(t, os.Remove(paths.JoinLocalPath(mapRoot, cityCode, MapBuildingsFileName+".gz")))
+				require.NoError(t, os.WriteFile(paths.JoinLocalPath(mapRoot, cityCode, MapBuildingsBinFileName+".gz"), []byte("bin"), 0o644))
+			},
+			wantErrType: "",
+			wantErr:     false,
+		},
+		{
+			name: "missing both buildings index forms",
+			setup: func(t *testing.T, mapRoot, tilesRoot, cityCode string) {
+				writeInstalledDownloadedMapFixture(t, mapRoot, tilesRoot, cityCode)
+				require.NoError(t, os.Remove(paths.JoinLocalPath(mapRoot, cityCode, MapBuildingsFileName+".gz")))
 			},
 			wantErrType: types.InstallErrorInvalidArchive,
 			wantErr:     true,

--- a/railyard/internal/files/map_validation_test.go
+++ b/railyard/internal/files/map_validation_test.go
@@ -94,6 +94,21 @@ func TestValidateMapArchive(t *testing.T) {
 			wantErr:     true,
 		},
 		{
+			name: "valid archive with gzipped payload files",
+			files: func() map[string][]byte {
+				f := requiredFiles("AAA")
+				// Ship demand and the JSON buildings index gzipped instead of plain.
+				delete(f, MapDemandFileName)
+				f[MapDemandFileName+".gz"] = []byte("gz")
+				delete(f, MapBuildingsFileName)
+				f[MapBuildingsFileName+".gz"] = []byte("gz")
+				return f
+			}(),
+			wantErrType: "",
+			wantErr:     false,
+			wantCode:    "AAA",
+		},
+		{
 			name: "invalid config json",
 			files: func() map[string][]byte {
 				f := requiredFiles("AAA")

--- a/railyard/internal/types/app_types.go
+++ b/railyard/internal/types/app_types.go
@@ -58,14 +58,13 @@ type GameRunningResponse struct {
 }
 
 type MetroMakerModConfig struct {
-	TileZoomLevel int                  `json:"tileZoomLevel"`
-	Places        []MetroMakerModPlace `json:"places"`
-	Port          int                  `json:"port"`
+	TileZoomLevel int               `json:"tileZoomLevel"`
+	Places        []MetroMakerPlace `json:"places"`
+	Port          int               `json:"port"`
 }
 
-// MetroMakerModPlace is a mod-config place entry: a map's ConfigData (embedded so its
-// fields stay top-level in JSON) plus the buildings-index stem the game should load.
-type MetroMakerModPlace struct {
+// MetroMakerPlace is a mod-config place entry: a map's ConfigData plus the buildings-index stem the game should load.
+type MetroMakerPlace struct {
 	ConfigData
 	BuildingsIndexFile string `json:"buildingsIndexFile"`
 }

--- a/railyard/internal/types/app_types.go
+++ b/railyard/internal/types/app_types.go
@@ -63,10 +63,8 @@ type MetroMakerModConfig struct {
 	Port          int                  `json:"port"`
 }
 
-// MetroMakerModPlace is a place entry in the generated map-loader mod config: the
-// map's ConfigData plus the buildings-index filename stem the game should load for
-// it, chosen from the installed forms per the detected game version. ConfigData is
-// embedded so its fields stay at the place's top level in the emitted JSON.
+// MetroMakerModPlace is a mod-config place entry: a map's ConfigData (embedded so its
+// fields stay top-level in JSON) plus the buildings-index stem the game should load.
 type MetroMakerModPlace struct {
 	ConfigData
 	BuildingsIndexFile string `json:"buildingsIndexFile"`

--- a/railyard/internal/types/app_types.go
+++ b/railyard/internal/types/app_types.go
@@ -58,9 +58,18 @@ type GameRunningResponse struct {
 }
 
 type MetroMakerModConfig struct {
-	TileZoomLevel int          `json:"tileZoomLevel"`
-	Places        []ConfigData `json:"places"`
-	Port          int          `json:"port"`
+	TileZoomLevel int                  `json:"tileZoomLevel"`
+	Places        []MetroMakerModPlace `json:"places"`
+	Port          int                  `json:"port"`
+}
+
+// MetroMakerModPlace is a place entry in the generated map-loader mod config: the
+// map's ConfigData plus the buildings-index filename stem the game should load for
+// it, chosen from the installed forms per the detected game version. ConfigData is
+// embedded so its fields stay at the place's top level in the emitted JSON.
+type MetroMakerModPlace struct {
+	ConfigData
+	BuildingsIndexFile string `json:"buildingsIndexFile"`
 }
 
 type MetroMakerModManifest struct {

--- a/railyard/internal/types/common.go
+++ b/railyard/internal/types/common.go
@@ -228,13 +228,13 @@ func NormalizeSemver(version string) string {
 	return "v" + trimmed
 }
 
-// DetectedVersion returns the detected game version as parsed semver. ok is false
-// when no version was detected; a detected version is assumed semver-compliant, as
-// install-time compatibility checks already assume.
+// DetectedVersion returns the detected game version as parsed semver.
 func (r GameVersionResponse) DetectedVersion() (*semver.Version, bool) {
+	// No version detecteed
 	if r.Status != ResponseSuccess || r.Version == "" {
 		return nil, false
 	}
+	// Assume detected version is semver-compliant
 	return semver.MustParse(strings.TrimPrefix(r.Version, "v")), true
 }
 

--- a/railyard/internal/types/common.go
+++ b/railyard/internal/types/common.go
@@ -228,6 +228,16 @@ func NormalizeSemver(version string) string {
 	return "v" + trimmed
 }
 
+// DetectedVersion returns the detected game version as parsed semver. ok is false
+// when no version was detected; a detected version is assumed semver-compliant, as
+// install-time compatibility checks already assume.
+func (r GameVersionResponse) DetectedVersion() (*semver.Version, bool) {
+	if r.Status != ResponseSuccess || r.Version == "" {
+		return nil, false
+	}
+	return semver.MustParse(strings.TrimPrefix(r.Version, "v")), true
+}
+
 // MissingFilesError is returned when required files are missing from an archive.
 type MissingFilesError struct {
 	Files []string

--- a/railyard/mod_buildings_index.go
+++ b/railyard/mod_buildings_index.go
@@ -10,23 +10,19 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 )
 
-// binaryBuildingsIndexGameFloor is the game-version boundary for the buildings index
-// format: builds strictly newer than this read the packed binary, older builds the
-// JSON. Mirrors the registry/jp-data 1.3.0 split.
-var binaryBuildingsIndexGameFloor = semver.MustParse("1.3.0")
+// binaryBuildingsIndexGameFloor is the game-version boundary for the buildings index format: builds strictly newer than this read the packed binary, older builds read only the JSON.
+var binaryBuildingsIndexGameFloor = semver.MustParse("1.3.0") // Non-inclusive. Binary support was added during the beta cycle following 1.3.0
 
-// gameSupportsBinaryBuildings reports whether the detected game version reads the
-// binary buildings index. An undetected version falls back to JSON, which every map
-// ships and older builds require.
-func gameSupportsBinaryBuildings(gv types.GameVersionResponse) bool {
+// preferBinaryBuildingsIndex reports whether the detected game version reads the binary buildings index.
+func preferBinaryBuildingsIndex(gv types.GameVersionResponse) bool {
 	version, ok := gv.DetectedVersion()
 	return ok && version.GreaterThan(binaryBuildingsIndexGameFloor)
 }
 
-// chooseBuildingsIndexStem picks the buildings-index filename stem the game loads for a map.
-func chooseBuildingsIndexStem(mapDataRoot string, code string, preferBinary bool) string {
-	// Use the binary only when the game supports it and the map actually ships it;
-	// otherwise the JSON form. The game API appends .gz to the stem.
+// setBuildingsIndexStem picks the buildings-index filename stem the game loads for a map.
+func setBuildingsIndexStem(mapDataRoot string, code string, preferBinary bool) string {
+	// Use the binary only when the game supports it and the map actually ships it; otherwise the JSON form.
+	// TODO: Hard fail here if the binary is supported but missing, to avoid loading maps without a valid/compatible buildings index
 	if preferBinary {
 		if _, err := os.Stat(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz")); err == nil {
 			return files.MapBuildingsBinFileName

--- a/railyard/mod_buildings_index.go
+++ b/railyard/mod_buildings_index.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+
+	"railyard/internal/files"
+	"railyard/internal/paths"
+	"railyard/internal/types"
+
+	semver "github.com/Masterminds/semver/v3"
+)
+
+// binaryBuildingsIndexGameFloor is the game-version boundary for the buildings index
+// format: builds strictly newer than this read the packed binary, older builds the
+// JSON. Mirrors the registry/jp-data 1.3.0 split.
+var binaryBuildingsIndexGameFloor = semver.MustParse("1.3.0")
+
+// gameSupportsBinaryBuildings reports whether the detected game version reads the
+// binary buildings index. An undetected version falls back to JSON, which every map
+// ships and older builds require.
+func gameSupportsBinaryBuildings(gv types.GameVersionResponse) bool {
+	version, ok := gv.DetectedVersion()
+	return ok && version.GreaterThan(binaryBuildingsIndexGameFloor)
+}
+
+// chooseBuildingsIndexStem picks the buildings-index filename stem the game loads for a map.
+func chooseBuildingsIndexStem(mapDataRoot string, code string, preferBinary bool) string {
+	// Use the binary only when the game supports it and the map actually ships it;
+	// otherwise the JSON form. The game API appends .gz to the stem.
+	if preferBinary {
+		if _, err := os.Stat(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz")); err == nil {
+			return files.MapBuildingsBinFileName
+		}
+	}
+	return files.MapBuildingsFileName
+}


### PR DESCRIPTION
Map releases now ship a packed binary buildings index, `buildings_index.bin.gz`, alongside `buildings_index.json` (game versions >1.3.0 read the binary; <=1.3.0 read the JSON). 

This PR updates Railyard to recognize/extract the binary if present and enforce an "at least one" buildings-index file rule.

Pairs with registry Subway-Builder-Modded/registry#3556, which records each map version's buildings-index forms in the integrity report.
