### PR TITLE
[Backend] Refactor game version enforcement, infer game version compatibility for maps from bin presence

### DIFF
--- a/railyard/app.go
+++ b/railyard/app.go
@@ -407,7 +407,7 @@ func (a *App) GetGameVersion() types.GameVersionResponse {
 	}
 }
 
-func (a *App) LaunchGame() types.GenericResponse {
+func (a *App) LaunchGame(skipIncompatibleMaps bool) types.GenericResponse {
 	a.gameMu.Lock()
 	if a.gameStarting {
 		a.gameMu.Unlock()
@@ -469,7 +469,7 @@ func (a *App) LaunchGame() types.GenericResponse {
 
 	a.generateMissingThumbnails(port)
 
-	if err := a.generateMod(port); err != nil {
+	if err := a.generateMod(port, skipIncompatibleMaps); err != nil {
 		a.Logger.Warn("Failed to generate mod", "error", err)
 		return types.ErrorResponse(err.Error())
 	}
@@ -810,7 +810,7 @@ func (a *App) generateMissingThumbnails(port int) {
 	}
 }
 
-func (a *App) generateMod(port int) error {
+func (a *App) generateMod(port int, skipIncompatibleMaps bool) error {
 	maps := a.Registry.GetInstalledMaps()
 	a.Logger.Info("Generating mod with maps", "count", len(maps))
 
@@ -821,9 +821,17 @@ func (a *App) generateMod(port int) error {
 		if _, err := os.Stat(paths.JoinLocalPath(a.Config.Cfg.GetMapsFolderPath(), m.MapConfig.Code, "ocean_depth_index.json.gz")); !errors.Is(err, fs.ErrNotExist) {
 			m.MapConfig.HasOceanDepth = true
 		}
+		stem, err := setBuildingsIndexStem(mapDataRoot, m.MapConfig.Code, preferBinary)
+		if err != nil {
+			if skipIncompatibleMaps {
+				a.Logger.Warn("Skipping incompatible map from mod template", "map", m.MapConfig.Code, "error", err)
+				continue
+			}
+			stem = files.MapBuildingsFileName
+		}
 		places = append(places, types.MetroMakerPlace{
 			ConfigData:         m.MapConfig,
-			BuildingsIndexFile: setBuildingsIndexStem(mapDataRoot, m.MapConfig.Code, preferBinary),
+			BuildingsIndexFile: stem,
 		})
 	}
 	config := types.MetroMakerModConfig{

--- a/railyard/app_mod_test.go
+++ b/railyard/app_mod_test.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"railyard/internal/config"
 	"railyard/internal/files"
+	"railyard/internal/logger"
 	"railyard/internal/paths"
+	"railyard/internal/registry"
 	"railyard/internal/types"
 
 	"github.com/stretchr/testify/require"
@@ -48,19 +54,156 @@ func TestChooseBuildingsIndexStem(t *testing.T) {
 		require.NoError(t, os.WriteFile(paths.JoinLocalPath(dir, files.MapBuildingsBinFileName+".gz"), []byte("bin"), 0o644))
 		return root
 	}
+	writeJSON := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		dir := paths.JoinLocalPath(root, code)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(paths.JoinLocalPath(dir, files.MapBuildingsFileName+".gz"), []byte("json"), 0o644))
+		return root
+	}
+	writeBoth := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		dir := paths.JoinLocalPath(root, code)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(paths.JoinLocalPath(dir, files.MapBuildingsBinFileName+".gz"), []byte("bin"), 0o644))
+		require.NoError(t, os.WriteFile(paths.JoinLocalPath(dir, files.MapBuildingsFileName+".gz"), []byte("json"), 0o644))
+		return root
+	}
 
-	t.Run("binary-capable game with the binary present loads the binary", func(t *testing.T) {
+	t.Run("binary game + binary present → binary, no error", func(t *testing.T) {
 		root := writeBin(t)
-		require.Equal(t, files.MapBuildingsBinFileName, setBuildingsIndexStem(root, code, true))
+		stem, err := setBuildingsIndexStem(root, code, true)
+		require.NoError(t, err)
+		require.Equal(t, files.MapBuildingsBinFileName, stem)
 	})
 
-	t.Run("binary-capable game without the binary falls back to json", func(t *testing.T) {
-		root := t.TempDir() // no bin written
-		require.Equal(t, files.MapBuildingsFileName, setBuildingsIndexStem(root, code, true))
+	t.Run("binary game + JSON only → error", func(t *testing.T) {
+		root := writeJSON(t)
+		stem, err := setBuildingsIndexStem(root, code, true)
+		require.Error(t, err)
+		require.Empty(t, stem)
 	})
 
-	t.Run("older game ignores an available binary and loads json", func(t *testing.T) {
+	t.Run("JSON game + JSON present → JSON, no error", func(t *testing.T) {
+		root := writeJSON(t)
+		stem, err := setBuildingsIndexStem(root, code, false)
+		require.NoError(t, err)
+		require.Equal(t, files.MapBuildingsFileName, stem)
+	})
+
+	t.Run("JSON game + binary only → error", func(t *testing.T) {
 		root := writeBin(t)
-		require.Equal(t, files.MapBuildingsFileName, setBuildingsIndexStem(root, code, false))
+		stem, err := setBuildingsIndexStem(root, code, false)
+		require.Error(t, err)
+		require.Empty(t, stem)
+	})
+
+	t.Run("binary game + both present → binary, no error", func(t *testing.T) {
+		root := writeBoth(t)
+		stem, err := setBuildingsIndexStem(root, code, true)
+		require.NoError(t, err)
+		require.Equal(t, files.MapBuildingsBinFileName, stem)
+	})
+
+	t.Run("JSON game + both present → JSON, no error", func(t *testing.T) {
+		root := writeBoth(t)
+		stem, err := setBuildingsIndexStem(root, code, false)
+		require.NoError(t, err)
+		require.Equal(t, files.MapBuildingsFileName, stem)
+	})
+}
+
+// newModTestApp creates a minimal App for generateMod tests. It uses the given
+// MetroMakerDataPath and pre-populates the registry with the provided maps.
+// Game version detection is left unconfigured, so preferBinary resolves to false
+// (no executable path set), which makes "binary-only" maps the incompatible case.
+func newModTestApp(t *testing.T, metroMakerDataPath string, maps []types.InstalledMapInfo) *App {
+	t.Helper()
+	l := logger.LoggerAtPath("")
+	cfg := config.NewConfig(l)
+	cfg.Cfg.MetroMakerDataPath = metroMakerDataPath
+	reg := registry.NewRegistry(l, cfg)
+	for _, m := range maps {
+		reg.AddInstalledMap(m.ID, m.Version, m.IsLocal, m.MapConfig)
+	}
+	return &App{Logger: l, Config: cfg, Registry: reg}
+}
+
+// readGeneratedModConfig parses the MetroMakerModConfig from a generated index.js file.
+func readGeneratedModConfig(t *testing.T, indexPath string) types.MetroMakerModConfig {
+	t.Helper()
+	raw, err := os.ReadFile(indexPath)
+	require.NoError(t, err)
+	// index.js starts with: const config = {...};
+	s := strings.TrimPrefix(string(raw), "const config = ")
+	var cfg types.MetroMakerModConfig
+	require.NoError(t, json.NewDecoder(strings.NewReader(s)).Decode(&cfg))
+	return cfg
+}
+
+func TestGenerateMod(t *testing.T) {
+	const compatCode = "compat-map"
+	const incompatCode = "incompat-map"
+
+	// setupMaps writes map data files and returns the populated InstalledMapInfo slice.
+	// No executable is configured so GetGameVersion returns not-detected → preferBinary=false.
+	// That means: JSON files are compatible, binary-only files are incompatible.
+	setupMaps := func(t *testing.T, dir string) []types.InstalledMapInfo {
+		t.Helper()
+		mapDataRoot := filepath.Join(dir, "cities", "data")
+
+		compatDir := filepath.Join(mapDataRoot, compatCode)
+		require.NoError(t, os.MkdirAll(compatDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(compatDir, files.MapBuildingsFileName+".gz"), []byte("json"), 0o644))
+
+		incompatDir := filepath.Join(mapDataRoot, incompatCode)
+		require.NoError(t, os.MkdirAll(incompatDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(incompatDir, files.MapBuildingsBinFileName+".gz"), []byte("bin"), 0o644))
+
+		return []types.InstalledMapInfo{
+			{ID: compatCode, Version: "1.0.0", MapConfig: types.ConfigData{Code: compatCode}},
+			{ID: incompatCode, Version: "1.0.0", MapConfig: types.ConfigData{Code: incompatCode}},
+		}
+	}
+
+	indexPath := func(dir string) string {
+		return filepath.Join(dir, "mods", "mapLoader", "index.js")
+	}
+
+	t.Run("skipIncompatibleMaps=true excludes binary-only map", func(t *testing.T) {
+		dir := t.TempDir()
+		maps := setupMaps(t, dir)
+		app := newModTestApp(t, dir, maps)
+
+		require.NoError(t, app.generateMod(0, true))
+
+		cfg := readGeneratedModConfig(t, indexPath(dir))
+		codes := make([]string, 0, len(cfg.Places))
+		for _, p := range cfg.Places {
+			codes = append(codes, p.ConfigData.Code)
+		}
+		require.Contains(t, codes, compatCode)
+		require.NotContains(t, codes, incompatCode)
+	})
+
+	t.Run("skipIncompatibleMaps=false includes binary-only map with JSON fallback", func(t *testing.T) {
+		dir := t.TempDir()
+		maps := setupMaps(t, dir)
+		app := newModTestApp(t, dir, maps)
+
+		require.NoError(t, app.generateMod(0, false))
+
+		cfg := readGeneratedModConfig(t, indexPath(dir))
+		codes := make([]string, 0, len(cfg.Places))
+		stemByCode := make(map[string]string)
+		for _, p := range cfg.Places {
+			codes = append(codes, p.ConfigData.Code)
+			stemByCode[p.ConfigData.Code] = p.BuildingsIndexFile
+		}
+		require.Contains(t, codes, compatCode)
+		require.Contains(t, codes, incompatCode)
+		require.Equal(t, files.MapBuildingsFileName, stemByCode[incompatCode])
 	})
 }

--- a/railyard/app_test.go
+++ b/railyard/app_test.go
@@ -49,12 +49,12 @@ func TestLaunchGameRejectsConcurrentStartWhileStarting(t *testing.T) {
 
 	firstResult := make(chan types.GenericResponse, 1)
 	go func() {
-		firstResult <- app.LaunchGame()
+		firstResult <- app.LaunchGame(false)
 	}()
 
 	<-ready
 
-	second := app.LaunchGame()
+	second := app.LaunchGame(false)
 	require.Equal(t, types.ResponseError, second.Status)
 	require.Equal(t, "game is already starting", second.Message)
 

--- a/railyard/frontend/wailsjs/go/models.ts
+++ b/railyard/frontend/wailsjs/go/models.ts
@@ -421,6 +421,7 @@ export namespace types {
 	    manifest?: string;
 	    prerelease: boolean;
 	    dependencies?: Record<string, string>;
+	    map_buildings_constraint?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new VersionInfo(source);
@@ -439,6 +440,7 @@ export namespace types {
 	        this.manifest = source["manifest"];
 	        this.prerelease = source["prerelease"];
 	        this.dependencies = source["dependencies"];
+	        this.map_buildings_constraint = source["map_buildings_constraint"];
 	    }
 	}
 	export class DependencyListEntry {
@@ -701,12 +703,27 @@ export namespace types {
 		    return a;
 		}
 	}
+	export class InstalledConstraint {
+	    type: string;
+	    range: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new InstalledConstraint(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.type = source["type"];
+	        this.range = source["range"];
+	    }
+	}
 	export class InstalledMapInfo {
 	    id: string;
 	    version: string;
 	    isLocal: boolean;
 	    config: ConfigData;
 	    installedSizeBytes?: number;
+	    constraints?: InstalledConstraint[];
 	
 	    static createFrom(source: any = {}) {
 	        return new InstalledMapInfo(source);
@@ -719,6 +736,7 @@ export namespace types {
 	        this.isLocal = source["isLocal"];
 	        this.config = this.convertValues(source["config"], ConfigData);
 	        this.installedSizeBytes = source["installedSizeBytes"];
+	        this.constraints = this.convertValues(source["constraints"], InstalledConstraint);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -822,6 +840,7 @@ export namespace types {
 	    isLocal: boolean;
 	    manifest?: MetroMakerModManifest;
 	    installedSizeBytes?: number;
+	    constraints?: InstalledConstraint[];
 	
 	    static createFrom(source: any = {}) {
 	        return new InstalledModInfo(source);
@@ -834,6 +853,7 @@ export namespace types {
 	        this.isLocal = source["isLocal"];
 	        this.manifest = this.convertValues(source["manifest"], MetroMakerModManifest);
 	        this.installedSizeBytes = source["installedSizeBytes"];
+	        this.constraints = this.convertValues(source["constraints"], InstalledConstraint);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/railyard/frontend/wailsjs/go/registry/Registry.d.ts
+++ b/railyard/frontend/wailsjs/go/registry/Registry.d.ts
@@ -67,7 +67,11 @@ export function RemoveInstalledMod(arg1:string):Promise<void>;
 
 export function SetContext(arg1:context.Context):Promise<void>;
 
+export function SetInstalledMapConstraints(arg1:string,arg2:Array<types.InstalledConstraint>):Promise<void>;
+
 export function SetInstalledMapsFromPath(arg1:string):Promise<void>;
+
+export function SetInstalledModConstraints(arg1:string,arg2:Array<types.InstalledConstraint>):Promise<void>;
 
 export function SetInstalledModsFromPath(arg1:string):Promise<void>;
 

--- a/railyard/frontend/wailsjs/go/registry/Registry.js
+++ b/railyard/frontend/wailsjs/go/registry/Registry.js
@@ -130,8 +130,16 @@ export function SetContext(arg1) {
   return window['go']['registry']['Registry']['SetContext'](arg1);
 }
 
+export function SetInstalledMapConstraints(arg1, arg2) {
+  return window['go']['registry']['Registry']['SetInstalledMapConstraints'](arg1, arg2);
+}
+
 export function SetInstalledMapsFromPath(arg1) {
   return window['go']['registry']['Registry']['SetInstalledMapsFromPath'](arg1);
+}
+
+export function SetInstalledModConstraints(arg1, arg2) {
+  return window['go']['registry']['Registry']['SetInstalledModConstraints'](arg1, arg2);
 }
 
 export function SetInstalledModsFromPath(arg1) {

--- a/railyard/internal/downloader/downloader.go
+++ b/railyard/internal/downloader/downloader.go
@@ -932,12 +932,20 @@ func (d *Downloader) ensureCompatibilityConstraints(assetType types.AssetType, a
 	gameVersionResp := d.GetGameVersion()
 	gameVersion, ok := gameVersionResp.DetectedVersion()
 	if !ok {
-		return nil // game not detected — do not block
+		resp := d.installError(
+			assetType, assetID, version, types.ConfigData{}, types.InstallErrorIncompatibleGameVersion,
+			"Cannot verify compatibility: game version could not be detected",
+			nil,
+			"asset_id", assetID,
+		)
+		return &resp
 	}
 	for _, c := range constraints {
 		constraint, err := semver.NewConstraint(strings.TrimPrefix(c.Range, "v"))
 		if err != nil {
-			continue // unparseable — do not block
+			d.Logger.Error("Unparseable compatibility constraint; skipping check", err,
+				"asset_id", assetID, "constraint_type", c.Type, "constraint", c.Range)
+			continue
 		}
 		if !constraint.Check(gameVersion) {
 			resp := d.installError(

--- a/railyard/internal/downloader/downloader.go
+++ b/railyard/internal/downloader/downloader.go
@@ -703,6 +703,12 @@ func (d *Downloader) importMapNow(zipPath string, replaceOnConflict bool) types.
 		d.Registry.RemoveInstalledMap(replacedConflict.ExistingAssetID)
 	}
 	d.Registry.AddInstalledMap(mapID, version, true, extractResp.Config)
+	// Disk is authoritative for local imports — compute and store the buildings_index constraint immediately.
+	if bc := registry.BuildingsIndexConstraintFromInstalled(d.getMapDataPath(), mapID); bc != "" {
+		d.Registry.SetInstalledMapConstraints(mapID, []types.InstalledConstraint{
+			{Type: types.ConstraintTypeBuildingsIndex, Range: bc},
+		})
+	}
 	if err := d.Registry.WriteInstalledToDisk(); err != nil {
 		return d.installError(types.AssetTypeMap, mapID, version, extractResp.Config, types.InstallErrorPersistStateFailed, "Failed to persist installed state after importing map", err, "map_id", mapID)
 	}
@@ -861,7 +867,8 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 	if versionInfo == nil {
 		return d.installError(types.AssetTypeMod, modId, version, types.ConfigData{}, types.InstallErrorVersionNotFound, "Specified version not found for mod", nil, "mod_id", modId, "version", version, "available_versions", availableVersions)
 	}
-	if depErr := d.ensureModDependencies(ctx, modId, version, *versionInfo, skipDependencies); depErr != nil {
+	modConstraints := constraintsFromVersionInfo(types.AssetTypeMod, *versionInfo)
+	if depErr := d.ensureModDependencies(ctx, modId, version, *versionInfo, modConstraints, skipDependencies); depErr != nil {
 		return *depErr
 	}
 
@@ -889,6 +896,7 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 		return d.installError(types.AssetTypeMod, modId, version, types.ConfigData{}, extractResp.ErrorType, "Failed to extract mod zip: "+extractResp.Message, nil, "mod_id", modId, "version", version)
 	}
 	os.Remove(downloadResp.Path)
+	d.Registry.SetInstalledModConstraints(modId, modConstraints)
 	if err := d.Registry.WriteInstalledToDisk(); err != nil {
 		d.Logger.Warn("Failed to persist installed state after installing mod", "error", err)
 	}
@@ -896,22 +904,65 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 	return d.installSuccess(types.AssetTypeMod, modId, version, types.ConfigData{}, "Mod installed successfully", "mod_id", modId, "version", version)
 }
 
-func (d *Downloader) ensureModDependencies(ctx context.Context, modID string, version string, versionInfo types.VersionInfo, skipDependencies bool) *types.AssetInstallResponse {
-	if d.GetGameVersion != nil {
-		gameVersionResp := d.GetGameVersion()
-		if gameVersion, ok := gameVersionResp.DetectedVersion(); ok {
-			if subwayBuilderDep, ok := versionInfo.Dependencies["subway-builder"]; ok {
-				constraint, err := semver.NewConstraint(strings.TrimPrefix(subwayBuilderDep, "v"))
-				if err != nil {
-					resp := d.installError(types.AssetTypeMod, modID, version, types.ConfigData{}, types.InstallErrorDependencyResolutionFailed, "Failed to parse mod dependency version constraint", err, "mod_id", modID, "dependency", "subway-builder", "constraint", subwayBuilderDep)
-					return &resp
-				}
-				if !constraint.Check(gameVersion) {
-					resp := d.installError(types.AssetTypeMod, modID, version, types.ConfigData{}, types.InstallErrorDependencyResolutionFailed, "Mod is not compatible with current game version", nil, "mod_id", modID, "dependency", "subway-builder", "constraint", subwayBuilderDep, "game_version", gameVersionResp.Version)
-					return &resp
-				}
-			}
+// constraintsFromVersionInfo builds the Constraints slice for an asset installation.
+// It reads vi.GameVersion (not Dependencies["subway-builder"]) so all enrichment sources are
+// covered: integrity report, custom JSON game_version field, and manifest.json fallback.
+// Only maps receive a buildings_index entry (from vi.MapBuildingsConstraint).
+func constraintsFromVersionInfo(assetType types.AssetType, vi types.VersionInfo) []types.InstalledConstraint {
+	var cs []types.InstalledConstraint
+	if vi.GameVersion != "" {
+		cs = append(cs, types.InstalledConstraint{
+			Type:  types.ConstraintTypeManifest,
+			Range: vi.GameVersion,
+		})
+	}
+	if assetType == types.AssetTypeMap && vi.MapBuildingsConstraint != "" {
+		cs = append(cs, types.InstalledConstraint{
+			Type:  types.ConstraintTypeBuildingsIndex,
+			Range: vi.MapBuildingsConstraint,
+		})
+	}
+	return cs
+}
+
+// ensureCompatibilityConstraints gates an install on all applicable constraints.
+// Returns the first violation as an install error response, or nil if all pass.
+// Mods preserve InstallErrorDependencyResolutionFailed for backward compatibility;
+// maps use InstallErrorIncompatibleGameVersion.
+func (d *Downloader) ensureCompatibilityConstraints(assetType types.AssetType, assetID, version string, constraints []types.InstalledConstraint) *types.AssetInstallResponse {
+	if d.GetGameVersion == nil || len(constraints) == 0 {
+		return nil
+	}
+	gameVersionResp := d.GetGameVersion()
+	gameVersion, ok := gameVersionResp.DetectedVersion()
+	if !ok {
+		return nil // game not detected — do not block
+	}
+	for _, c := range constraints {
+		constraint, err := semver.NewConstraint(strings.TrimPrefix(c.Range, "v"))
+		if err != nil {
+			continue // unparseable — do not block
 		}
+		if !constraint.Check(gameVersion) {
+			errType := types.InstallErrorIncompatibleGameVersion
+			if assetType == types.AssetTypeMod {
+				errType = types.InstallErrorDependencyResolutionFailed
+			}
+			resp := d.installError(
+				assetType, assetID, version, types.ConfigData{}, errType,
+				fmt.Sprintf("Asset is not compatible with current game version (%s): requires %s (%s)", gameVersionResp.Version, c.Range, c.Type),
+				nil,
+				"asset_id", assetID, "constraint_type", c.Type, "constraint", c.Range, "game_version", gameVersionResp.Version,
+			)
+			return &resp
+		}
+	}
+	return nil
+}
+
+func (d *Downloader) ensureModDependencies(ctx context.Context, modID string, version string, versionInfo types.VersionInfo, constraints []types.InstalledConstraint, skipDependencies bool) *types.AssetInstallResponse {
+	if resp := d.ensureCompatibilityConstraints(types.AssetTypeMod, modID, version, constraints); resp != nil {
+		return resp
 	}
 	if skipDependencies {
 		return nil
@@ -999,6 +1050,11 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 		return d.installError(types.AssetTypeMap, mapId, version, types.ConfigData{}, types.InstallErrorVersionNotFound, "Specified version not found for map", nil, "map_id", mapId, "version", version, "available_versions", availableVersions)
 	}
 
+	mapConstraints := constraintsFromVersionInfo(types.AssetTypeMap, *versionInfo)
+	if resp := d.ensureCompatibilityConstraints(types.AssetTypeMap, mapId, version, mapConstraints); resp != nil {
+		return *resp
+	}
+
 	d.Logger.Info("Downloading map", "map_id", mapId, "version", version, "download_url", versionInfo.DownloadURL)
 	// Pass in context to the download function so that it can be cancelled if the operation is no longer needed
 	downloadResp := d.downloadTempZip(ctx, versionInfo.DownloadURL, mapId)
@@ -1054,6 +1110,7 @@ func (d *Downloader) installMapNow(ctx context.Context, mapId string, version st
 		d.Registry.RemoveInstalledMap(replacedConflict.ExistingAssetID)
 	}
 	d.Registry.AddInstalledMap(mapId, version, false, extractResp.Config)
+	d.Registry.SetInstalledMapConstraints(mapId, mapConstraints)
 	if err := d.Registry.WriteInstalledToDisk(); err != nil {
 		d.Logger.Warn("Failed to persist installed state after installing map", "error", err)
 	}

--- a/railyard/internal/downloader/downloader.go
+++ b/railyard/internal/downloader/downloader.go
@@ -940,13 +940,8 @@ func (d *Downloader) ensureCompatibilityConstraints(assetType types.AssetType, a
 			continue // unparseable — do not block
 		}
 		if !constraint.Check(gameVersion) {
-			errType := types.InstallErrorIncompatibleGameVersion
-			if assetType == types.AssetTypeMod {
-				errType = types.InstallErrorDependencyResolutionFailed
-			}
-			// Return the first violation as an install error response
 			resp := d.installError(
-				assetType, assetID, version, types.ConfigData{}, errType,
+				assetType, assetID, version, types.ConfigData{}, types.InstallErrorIncompatibleGameVersion,
 				fmt.Sprintf("Asset is not compatible with current game version (%s): requires %s (%s)", gameVersionResp.Version, c.Range, c.Type),
 				nil,
 				"asset_id", assetID, "constraint_type", c.Type, "constraint", c.Range, "game_version", gameVersionResp.Version,

--- a/railyard/internal/downloader/downloader.go
+++ b/railyard/internal/downloader/downloader.go
@@ -905,17 +905,16 @@ func (d *Downloader) installModNow(ctx context.Context, modId string, version st
 }
 
 // constraintsFromVersionInfo builds the Constraints slice for an asset installation.
-// It reads vi.GameVersion (not Dependencies["subway-builder"]) so all enrichment sources are
-// covered: integrity report, custom JSON game_version field, and manifest.json fallback.
-// Only maps receive a buildings_index entry (from vi.MapBuildingsConstraint).
 func constraintsFromVersionInfo(assetType types.AssetType, vi types.VersionInfo) []types.InstalledConstraint {
 	var cs []types.InstalledConstraint
+	// Read GameVersion from VersionInfo so all enrichment sources are covered: integrity report, custom JSON game_version field, and manifest.json fallback.
 	if vi.GameVersion != "" {
 		cs = append(cs, types.InstalledConstraint{
 			Type:  types.ConstraintTypeManifest,
 			Range: vi.GameVersion,
 		})
 	}
+	// Only maps receive a buildings_index entry constraint
 	if assetType == types.AssetTypeMap && vi.MapBuildingsConstraint != "" {
 		cs = append(cs, types.InstalledConstraint{
 			Type:  types.ConstraintTypeBuildingsIndex,
@@ -926,9 +925,6 @@ func constraintsFromVersionInfo(assetType types.AssetType, vi types.VersionInfo)
 }
 
 // ensureCompatibilityConstraints gates an install on all applicable constraints.
-// Returns the first violation as an install error response, or nil if all pass.
-// Mods preserve InstallErrorDependencyResolutionFailed for backward compatibility;
-// maps use InstallErrorIncompatibleGameVersion.
 func (d *Downloader) ensureCompatibilityConstraints(assetType types.AssetType, assetID, version string, constraints []types.InstalledConstraint) *types.AssetInstallResponse {
 	if d.GetGameVersion == nil || len(constraints) == 0 {
 		return nil
@@ -948,6 +944,7 @@ func (d *Downloader) ensureCompatibilityConstraints(assetType types.AssetType, a
 			if assetType == types.AssetTypeMod {
 				errType = types.InstallErrorDependencyResolutionFailed
 			}
+			// Return the first violation as an install error response
 			resp := d.installError(
 				assetType, assetID, version, types.ConfigData{}, errType,
 				fmt.Sprintf("Asset is not compatible with current game version (%s): requires %s (%s)", gameVersionResp.Version, c.Range, c.Type),

--- a/railyard/internal/profiles/profiles_sync_test.go
+++ b/railyard/internal/profiles/profiles_sync_test.go
@@ -237,6 +237,9 @@ func TestSyncSubscriptions(t *testing.T) {
 							Code: "BBB",
 							Name: "Fixture Map",
 						},
+						Constraints: []types.InstalledConstraint{
+							{Type: types.ConstraintTypeBuildingsIndex, Range: "<=1.3.0"},
+						},
 					},
 				},
 			},
@@ -340,6 +343,9 @@ func TestSyncSubscriptions(t *testing.T) {
 						MapConfig: types.ConfigData{
 							Code: "AAA",
 							Name: "Fixture Map",
+						},
+						Constraints: []types.InstalledConstraint{
+							{Type: types.ConstraintTypeBuildingsIndex, Range: "<=1.3.0"},
 						},
 					},
 				},

--- a/railyard/internal/registry/game_version.go
+++ b/railyard/internal/registry/game_version.go
@@ -54,8 +54,8 @@ func (r *Registry) applyIntegrityGameMeta(repo string, versions []types.VersionI
 	}
 }
 
-// buildingsIndexConstraintFromMatchedFiles derives the buildings-index semver constraint from an integrity version's MatchedFiles map. 
-// The Registry keys are "buildings_index_json" and "buildings_index_bin" 
+// buildingsIndexConstraintFromMatchedFiles derives the buildings-index semver constraint from an integrity version's MatchedFiles map.
+// The Registry keys are "buildings_index_json" and "buildings_index_bin"
 func buildingsIndexConstraintFromMatchedFiles(matched map[string]string) string {
 	// JSON null entries unmarshal to "" in map[string]string, so != "" is the correct presence check.
 	hasBin := matched["buildings_index_bin"] != ""

--- a/railyard/internal/registry/game_version.go
+++ b/railyard/internal/registry/game_version.go
@@ -54,6 +54,29 @@ func (r *Registry) applyIntegrityGameMeta(repo string, versions []types.VersionI
 	}
 }
 
+// buildingsIndexConstraintFromMatchedFiles derives the buildings-index semver constraint from an
+// integrity version's MatchedFiles map. Registry keys are "buildings_index_json" and
+// "buildings_index_bin" — NOT Railyard's internal archive key constants ("buildings"/"buildingsBin").
+// JSON null entries unmarshal to "" in map[string]string, so != "" is the correct presence check.
+//
+// The registry pipeline's withBuildingsIndexPresenceIfMissing backfill rewrites cache entries
+// predating the json/bin split: it sets buildings_index_bin:null and promotes the legacy
+// buildings_index value to buildings_index_json. "Neither present" therefore means a stale or
+// malformed entry, not genuinely unknown. The registry contract is: binary absence == JSON-only
+// for all pre-binary releases, so "neither" is treated as JSON-only (<=1.3.0) to match.
+func buildingsIndexConstraintFromMatchedFiles(matched map[string]string) string {
+	hasBin := matched["buildings_index_bin"] != ""
+	hasJSON := matched["buildings_index_json"] != ""
+	switch {
+	case hasBin && !hasJSON:
+		return ">1.3.0"
+	case hasBin && hasJSON:
+		return "" // both present — compatible with any game version
+	default:
+		return "<=1.3.0" // JSON only, or neither (registry contract: binary absent = JSON only)
+	}
+}
+
 // enrichVersions fills GameVersion/dependencies from each version's manifest.json,
 // in parallel, as a fallback when the source/integrity did not already provide them.
 func (r *Registry) enrichVersions(versions []types.VersionInfo) {

--- a/railyard/internal/registry/game_version.go
+++ b/railyard/internal/registry/game_version.go
@@ -54,17 +54,10 @@ func (r *Registry) applyIntegrityGameMeta(repo string, versions []types.VersionI
 	}
 }
 
-// buildingsIndexConstraintFromMatchedFiles derives the buildings-index semver constraint from an
-// integrity version's MatchedFiles map. Registry keys are "buildings_index_json" and
-// "buildings_index_bin" — NOT Railyard's internal archive key constants ("buildings"/"buildingsBin").
-// JSON null entries unmarshal to "" in map[string]string, so != "" is the correct presence check.
-//
-// The registry pipeline's withBuildingsIndexPresenceIfMissing backfill rewrites cache entries
-// predating the json/bin split: it sets buildings_index_bin:null and promotes the legacy
-// buildings_index value to buildings_index_json. "Neither present" therefore means a stale or
-// malformed entry, not genuinely unknown. The registry contract is: binary absence == JSON-only
-// for all pre-binary releases, so "neither" is treated as JSON-only (<=1.3.0) to match.
+// buildingsIndexConstraintFromMatchedFiles derives the buildings-index semver constraint from an integrity version's MatchedFiles map. 
+// The Registry keys are "buildings_index_json" and "buildings_index_bin" 
 func buildingsIndexConstraintFromMatchedFiles(matched map[string]string) string {
+	// JSON null entries unmarshal to "" in map[string]string, so != "" is the correct presence check.
 	hasBin := matched["buildings_index_bin"] != ""
 	hasJSON := matched["buildings_index_json"] != ""
 	switch {

--- a/railyard/internal/registry/installable_versions.go
+++ b/railyard/internal/registry/installable_versions.go
@@ -98,7 +98,24 @@ func (r *Registry) GetInstallableVersions(assetType types.AssetType, assetID str
 		return nil, err
 	}
 
-	return r.filterVersionsByIntegrity(assetType, assetID, versions)
+	filtered, err := r.filterVersionsByIntegrity(assetType, assetID, versions)
+	if err != nil {
+		return nil, err
+	}
+
+	// For maps, enrich each version with its buildings-index constraint derived from
+	// the integrity report's matched_files. This is the authoritative source for remote maps.
+	if assetType == types.AssetTypeMap {
+		if listing, ok := r.getIntegrityListing(assetType, assetID); ok {
+			for i := range filtered {
+				if status, ok := listing.Versions[filtered[i].Version]; ok {
+					filtered[i].MapBuildingsConstraint = buildingsIndexConstraintFromMatchedFiles(status.MatchedFiles)
+				}
+			}
+		}
+	}
+
+	return filtered, nil
 }
 
 // GetInstallableVersionsResponse returns installable versions with response metadata.

--- a/railyard/internal/registry/installed.go
+++ b/railyard/internal/registry/installed.go
@@ -14,14 +14,7 @@ import (
 	"railyard/internal/types"
 )
 
-// BuildingsIndexConstraintFromInstalled infers the buildings-index semver constraint for a map
-// by checking which index files are present on disk.
-//   - Binary only  → ">1.3.0"
-//   - JSON only    → "<=1.3.0"
-//   - Both present → "" (no format-driven restriction)
-//   - Neither      → "<0.0.0" (impossible constraint — broken install; integrity validation
-//     rejects archives missing both files, so this state should never arise via normal install)
-//
+// BuildingsIndexConstraintFromInstalled infers the buildings-index semver constraint for a map by checking which index files are present on disk.
 // Used for the existing-install disk fallback and for local map imports.
 func BuildingsIndexConstraintFromInstalled(mapDataRoot, code string) string {
 	hasBin := installedFileExistsAt(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz"))
@@ -34,7 +27,8 @@ func BuildingsIndexConstraintFromInstalled(mapDataRoot, code string) string {
 	case hasBin && hasJSON:
 		return "" // both present — compatible with any game version
 	default:
-		return "<0.0.0" // neither present — broken install; marks asset incompatible
+		// Integrity validation rejects archives missing both files, so this state should never arise via normal install; therefore, this is a fallback path for broken installs or local imports.
+		return "<0.0.0" // Return unfulfillable constraint to block install
 	}
 }
 

--- a/railyard/internal/registry/installed.go
+++ b/railyard/internal/registry/installed.go
@@ -38,7 +38,6 @@ func installedFileExistsAt(p string) bool {
 }
 
 // SetInstalledModConstraints updates the Constraints field of an installed mod in memory.
-// Call WriteInstalledToDisk to persist.
 func (r *Registry) SetInstalledModConstraints(modID string, constraints []types.InstalledConstraint) {
 	for i := range r.installedMods {
 		if r.installedMods[i].ID == modID {
@@ -49,7 +48,6 @@ func (r *Registry) SetInstalledModConstraints(modID string, constraints []types.
 }
 
 // SetInstalledMapConstraints updates the Constraints field of an installed map in memory.
-// Call WriteInstalledToDisk to persist.
 func (r *Registry) SetInstalledMapConstraints(mapID string, constraints []types.InstalledConstraint) {
 	for i := range r.installedMaps {
 		if r.installedMaps[i].ID == mapID {

--- a/railyard/internal/registry/installed.go
+++ b/railyard/internal/registry/installed.go
@@ -6,12 +6,64 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 
 	"railyard/internal/constants"
 	"railyard/internal/files"
 	"railyard/internal/paths"
 	"railyard/internal/types"
 )
+
+// BuildingsIndexConstraintFromInstalled infers the buildings-index semver constraint for a map
+// by checking which index files are present on disk.
+//   - Binary only  → ">1.3.0"
+//   - JSON only    → "<=1.3.0"
+//   - Both present → "" (no format-driven restriction)
+//   - Neither      → "<0.0.0" (impossible constraint — broken install; integrity validation
+//     rejects archives missing both files, so this state should never arise via normal install)
+//
+// Used for the existing-install disk fallback and for local map imports.
+func BuildingsIndexConstraintFromInstalled(mapDataRoot, code string) string {
+	hasBin := installedFileExistsAt(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz"))
+	hasJSON := installedFileExistsAt(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsFileName+".gz"))
+	switch {
+	case hasBin && !hasJSON:
+		return ">1.3.0"
+	case hasJSON && !hasBin:
+		return "<=1.3.0"
+	case hasBin && hasJSON:
+		return "" // both present — compatible with any game version
+	default:
+		return "<0.0.0" // neither present — broken install; marks asset incompatible
+	}
+}
+
+func installedFileExistsAt(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// SetInstalledModConstraints updates the Constraints field of an installed mod in memory.
+// Call WriteInstalledToDisk to persist.
+func (r *Registry) SetInstalledModConstraints(modID string, constraints []types.InstalledConstraint) {
+	for i := range r.installedMods {
+		if r.installedMods[i].ID == modID {
+			r.installedMods[i].Constraints = constraints
+			return
+		}
+	}
+}
+
+// SetInstalledMapConstraints updates the Constraints field of an installed map in memory.
+// Call WriteInstalledToDisk to persist.
+func (r *Registry) SetInstalledMapConstraints(mapID string, constraints []types.InstalledConstraint) {
+	for i := range r.installedMaps {
+		if r.installedMaps[i].ID == mapID {
+			r.installedMaps[i].Constraints = constraints
+			return
+		}
+	}
+}
 
 // WriteInstalledToDisk persists installed mods and maps state to disk.
 func (r *Registry) WriteInstalledToDisk() error {
@@ -185,10 +237,12 @@ func (r *Registry) enrichModInfoWithFileSizes(mods []types.InstalledModInfo) []t
 	return updated
 }
 
-// enrichMapInfoWithFileSizes enriches installed map info with on-disk size metadata.
+// enrichMapInfoWithFileSizes enriches installed map info with on-disk size metadata and
+// infers a buildings_index constraint from disk for existing installs that predate constraint storage.
 func (r *Registry) enrichMapInfoWithFileSizes(maps []types.InstalledMapInfo) []types.InstalledMapInfo {
 	updated := make([]types.InstalledMapInfo, 0, len(maps))
 	mapsRoot := r.config.Cfg.GetMapsFolderPath()
+	mapDataRoot := paths.MetroMakerMapsDataPath(r.config.Cfg.MetroMakerDataPath)
 	tilesRoot := paths.TilesPath()
 	for _, item := range maps {
 		copyItem := item
@@ -198,6 +252,21 @@ func (r *Registry) enrichMapInfoWithFileSizes(maps []types.InstalledMapInfo) []t
 			size = 0
 		}
 		copyItem.InstalledSizeBytes = size
+
+		// Disk fallback: for pre-existing installs with no buildings_index constraint stored,
+		// infer it from installed files. Same migration-bridge pattern as InstalledSizeBytes.
+		hasBuildingsConstraint := slices.ContainsFunc(item.Constraints, func(c types.InstalledConstraint) bool {
+			return c.Type == types.ConstraintTypeBuildingsIndex
+		})
+		if !hasBuildingsConstraint {
+			if bc := BuildingsIndexConstraintFromInstalled(mapDataRoot, item.MapConfig.Code); bc != "" {
+				copyItem.Constraints = append(copyItem.Constraints, types.InstalledConstraint{
+					Type:  types.ConstraintTypeBuildingsIndex,
+					Range: bc,
+				})
+			}
+		}
+
 		updated = append(updated, copyItem)
 	}
 	return updated

--- a/railyard/internal/types/registry_types.go
+++ b/railyard/internal/types/registry_types.go
@@ -171,7 +171,7 @@ type VersionInfo struct {
 	Downloads              int               `json:"downloads"`
 	Manifest               string            `json:"manifest,omitempty"`
 	Prerelease             bool              `json:"prerelease"`
-	Dependencies           map[string]string `json:"dependencies,omitempty"`            // Map of dependency mod IDs to version constraints
+	Dependencies           map[string]string `json:"dependencies,omitempty"`             // Map of dependency mod IDs to version constraints
 	MapBuildingsConstraint string            `json:"map_buildings_constraint,omitempty"` // Derived semver range for map versions based on which buildings-index files the version ships; always empty for mods
 }
 

--- a/railyard/internal/types/registry_types.go
+++ b/railyard/internal/types/registry_types.go
@@ -1,6 +1,6 @@
 package types
 
-// InstalledConstraint is a single semver compatibility requirement stored at install time.
+// InstalledConstraint is a  semver compatibility requirement stored at install time.
 // The current game version must satisfy Range; failing any constraint marks the asset incompatible.
 type InstalledConstraint struct {
 	Type  string `json:"type"`  // ConstraintTypeManifest | ConstraintTypeBuildingsIndex | ...
@@ -9,10 +9,8 @@ type InstalledConstraint struct {
 
 const (
 	// ConstraintTypeManifest is a game version constraint from the manifest game_version field
-	// (integrity report, custom JSON, or manifest.json fallback).
 	ConstraintTypeManifest = "manifest"
-	// ConstraintTypeBuildingsIndex is a constraint derived from which buildings-index files the
-	// map version ships (binary-only → >1.3.0; JSON-only → <=1.3.0).
+	// ConstraintTypeBuildingsIndex is a constraint derived from which buildings-index files the map zip contains (JSON-only vs. binrary vs. both)
 	ConstraintTypeBuildingsIndex = "buildings_index"
 )
 

--- a/railyard/internal/types/registry_types.go
+++ b/railyard/internal/types/registry_types.go
@@ -1,5 +1,21 @@
 package types
 
+// InstalledConstraint is a single semver compatibility requirement stored at install time.
+// The current game version must satisfy Range; failing any constraint marks the asset incompatible.
+type InstalledConstraint struct {
+	Type  string `json:"type"`  // ConstraintTypeManifest | ConstraintTypeBuildingsIndex | ...
+	Range string `json:"range"` // semver constraint string, e.g. ">=1.3.0", "<=1.3.0"
+}
+
+const (
+	// ConstraintTypeManifest is a game version constraint from the manifest game_version field
+	// (integrity report, custom JSON, or manifest.json fallback).
+	ConstraintTypeManifest = "manifest"
+	// ConstraintTypeBuildingsIndex is a constraint derived from which buildings-index files the
+	// map version ships (binary-only → >1.3.0; JSON-only → <=1.3.0).
+	ConstraintTypeBuildingsIndex = "buildings_index"
+)
+
 // UpdateConfig describes how a mod or map receives updates.
 type UpdateConfig struct {
 	Type string `json:"type"`
@@ -56,6 +72,7 @@ type InstalledModInfo struct {
 	IsLocal            bool                   `json:"isLocal"` // Unused for now
 	Manifest           *MetroMakerModManifest `json:"manifest,omitempty"`
 	InstalledSizeBytes int64                  `json:"installedSizeBytes,omitempty"` // Populated in response payloads only
+	Constraints        []InstalledConstraint  `json:"constraints,omitempty"`        // Semver compatibility requirements stored at install time
 }
 
 type InstalledModsResponse struct {
@@ -65,11 +82,12 @@ type InstalledModsResponse struct {
 
 // InstalledMapInfo represents the information stored about an installed map in the registry's installed_maps.json file.
 type InstalledMapInfo struct {
-	ID                 string     `json:"id"`
-	Version            string     `json:"version"`
-	IsLocal            bool       `json:"isLocal"` // Indicates whether or not the map was installed from a local file rather than downloaded via the registry
-	MapConfig          ConfigData `json:"config"`
-	InstalledSizeBytes int64      `json:"installedSizeBytes,omitempty"` // Populated in response payloads only
+	ID                 string                `json:"id"`
+	Version            string                `json:"version"`
+	IsLocal            bool                  `json:"isLocal"` // Indicates whether or not the map was installed from a local file rather than downloaded via the registry
+	MapConfig          ConfigData            `json:"config"`
+	InstalledSizeBytes int64                 `json:"installedSizeBytes,omitempty"` // Populated in response payloads only
+	Constraints        []InstalledConstraint `json:"constraints,omitempty"`        // Semver compatibility requirements stored at install time
 }
 
 type InstalledMapsResponse struct {
@@ -143,17 +161,18 @@ type GalleryImageResponse struct {
 
 // VersionInfo represents a single release version for a mod or map.
 type VersionInfo struct {
-	Version      string            `json:"version"`
-	Name         string            `json:"name"`
-	Changelog    string            `json:"changelog"`
-	Date         string            `json:"date"`
-	DownloadURL  string            `json:"download_url"`
-	GameVersion  string            `json:"game_version"`
-	SHA256       string            `json:"sha256"`
-	Downloads    int               `json:"downloads"`
-	Manifest     string            `json:"manifest,omitempty"`
-	Prerelease   bool              `json:"prerelease"`
-	Dependencies map[string]string `json:"dependencies,omitempty"` // Map of dependency mod IDs to version constraints
+	Version                string            `json:"version"`
+	Name                   string            `json:"name"`
+	Changelog              string            `json:"changelog"`
+	Date                   string            `json:"date"`
+	DownloadURL            string            `json:"download_url"`
+	GameVersion            string            `json:"game_version"`
+	SHA256                 string            `json:"sha256"`
+	Downloads              int               `json:"downloads"`
+	Manifest               string            `json:"manifest,omitempty"`
+	Prerelease             bool              `json:"prerelease"`
+	Dependencies           map[string]string `json:"dependencies,omitempty"`            // Map of dependency mod IDs to version constraints
+	MapBuildingsConstraint string            `json:"map_buildings_constraint,omitempty"` // Derived semver range for map versions based on which buildings-index files the version ships; always empty for mods
 }
 
 // VersionsCacheEntry is a persisted upstream-release lookup: the resolved versions plus the HTTP ETag used to revalidate them with a conditional request.

--- a/railyard/mod_buildings_index.go
+++ b/railyard/mod_buildings_index.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"railyard/internal/files"
@@ -19,14 +20,26 @@ func preferBinaryBuildingsIndex(gv types.GameVersionResponse) bool {
 	return ok && version.GreaterThan(binaryBuildingsIndexGameFloor)
 }
 
-// setBuildingsIndexStem picks the buildings-index filename stem the game loads for a map.
-func setBuildingsIndexStem(mapDataRoot string, code string, preferBinary bool) string {
-	// Use the binary only when the game supports it and the map actually ships it; otherwise the JSON form.
-	// TODO: Hard fail here if the binary is supported but missing, to avoid loading maps without a valid/compatible buildings index
+// setBuildingsIndexStem picks the buildings-index filename stem for a map, or returns
+// an error if the installed files are incompatible with the detected game version.
+func setBuildingsIndexStem(mapDataRoot string, code string, preferBinary bool) (string, error) {
+	hasBin := func() bool {
+		_, err := os.Stat(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz"))
+		return err == nil
+	}()
+	hasJSON := func() bool {
+		_, err := os.Stat(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsFileName+".gz"))
+		return err == nil
+	}()
+
 	if preferBinary {
-		if _, err := os.Stat(paths.JoinLocalPath(mapDataRoot, code, files.MapBuildingsBinFileName+".gz")); err == nil {
-			return files.MapBuildingsBinFileName
+		if hasBin {
+			return files.MapBuildingsBinFileName, nil
 		}
+		return "", fmt.Errorf("map %q: game requires binary buildings index (>1.3.0) but only JSON is installed", code)
 	}
-	return files.MapBuildingsFileName
+	if hasJSON {
+		return files.MapBuildingsFileName, nil
+	}
+	return "", fmt.Errorf("map %q: game requires JSON buildings index (<=1.3.0) but only binary is installed", code)
 }


### PR DESCRIPTION
As stated in title

This PR adds a new asset-type agnostic `InstalledConstraint`

```
const (
    ConstraintTypeManifest       = "manifest"        // from dependencies["subway-builder"]
    ConstraintTypeBuildingsIndex = "buildings_index"  // derived from index file format
)
```
is the example for maps

And then adds the specific enforcement constraint for maps....

Still WIP