### PR TITLE
[Frontend] Add `Status` column/chips to library, enforce asset game version compatibility

### DIFF
--- a/packages/asset-listings-ui/src/components/sidebar-filters.tsx
+++ b/packages/asset-listings-ui/src/components/sidebar-filters.tsx
@@ -60,7 +60,7 @@ export interface SidebarFiltersProps {
   collapsibleSections?: boolean;
   sourceQualityTitle?: string;
   minimumVisibleOptions?: number;
-  afterTypeContent?: ReactNode;
+  statusContent?: ReactNode;
 }
 
 const typeOptions: Array<{
@@ -89,7 +89,7 @@ export function SidebarFilters({
   collapsibleSections = true,
   sourceQualityTitle = "Source Quality",
   minimumVisibleOptions = 1,
-  afterTypeContent,
+  statusContent: statusContent,
 }: SidebarFiltersProps) {
   const counts: Record<GalleryAssetType, number> = {
     mod: modCount,
@@ -169,7 +169,7 @@ export function SidebarFilters({
         </nav>
       </div>
 
-      {afterTypeContent}
+      {statusContent}
 
       {filters.type !== "map" && (
         <>

--- a/packages/asset-listings-ui/src/components/sidebar-filters.tsx
+++ b/packages/asset-listings-ui/src/components/sidebar-filters.tsx
@@ -60,6 +60,7 @@ export interface SidebarFiltersProps {
   collapsibleSections?: boolean;
   sourceQualityTitle?: string;
   minimumVisibleOptions?: number;
+  afterTypeContent?: ReactNode;
 }
 
 const typeOptions: Array<{
@@ -88,6 +89,7 @@ export function SidebarFilters({
   collapsibleSections = true,
   sourceQualityTitle = "Source Quality",
   minimumVisibleOptions = 1,
+  afterTypeContent,
 }: SidebarFiltersProps) {
   const counts: Record<GalleryAssetType, number> = {
     mod: modCount,
@@ -166,6 +168,8 @@ export function SidebarFilters({
           })}
         </nav>
       </div>
+
+      {afterTypeContent}
 
       {filters.type !== "map" && (
         <>

--- a/packages/asset-listings-ui/src/index.ts
+++ b/packages/asset-listings-ui/src/index.ts
@@ -75,6 +75,8 @@ export {
 	SidebarFilters,
 	type SidebarFiltersProps,
 	type SidebarFilterState,
+	FILTER_SECTION_TITLE_CLASS,
+	FILTER_COUNT_BADGE_CLASS,
 } from './components/sidebar-filters';
 export {
 	SIDEBAR_CONTENT_OFFSET,

--- a/packages/config/src/asset-listings/sort.ts
+++ b/packages/config/src/asset-listings/sort.ts
@@ -9,6 +9,7 @@ export type SortField =
   | 'country'
   | 'author'
   | 'size'
+  | 'status'
   | 'population'
   | 'downloads'
   | 'last_updated'

--- a/packages/shared-ui/src/components/dialog.tsx
+++ b/packages/shared-ui/src/components/dialog.tsx
@@ -47,16 +47,22 @@ const DialogOverlay = React.forwardRef<
 });
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+const DIALOG_SIZE_CLASSES: Record<string, string> = {
+  md: 'sm:max-w-lg',
+  lg: 'sm:max-w-2xl',
+};
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     showCloseButton?: boolean;
     overlayClassName?: string;
     unstyled?: boolean;
+    size?: 'md' | 'lg';
   }
->(({ className, children, showCloseButton = true, overlayClassName, unstyled = false, ...props }, ref) => {
+>(({ className, children, showCloseButton = true, overlayClassName, unstyled = false, size = 'md', ...props }, ref) => {
   const defaultContentClasses =
-    'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg';
+    `bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none ${DIALOG_SIZE_CLASSES[size] ?? DIALOG_SIZE_CLASSES.md}`;
 
   return (
     <DialogPortal data-slot="dialog-portal">

--- a/railyard/frontend/src/App.tsx
+++ b/railyard/frontend/src/App.tsx
@@ -139,7 +139,7 @@ function App() {
     consumePendingDeepLink: () => ConsumePendingDeepLink(),
     getProjectRoute: (type, id) => `/project/${type}/${encodeURIComponent(id)}`,
     launchGame: async () => {
-      await LaunchGame();
+      await LaunchGame(false);
     },
     canNavigatePendingRoute: appReadyForNavigation,
     navigate: (route) => setLocation(route),

--- a/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
+++ b/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
@@ -33,6 +33,15 @@ interface IncompatibleAssetsDialogProps {
 
 const ACCENT = getLocalAccentClasses('uninstall');
 
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <p>
+      <span className="text-muted-foreground">{label}:</span>{' '}
+      <span className="font-medium text-foreground">{value}</span>
+    </p>
+  );
+}
+
 function constraintTypeLabel(type: string): string {
   if (type === 'buildings_index') return 'Buildings index format';
   if (type === 'manifest') return 'Game version';
@@ -91,24 +100,17 @@ export function IncompatibleAssetsDialog({
             'rounded-md border bg-muted/30 px-3 py-2 text-xs',
           )}
         >
-          <p>
-            <span className="text-muted-foreground">Incompatible Asset:</span>{' '}
-            <span className="font-medium text-foreground">{asset.name}</span>
-          </p>
-          <p className="mt-1">
-            <span className="text-muted-foreground">Asset Type:</span>{' '}
-            <span className="font-medium text-foreground">
-              {asset.assetType === 'map' ? 'Map' : 'Mod'}
-            </span>
-          </p>
-          <p className="mt-1">
-            <span className="text-muted-foreground">
-              Incompatibility Reason:
-            </span>{' '}
-            <span className="font-medium text-foreground">
-              {primaryFailureReason(asset.constraints)}
-            </span>
-          </p>
+          <div className="space-y-1">
+            <DetailRow label="Incompatible Asset" value={asset.name} />
+            <DetailRow
+              label="Asset Type"
+              value={asset.assetType === 'map' ? 'Map' : 'Mod'}
+            />
+            <DetailRow
+              label="Incompatibility Reason"
+              value={primaryFailureReason(asset.constraints)}
+            />
+          </div>
         </div>
 
         {total > 1 && (

--- a/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
+++ b/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
@@ -1,0 +1,170 @@
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  getLocalAccentClasses,
+} from '@subway-builder-modded/shared-ui';
+import { CircleAlert, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+import type { InstalledConstraint } from '@/lib/version-compatibility';
+
+export interface IncompatibleAsset {
+  name: string;
+  version: string;
+  assetType: 'map' | 'mod';
+  constraints: InstalledConstraint[];
+}
+
+interface IncompatibleAssetsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  gameVersion: string;
+  assets: IncompatibleAsset[];
+  onSkip: () => void;
+  onContinue: () => void;
+  loading?: boolean;
+}
+
+const ACCENT = getLocalAccentClasses('uninstall');
+
+function constraintTypeLabel(type: string): string {
+  if (type === 'buildings_index') return 'Buildings index format';
+  if (type === 'manifest') return 'Game version';
+  return type;
+}
+
+function primaryFailureReason(constraints: InstalledConstraint[]): string {
+  // buildings_index is sorted first by getFailingConstraints; show the top one
+  const c = constraints[0];
+  if (!c) return 'Unknown';
+  return `${constraintTypeLabel(c.type)} (requires ${c.range})`;
+}
+
+export function IncompatibleAssetsDialog({
+  open,
+  onOpenChange,
+  gameVersion: _gameVersion,
+  assets,
+  onSkip,
+  onContinue,
+  loading,
+}: IncompatibleAssetsDialogProps) {
+  const [index, setIndex] = useState(0);
+  const safeIndex = Math.min(index, Math.max(0, assets.length - 1));
+  const asset = assets[safeIndex];
+  const total = assets.length;
+
+  if (!asset) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        if (!value) setIndex(0);
+        onOpenChange(value);
+      }}
+    >
+      <DialogContent showCloseButton={false} size="lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CircleAlert className="h-5 w-5 text-destructive" />
+            Incompatible Assets
+          </DialogTitle>
+          <DialogDescription>
+            {total === 1
+              ? '1 installed asset is'
+              : `${total} installed assets are`}{' '}
+            incompatible with the current game version and may not function as
+            intended.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className={cn(
+            ACCENT.dialogPanel,
+            'rounded-md border bg-muted/30 px-3 py-2 text-xs',
+          )}
+        >
+          <p>
+            <span className="text-muted-foreground">Incompatible Asset:</span>{' '}
+            <span className="font-medium text-foreground">{asset.name}</span>
+          </p>
+          <p className="mt-1">
+            <span className="text-muted-foreground">Asset Type:</span>{' '}
+            <span className="font-medium text-foreground">
+              {asset.assetType === 'map' ? 'Map' : 'Mod'}
+            </span>
+          </p>
+          <p className="mt-1">
+            <span className="text-muted-foreground">
+              Incompatibility Reason:
+            </span>{' '}
+            <span className="font-medium text-foreground">
+              {primaryFailureReason(asset.constraints)}
+            </span>
+          </p>
+        </div>
+
+        {total > 1 && (
+          <div className="flex items-center justify-center gap-3 text-xs text-muted-foreground">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => setIndex((i) => Math.max(0, i - 1))}
+              disabled={safeIndex === 0}
+              aria-label="Previous asset"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span>
+              {safeIndex + 1} of {total}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => setIndex((i) => Math.min(total - 1, i + 1))}
+              disabled={safeIndex === total - 1}
+              aria-label="Next asset"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={loading}
+            className={ACCENT.dialogCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={onSkip}
+            disabled={loading}
+            className={ACCENT.dialogCancel}
+          >
+            Launch Without Incompatible Assets
+          </Button>
+          <Button
+            onClick={onContinue}
+            disabled={loading}
+            className={ACCENT.solidButton}
+          >
+            Understood, Continue
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
+++ b/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
@@ -33,7 +33,13 @@ interface IncompatibleAssetsDialogProps {
 
 const ACCENT = getLocalAccentClasses('uninstall');
 
-function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
   return (
     <p>
       <span className="text-muted-foreground">{label}:</span>{' '}

--- a/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
+++ b/railyard/frontend/src/components/layout/IncompatibleAssetsDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
   getLocalAccentClasses,
 } from '@subway-builder-modded/shared-ui';
-import { CircleAlert, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, CircleAlert } from 'lucide-react';
 import { useState } from 'react';
 
 import type { InstalledConstraint } from '@/lib/version-compatibility';

--- a/railyard/frontend/src/components/layout/Navbar.tsx
+++ b/railyard/frontend/src/components/layout/Navbar.tsx
@@ -41,6 +41,12 @@ import { useConfigStore } from '@/stores/config-store';
 import { useGameStore } from '@/stores/game-store';
 import { useInstalledStore } from '@/stores/installed-store';
 import { useRegistryStore } from '@/stores/registry-store';
+import { useGameVersion } from '@/hooks/use-game-version';
+import { isInstalledCompatible } from '@/lib/version-compatibility';
+import {
+  IncompatibleAssetsDialog,
+  type IncompatibleAsset,
+} from '@/components/layout/IncompatibleAssetsDialog';
 
 type NavLinkConfig = {
   href: string;
@@ -107,7 +113,14 @@ export function Navbar() {
   const launch = useGameStore((s) => s.launch);
   const stop = useGameStore((s) => s.stop);
   const installedMaps = useInstalledStore((s) => s.installedMaps);
+  const installedMods = useInstalledStore((s) => s.installedMods);
+  const gameVersion = useGameVersion();
   const [showModReminder, setShowModReminder] = useState(false);
+  const [incompatibleAssets, setIncompatibleAssets] = useState<
+    IncompatibleAsset[]
+  >([]);
+  const [showIncompatibleDialog, setShowIncompatibleDialog] = useState(false);
+  const [launchLoading, setLaunchLoading] = useState(false);
 
   const runWithToast = async (
     action: () => Promise<void>,
@@ -117,6 +130,43 @@ export function Navbar() {
       await action();
     } catch (err) {
       toast.error(String(err) || fallbackMessage);
+    }
+  };
+
+  const buildIncompatibleAssets = (): IncompatibleAsset[] => {
+    const result: IncompatibleAsset[] = [];
+    for (const m of installedMaps) {
+      if (isInstalledCompatible(gameVersion, m.constraints ?? []) === false) {
+        result.push({
+          name: m.config?.name ?? m.id,
+          version: m.version,
+          assetType: 'map' as const,
+          constraints: m.constraints ?? [],
+        });
+      }
+    }
+    for (const m of installedMods) {
+      if (isInstalledCompatible(gameVersion, m.constraints ?? []) === false) {
+        result.push({
+          name: m.manifest?.name ?? m.id,
+          version: m.version,
+          assetType: 'mod' as const,
+          constraints: m.constraints ?? [],
+        });
+      }
+    }
+    return result;
+  };
+
+  const proceedToLaunch = async (skipIncompatibleMaps: boolean) => {
+    setLaunchLoading(true);
+    try {
+      await launch(skipIncompatibleMaps);
+    } catch (err) {
+      toast.error(String(err) || 'Failed to launch game.');
+    } finally {
+      setLaunchLoading(false);
+      setShowIncompatibleDialog(false);
     }
   };
 
@@ -130,13 +180,28 @@ export function Navbar() {
       return;
     }
 
-    await runWithToast(launch, 'Failed to launch game.');
+    const incompatible = gameVersion ? buildIncompatibleAssets() : [];
+    if (incompatible.length > 0) {
+      setIncompatibleAssets(incompatible);
+      setShowIncompatibleDialog(true);
+      return;
+    }
+
+    await runWithToast(() => launch(false), 'Failed to launch game.');
   };
 
   const handleAcknowledgeAndLaunch = async () => {
     localStorage.setItem(MOD_REMINDER_KEY, 'true');
     setShowModReminder(false);
-    await runWithToast(launch, 'Failed to launch game.');
+
+    const incompatible = gameVersion ? buildIncompatibleAssets() : [];
+    if (incompatible.length > 0) {
+      setIncompatibleAssets(incompatible);
+      setShowIncompatibleDialog(true);
+      return;
+    }
+
+    await runWithToast(() => launch(false), 'Failed to launch game.');
   };
 
   const handleStop = async () => runWithToast(stop, 'Failed to stop game.');
@@ -321,6 +386,16 @@ export function Navbar() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <IncompatibleAssetsDialog
+        open={showIncompatibleDialog}
+        onOpenChange={setShowIncompatibleDialog}
+        gameVersion={gameVersion}
+        assets={incompatibleAssets}
+        onSkip={() => void proceedToLaunch(true)}
+        onContinue={() => void proceedToLaunch(false)}
+        loading={launchLoading}
+      />
     </header>
   );
 }

--- a/railyard/frontend/src/components/layout/Navbar.tsx
+++ b/railyard/frontend/src/components/layout/Navbar.tsx
@@ -37,16 +37,16 @@ import { type ComponentType, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Link, useLocation } from 'wouter';
 
+import {
+  type IncompatibleAsset,
+  IncompatibleAssetsDialog,
+} from '@/components/layout/IncompatibleAssetsDialog';
+import { useGameVersion } from '@/hooks/use-game-version';
+import { isInstalledCompatible } from '@/lib/version-compatibility';
 import { useConfigStore } from '@/stores/config-store';
 import { useGameStore } from '@/stores/game-store';
 import { useInstalledStore } from '@/stores/installed-store';
 import { useRegistryStore } from '@/stores/registry-store';
-import { useGameVersion } from '@/hooks/use-game-version';
-import { isInstalledCompatible } from '@/lib/version-compatibility';
-import {
-  IncompatibleAssetsDialog,
-  type IncompatibleAsset,
-} from '@/components/layout/IncompatibleAssetsDialog';
 
 type NavLinkConfig = {
   href: string;

--- a/railyard/frontend/src/components/layout/Navbar.tsx
+++ b/railyard/frontend/src/components/layout/Navbar.tsx
@@ -170,6 +170,16 @@ export function Navbar() {
     }
   };
 
+  const checkAndShowIncompatibleAssets = (): boolean => {
+    const incompatible = gameVersion ? buildIncompatibleAssets() : [];
+    if (incompatible.length > 0) {
+      setIncompatibleAssets(incompatible);
+      setShowIncompatibleDialog(true);
+      return true;
+    }
+    return false;
+  };
+
   const handleLaunch = async () => {
     const hasMaps = installedMaps.length > 0;
     const alreadyAcknowledged =
@@ -180,27 +190,14 @@ export function Navbar() {
       return;
     }
 
-    const incompatible = gameVersion ? buildIncompatibleAssets() : [];
-    if (incompatible.length > 0) {
-      setIncompatibleAssets(incompatible);
-      setShowIncompatibleDialog(true);
-      return;
-    }
-
+    if (checkAndShowIncompatibleAssets()) return;
     await runWithToast(() => launch(false), 'Failed to launch game.');
   };
 
   const handleAcknowledgeAndLaunch = async () => {
     localStorage.setItem(MOD_REMINDER_KEY, 'true');
     setShowModReminder(false);
-
-    const incompatible = gameVersion ? buildIncompatibleAssets() : [];
-    if (incompatible.length > 0) {
-      setIncompatibleAssets(incompatible);
-      setShowIncompatibleDialog(true);
-      return;
-    }
-
+    if (checkAndShowIncompatibleAssets()) return;
     await runWithToast(() => launch(false), 'Failed to launch game.');
   };
 

--- a/railyard/frontend/src/components/library/LibraryList.tsx
+++ b/railyard/frontend/src/components/library/LibraryList.tsx
@@ -14,7 +14,15 @@ import { AppDialog } from '@subway-builder-modded/shared-ui';
 import { LOCAL_ACCENTS } from '@subway-builder-modded/shared-ui';
 import { Checkbox } from '@subway-builder-modded/shared-ui';
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@subway-builder-modded/shared-ui';
+import {
+  CircleAlert,
   CircleFadingArrowUp,
+  FlaskConical,
   FolderOpen,
   HardDrive,
   OctagonX,
@@ -27,6 +35,11 @@ import { Link } from 'wouter';
 import { AuthorName } from '@/components/shared/AuthorName';
 import { GalleryImage } from '@/components/shared/GalleryImage';
 import type { InstalledTaggedItem } from '@/hooks/use-filtered-installed-items';
+import { useGameVersion } from '@/hooks/use-game-version';
+import {
+  getFailingConstraints,
+  isInstalledCompatible,
+} from '@/lib/version-compatibility';
 import { getCountryFlagIcon } from '@/lib/flags';
 import { openInstallFolder } from '@/lib/install-path';
 import { formatStorageSize } from '@/lib/size-format';
@@ -68,8 +81,38 @@ export function LocalBadge({ className }: { className?: string }) {
   );
 }
 
+export function IncompatibleBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border border-red-400/30 bg-red-500/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-red-600 dark:text-red-400',
+        className,
+      )}
+    >
+      <CircleAlert className="h-2.5 w-2.5 shrink-0" />
+      Incompatible
+    </span>
+  );
+}
+
+export function TestBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest',
+        'border-[color-mix(in_srgb,var(--update-primary)_30%,transparent)] bg-[color-mix(in_srgb,var(--update-primary)_10%,transparent)] text-(--update-primary)',
+        className,
+      )}
+    >
+      <FlaskConical className="h-2.5 w-2.5 shrink-0" />
+      Test
+    </span>
+  );
+}
+
 const COL = {
   gap: 'gap-3',
+  status: 'w-32',
   city: 'w-[5.5rem]',
   country: 'w-[9rem]',
   size: 'w-[6.5rem]',
@@ -145,6 +188,15 @@ export function LibraryList({
           <SortableHeaderCell
             label="Name"
             field="name"
+            sort={sort}
+            textFields={LIBRARY_TEXT_SORT_FIELDS}
+            onSort={handleColumnSort}
+          />
+        </div>
+        <div className={cn(COL.status, 'flex shrink-0 items-center')}>
+          <SortableHeaderCell
+            label="Status"
+            field="status"
             sort={sort}
             textFields={LIBRARY_TEXT_SORT_FIELDS}
             onSort={handleColumnSort}
@@ -245,11 +297,18 @@ function LibraryListRow({
   const metroMakerDataPath = useConfigStore(
     (s) => s.config?.metroMakerDataPath,
   );
+  const gameVersion = useGameVersion();
 
   const key = composeAssetKey(entry.type, entry.item.id);
   const isSelected = selectedIds.has(key);
   const isMap = entry.type === 'map';
   const isLocal = entry.isLocal;
+  const showIncompatible =
+    isInstalledCompatible(gameVersion, entry.constraints ?? []) === false;
+  const failingConstraints = showIncompatible
+    ? getFailingConstraints(gameVersion, entry.constraints ?? [])
+    : [];
+  const showTest = !isLocal && entry.item.is_test === true;
   const map = isMap ? (entry.item as types.MapManifest) : null;
 
   const mapCityCode = map?.city_code?.trim().toUpperCase() ?? '';
@@ -389,28 +448,50 @@ function LibraryListRow({
             </p>
           </div>
 
-          <div className="shrink-0 flex items-center gap-1">
-            {isLocal ? (
-              <LocalBadge />
-            ) : (
-              <>
-                {visibleBadges.map((badge) => (
-                  <Badge
-                    key={badge}
-                    variant="secondary"
-                    className="px-1.5 py-0 text-xs"
-                  >
-                    {badge}
-                  </Badge>
-                ))}
-                {overflowCount > 0 && (
-                  <Badge variant="outline" className="px-1.5 py-0 text-xs">
-                    +{overflowCount}
-                  </Badge>
-                )}
-              </>
-            )}
-          </div>
+          {!isLocal && (
+            <div className="shrink-0 flex items-center gap-1">
+              {visibleBadges.map((badge) => (
+                <Badge
+                  key={badge}
+                  variant="secondary"
+                  className="px-1.5 py-0 text-xs"
+                >
+                  {badge}
+                </Badge>
+              ))}
+              {overflowCount > 0 && (
+                <Badge variant="outline" className="px-1.5 py-0 text-xs">
+                  +{overflowCount}
+                </Badge>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className={cn(COL.status, 'shrink-0 flex flex-col items-start gap-0.5')}>
+          {showTest && <TestBadge />}
+          {isLocal && <LocalBadge />}
+          {showIncompatible && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <IncompatibleBadge />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-56 space-y-0.5">
+                  {failingConstraints.map((c) => (
+                    <p key={c.type}>
+                      {c.type === 'buildings_index'
+                        ? 'Buildings index format'
+                        : 'Game version'}
+                      : requires {c.range}
+                    </p>
+                  ))}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
 
         {showMapColumns && (

--- a/railyard/frontend/src/components/library/LibraryList.tsx
+++ b/railyard/frontend/src/components/library/LibraryList.tsx
@@ -67,46 +67,58 @@ const UNINSTALL_ICON_ACCENT = LOCAL_ACCENTS.uninstall.iconButton;
 const ENTRIES_PREVIEW_LIMIT = 10;
 const LIBRARY_TEXT_SORT_FIELDS = new Set<SortField>(TEXT_SORT_FIELDS);
 
+const BADGE_BASE_CLASS =
+  'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest';
+
+function StatusBadge({
+  icon: Icon,
+  label,
+  colorClassName,
+  className,
+}: {
+  icon: React.ElementType;
+  label: string;
+  colorClassName: string;
+  className?: string;
+}) {
+  return (
+    <span className={cn(BADGE_BASE_CLASS, colorClassName, className)}>
+      <Icon className="h-2.5 w-2.5 shrink-0" />
+      {label}
+    </span>
+  );
+}
+
 export function LocalBadge({ className }: { className?: string }) {
   return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-amber-600 dark:text-amber-400',
-        className,
-      )}
-    >
-      <HardDrive className="h-2.5 w-2.5 shrink-0" />
-      Local
-    </span>
+    <StatusBadge
+      icon={HardDrive}
+      label="Local"
+      colorClassName="border-amber-400/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+      className={className}
+    />
   );
 }
 
 export function IncompatibleBadge({ className }: { className?: string }) {
   return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full border border-red-400/30 bg-red-500/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-red-600 dark:text-red-400',
-        className,
-      )}
-    >
-      <CircleAlert className="h-2.5 w-2.5 shrink-0" />
-      Incompatible
-    </span>
+    <StatusBadge
+      icon={CircleAlert}
+      label="Incompatible"
+      colorClassName="border-red-400/30 bg-red-500/10 text-red-600 dark:text-red-400"
+      className={className}
+    />
   );
 }
 
 export function TestBadge({ className }: { className?: string }) {
   return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest',
-        'border-[color-mix(in_srgb,var(--update-primary)_30%,transparent)] bg-[color-mix(in_srgb,var(--update-primary)_10%,transparent)] text-(--update-primary)',
-        className,
-      )}
-    >
-      <FlaskConical className="h-2.5 w-2.5 shrink-0" />
-      Test
-    </span>
+    <StatusBadge
+      icon={FlaskConical}
+      label="Test"
+      colorClassName="border-[color-mix(in_srgb,var(--update-primary)_30%,transparent)] bg-[color-mix(in_srgb,var(--update-primary)_10%,transparent)] text-(--update-primary)"
+      className={className}
+    />
   );
 }
 

--- a/railyard/frontend/src/components/library/LibraryList.tsx
+++ b/railyard/frontend/src/components/library/LibraryList.tsx
@@ -36,10 +36,6 @@ import { AuthorName } from '@/components/shared/AuthorName';
 import { GalleryImage } from '@/components/shared/GalleryImage';
 import type { InstalledTaggedItem } from '@/hooks/use-filtered-installed-items';
 import { useGameVersion } from '@/hooks/use-game-version';
-import {
-  getFailingConstraints,
-  isInstalledCompatible,
-} from '@/lib/version-compatibility';
 import { getCountryFlagIcon } from '@/lib/flags';
 import { openInstallFolder } from '@/lib/install-path';
 import { formatStorageSize } from '@/lib/size-format';
@@ -54,6 +50,10 @@ import {
   type PendingUpdatesByKey,
   type PendingUpdateTarget,
 } from '@/lib/subscription-updates';
+import {
+  getFailingConstraints,
+  isInstalledCompatible,
+} from '@/lib/version-compatibility';
 import { useConfigStore } from '@/stores/config-store';
 import { useInstalledStore } from '@/stores/installed-store';
 import { useLibraryStore } from '@/stores/library-store';
@@ -468,7 +468,12 @@ function LibraryListRow({
           )}
         </div>
 
-        <div className={cn(COL.status, 'shrink-0 flex flex-col items-start gap-0.5')}>
+        <div
+          className={cn(
+            COL.status,
+            'shrink-0 flex flex-col items-start gap-0.5',
+          )}
+        >
           {showTest && <TestBadge />}
           {isLocal && <LocalBadge />}
           {showIncompatible && (

--- a/railyard/frontend/src/components/project/ProjectVersions.tsx
+++ b/railyard/frontend/src/components/project/ProjectVersions.tsx
@@ -460,7 +460,10 @@ export function ProjectVersions({
           )}
         >
           <div
-            className={cn(FILES_ACCENT.dialogPanel, 'rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground')}
+            className={cn(
+              FILES_ACCENT.dialogPanel,
+              'rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground',
+            )}
           >
             <p className="font-medium text-foreground">
               Conflicting City Code: {conflictState.conflict.cityCode}

--- a/railyard/frontend/src/components/project/ProjectVersions.tsx
+++ b/railyard/frontend/src/components/project/ProjectVersions.tsx
@@ -13,7 +13,7 @@ import {
 } from '@subway-builder-modded/asset-listings-ui';
 import type { AssetType } from '@subway-builder-modded/config';
 import { assetTypeToListingPath } from '@subway-builder-modded/config';
-import { Badge, Button } from '@subway-builder-modded/shared-ui';
+import { Badge, Button, cn } from '@subway-builder-modded/shared-ui';
 import { AppDialog } from '@subway-builder-modded/shared-ui';
 import { getLocalAccentClasses } from '@subway-builder-modded/shared-ui';
 import {
@@ -236,7 +236,14 @@ export function ProjectVersions({
           const installingVersion = getInstallingVersion(itemId);
           const uninstalling = isUninstalling(itemId);
           const compat = isCompatible(gameVersion, v.game_version);
-          const incompatible = compat === false;
+          const buildingsCompat = v.map_buildings_constraint
+            ? isCompatible(gameVersion, v.map_buildings_constraint)
+            : null;
+          const incompatible = compat === false || buildingsCompat === false;
+          const incompatibleConstraint =
+            buildingsCompat === false
+              ? v.map_buildings_constraint
+              : v.game_version;
 
           return (
             <ProjectVersionRow
@@ -289,7 +296,7 @@ export function ProjectVersions({
                       </TooltipTrigger>
                       <TooltipContent>
                         Not compatible with your game version (you have{' '}
-                        {gameVersion}, need {v.game_version})
+                        {gameVersion}, need {incompatibleConstraint})
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
@@ -453,7 +460,7 @@ export function ProjectVersions({
           )}
         >
           <div
-            className={`rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground ${FILES_ACCENT.dialogPanel}`}
+            className={cn(FILES_ACCENT.dialogPanel, 'rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground')}
           >
             <p className="font-medium text-foreground">
               Conflicting City Code: {conflictState.conflict.cityCode}

--- a/railyard/frontend/src/hooks/use-filtered-installed-items.ts
+++ b/railyard/frontend/src/hooks/use-filtered-installed-items.ts
@@ -7,12 +7,14 @@ import { useMemo } from 'react';
 
 import { type TaggedItemFilterState } from '@/hooks/use-filtered-items';
 import { usePaginationSync } from '@/hooks/use-pagination-sync';
+import { useGameVersion } from '@/hooks/use-game-version';
 import { compareItems } from '@/lib/tagged-items';
 import {
   buildDimensionCounts,
   createTaggedListingAccessors,
 } from '@/lib/tagged-listing-filters';
-import { useLibraryStore } from '@/stores/library-store';
+import { isInstalledCompatible } from '@/lib/version-compatibility';
+import { useLibraryStore, type StatusFilter } from '@/stores/library-store';
 import { useProfileStore } from '@/stores/profile-store';
 
 import type { types } from '../../wailsjs/go/models';
@@ -24,6 +26,7 @@ export type InstalledTaggedItem =
       installedVersion: string;
       installedSizeBytes: number;
       isLocal: boolean;
+      constraints?: types.InstalledConstraint[];
     }
   | {
       type: 'map';
@@ -31,12 +34,33 @@ export type InstalledTaggedItem =
       installedVersion: string;
       installedSizeBytes: number;
       isLocal: boolean;
+      constraints?: types.InstalledConstraint[];
     };
 
 interface UseFilteredInstalledParams {
   items: InstalledTaggedItem[];
   modDownloadTotals: Record<string, number>;
   mapDownloadTotals: Record<string, number>;
+}
+
+function itemStatusRank(item: InstalledTaggedItem, gameVersion: string): number {
+  if (isInstalledCompatible(gameVersion, item.constraints ?? []) === false)
+    return 3;
+  if (!item.isLocal && item.item.is_test === true) return 2;
+  if (item.isLocal) return 1;
+  return 0;
+}
+
+function matchesStatusFilter(
+  item: InstalledTaggedItem,
+  sf: StatusFilter,
+  gameVersion: string,
+): boolean {
+  if (sf === 'local') return item.isLocal;
+  if (sf === 'incompatible')
+    return isInstalledCompatible(gameVersion, item.constraints ?? []) === false;
+  if (sf === 'test') return !item.isLocal && item.item.is_test === true;
+  return false;
 }
 
 export function useFilteredInstalledItems({
@@ -50,6 +74,8 @@ export function useFilteredInstalledItems({
   const setType = useLibraryStore((s) => s.setType);
   const page = useLibraryStore((s) => s.page);
   const setPage = useLibraryStore((s) => s.setPage);
+  const statusFilters = useLibraryStore((s) => s.statusFilters);
+  const gameVersion = useGameVersion();
   const accessors = useMemo(
     () => createTaggedListingAccessors<InstalledTaggedItem>(),
     [],
@@ -72,7 +98,7 @@ export function useFilteredInstalledItems({
   );
 
   const filtered = useMemo(() => {
-    const result = filterAndSortTaggedItems({
+    let result = filterAndSortTaggedItems({
       items,
       filters,
       modDownloadTotals,
@@ -82,6 +108,17 @@ export function useFilteredInstalledItems({
       fuseOptions: ASSET_LISTING_FUSE_SEARCH_OPTIONS,
       accessors,
     });
+
+    // Status filter — applied post-process since it depends on runtime game version
+    if (statusFilters.length > 0) {
+      result = result.filter((item) =>
+        statusFilters.some((sf) =>
+          matchesStatusFilter(item as InstalledTaggedItem, sf, gameVersion),
+        ),
+      );
+    }
+
+    // Frontend-only sorts not handled by the shared compare function
     if (filters.sort.field === 'size') {
       const dir = filters.sort.direction;
       return [...result].sort((a, b) => {
@@ -90,8 +127,17 @@ export function useFilteredInstalledItems({
         return dir === 'asc' ? sizeA - sizeB : sizeB - sizeA;
       });
     }
+    if (filters.sort.field === 'status') {
+      const dir = filters.sort.direction;
+      return [...result].sort((a, b) => {
+        const ra = itemStatusRank(a as InstalledTaggedItem, gameVersion);
+        const rb = itemStatusRank(b as InstalledTaggedItem, gameVersion);
+        return dir === 'desc' ? rb - ra : ra - rb;
+      });
+    }
+
     return result;
-  }, [accessors, items, filters, mapDownloadTotals, modDownloadTotals]);
+  }, [accessors, items, filters, mapDownloadTotals, modDownloadTotals, statusFilters, gameVersion]);
 
   const totalResults = filtered.length;
   const totalPages = Math.max(1, Math.ceil(totalResults / filters.perPage));

--- a/railyard/frontend/src/hooks/use-filtered-installed-items.ts
+++ b/railyard/frontend/src/hooks/use-filtered-installed-items.ts
@@ -6,15 +6,15 @@ import {
 import { useMemo } from 'react';
 
 import { type TaggedItemFilterState } from '@/hooks/use-filtered-items';
-import { usePaginationSync } from '@/hooks/use-pagination-sync';
 import { useGameVersion } from '@/hooks/use-game-version';
+import { usePaginationSync } from '@/hooks/use-pagination-sync';
 import { compareItems } from '@/lib/tagged-items';
 import {
   buildDimensionCounts,
   createTaggedListingAccessors,
 } from '@/lib/tagged-listing-filters';
 import { isInstalledCompatible } from '@/lib/version-compatibility';
-import { useLibraryStore, type StatusFilter } from '@/stores/library-store';
+import { type StatusFilter, useLibraryStore } from '@/stores/library-store';
 import { useProfileStore } from '@/stores/profile-store';
 
 import type { types } from '../../wailsjs/go/models';
@@ -43,7 +43,10 @@ interface UseFilteredInstalledParams {
   mapDownloadTotals: Record<string, number>;
 }
 
-function itemStatusRank(item: InstalledTaggedItem, gameVersion: string): number {
+function itemStatusRank(
+  item: InstalledTaggedItem,
+  gameVersion: string,
+): number {
   if (isInstalledCompatible(gameVersion, item.constraints ?? []) === false)
     return 3;
   if (!item.isLocal && item.item.is_test === true) return 2;
@@ -137,7 +140,15 @@ export function useFilteredInstalledItems({
     }
 
     return result;
-  }, [accessors, items, filters, mapDownloadTotals, modDownloadTotals, statusFilters, gameVersion]);
+  }, [
+    accessors,
+    items,
+    filters,
+    mapDownloadTotals,
+    modDownloadTotals,
+    statusFilters,
+    gameVersion,
+  ]);
 
   const totalResults = filtered.length;
   const totalPages = Math.max(1, Math.ceil(totalResults / filters.perPage));

--- a/railyard/frontend/src/hooks/use-filtered-installed-items.ts
+++ b/railyard/frontend/src/hooks/use-filtered-installed-items.ts
@@ -121,21 +121,20 @@ export function useFilteredInstalledItems({
       );
     }
 
-    // Frontend-only sorts not handled by the shared compare function
-    if (filters.sort.field === 'size') {
+    // Frontend-only numeric sorts: field → value extractor. Add future fields here.
+    const frontendSort: Partial<
+      Record<string, (i: InstalledTaggedItem) => number>
+    > = {
+      size: (i) => i.installedSizeBytes ?? 0,
+      status: (i) => itemStatusRank(i, gameVersion),
+    };
+    const getSortValue = frontendSort[filters.sort.field];
+    if (getSortValue) {
       const dir = filters.sort.direction;
       return [...result].sort((a, b) => {
-        const sizeA = (a as InstalledTaggedItem).installedSizeBytes ?? 0;
-        const sizeB = (b as InstalledTaggedItem).installedSizeBytes ?? 0;
-        return dir === 'asc' ? sizeA - sizeB : sizeB - sizeA;
-      });
-    }
-    if (filters.sort.field === 'status') {
-      const dir = filters.sort.direction;
-      return [...result].sort((a, b) => {
-        const ra = itemStatusRank(a as InstalledTaggedItem, gameVersion);
-        const rb = itemStatusRank(b as InstalledTaggedItem, gameVersion);
-        return dir === 'desc' ? rb - ra : ra - rb;
+        const va = getSortValue(a as InstalledTaggedItem);
+        const vb = getSortValue(b as InstalledTaggedItem);
+        return dir === 'asc' ? va - vb : vb - va;
       });
     }
 

--- a/railyard/frontend/src/lib/version-compatibility.test.ts
+++ b/railyard/frontend/src/lib/version-compatibility.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getFailingConstraints,
+  type InstalledConstraint,
   isInstalledCompatible,
   selectLatestCompatibleVersion,
 } from './version-compatibility';
+
+const MANIFEST: InstalledConstraint = { type: 'manifest', range: '>=1.0.0' };
+const BUILDINGS: InstalledConstraint = {
+  type: 'buildings_index',
+  range: '>1.3.0',
+};
 
 describe('selectLatestCompatibleVersion', () => {
   const versions = [
@@ -12,18 +19,14 @@ describe('selectLatestCompatibleVersion', () => {
     { version: '1.0.0', game_version: '>=1.0.0 <2.0.0' },
   ];
 
-  it('returns the latest version when the game version is unknown', () => {
-    expect(selectLatestCompatibleVersion(versions, '')?.version).toBe('2.0.0');
-  });
-
-  it('returns the first compatible version for the current game version', () => {
-    expect(selectLatestCompatibleVersion(versions, '1.5.0')?.version).toBe(
-      '1.0.0',
+  it.each([
+    ['unknown game version returns latest', '', '2.0.0'],
+    ['selects first compatible version', '1.5.0', '1.0.0'],
+    ['returns undefined when none compatible', '2.5.0', undefined],
+  ] as const)('%s', (_, gameVersion, expected) => {
+    expect(selectLatestCompatibleVersion(versions, gameVersion)?.version).toBe(
+      expected,
     );
-  });
-
-  it('does not fall back to an incompatible latest version', () => {
-    expect(selectLatestCompatibleVersion(versions, '2.5.0')).toBeUndefined();
   });
 
   describe('map_buildings_constraint', () => {
@@ -40,21 +43,16 @@ describe('selectLatestCompatibleVersion', () => {
       },
     ];
 
-    it('rejects versions whose buildings constraint fails', () => {
-      // game 1.2.0 — JSON-only game, map v2.0.0 needs binary (>1.3.0)
-      expect(selectLatestCompatibleVersion(mapVersions, '1.2.0')?.version).toBe(
-        '1.0.0',
-      );
+    it.each([
+      ['JSON game rejects binary-only version', '1.2.0', '1.0.0'],
+      ['binary game selects binary version', '1.4.0', '2.0.0'],
+    ] as const)('%s', (_, gameVersion, expected) => {
+      expect(
+        selectLatestCompatibleVersion(mapVersions, gameVersion)?.version,
+      ).toBe(expected);
     });
 
-    it('accepts versions whose buildings constraint passes', () => {
-      // game 1.4.0 — binary game, map v2.0.0 ships binary (>1.3.0)
-      expect(selectLatestCompatibleVersion(mapVersions, '1.4.0')?.version).toBe(
-        '2.0.0',
-      );
-    });
-
-    it('ignores missing map_buildings_constraint', () => {
+    it('ignores absent map_buildings_constraint', () => {
       const plain = [{ version: '1.0.0', game_version: '>=1.0.0' }];
       expect(selectLatestCompatibleVersion(plain, '1.4.0')?.version).toBe(
         '1.0.0',
@@ -64,84 +62,36 @@ describe('selectLatestCompatibleVersion', () => {
 });
 
 describe('getFailingConstraints', () => {
-  it('returns empty array when game version is unknown', () => {
-    expect(
-      getFailingConstraints('', [{ type: 'manifest', range: '>=1.0.0' }]),
-    ).toEqual([]);
-  });
-
-  it('returns empty array when constraints list is empty', () => {
-    expect(getFailingConstraints('1.4.0', [])).toEqual([]);
-  });
-
-  it('returns empty array when all constraints pass', () => {
-    expect(
-      getFailingConstraints('1.4.0', [
-        { type: 'manifest', range: '>=1.0.0' },
-        { type: 'buildings_index', range: '>1.3.0' },
-      ]),
-    ).toEqual([]);
+  it.each<[string, string, InstalledConstraint[], number]>([
+    ['empty game version', '', [MANIFEST], 0],
+    ['empty constraints', '1.4.0', [], 0],
+    ['all constraints pass', '1.4.0', [MANIFEST, BUILDINGS], 0],
+  ])('%s → returns empty', (_, gameVersion, constraints, len) => {
+    expect(getFailingConstraints(gameVersion, constraints)).toHaveLength(len);
   });
 
   it('returns only the failing constraint', () => {
-    const result = getFailingConstraints('1.2.0', [
-      { type: 'manifest', range: '>=1.0.0' },
-      { type: 'buildings_index', range: '>1.3.0' },
-    ]);
+    const result = getFailingConstraints('1.2.0', [MANIFEST, BUILDINGS]);
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('buildings_index');
   });
 
   it('sorts buildings_index before manifest when both fail', () => {
-    const result = getFailingConstraints('0.5.0', [
-      { type: 'manifest', range: '>=1.0.0' },
-      { type: 'buildings_index', range: '>1.3.0' },
-    ]);
+    const result = getFailingConstraints('0.5.0', [MANIFEST, BUILDINGS]);
     expect(result[0].type).toBe('buildings_index');
     expect(result[1].type).toBe('manifest');
   });
 });
 
 describe('isInstalledCompatible', () => {
-  it('returns null when game version is unknown', () => {
-    expect(
-      isInstalledCompatible('', [{ type: 'manifest', range: '>=1.0.0' }]),
-    ).toBeNull();
-  });
-
-  it('returns null when constraints list is empty', () => {
-    expect(isInstalledCompatible('1.4.0', [])).toBeNull();
-  });
-
-  it('returns true when all constraints pass', () => {
-    expect(
-      isInstalledCompatible('1.4.0', [
-        { type: 'manifest', range: '>=1.0.0' },
-        { type: 'buildings_index', range: '>1.3.0' },
-      ]),
-    ).toBe(true);
-  });
-
-  it('returns false when any constraint fails', () => {
-    expect(
-      isInstalledCompatible('1.2.0', [
-        { type: 'manifest', range: '>=1.0.0' },
-        { type: 'buildings_index', range: '>1.3.0' },
-      ]),
-    ).toBe(false);
-  });
-
-  it('returns false when only the buildings_index constraint fails', () => {
-    expect(
-      isInstalledCompatible('1.2.0', [
-        { type: 'buildings_index', range: '>1.3.0' },
-      ]),
-    ).toBe(false);
-  });
-
-  it('returns false when only the manifest constraint fails', () => {
-    expect(
-      isInstalledCompatible('0.9.0', [{ type: 'manifest', range: '>=1.0.0' }]),
-    ).toBe(false);
+  it.each<[string, string, InstalledConstraint[], boolean | null]>([
+    ['unknown game version', '', [MANIFEST], null],
+    ['empty constraints', '1.4.0', [], null],
+    ['all constraints pass', '1.4.0', [MANIFEST, BUILDINGS], true],
+    ['buildings_index fails', '1.2.0', [MANIFEST, BUILDINGS], false],
+    ['only buildings_index (fails)', '1.2.0', [BUILDINGS], false],
+    ['only manifest (fails)', '0.9.0', [MANIFEST], false],
+  ])('%s', (_, gameVersion, constraints, expected) => {
+    expect(isInstalledCompatible(gameVersion, constraints)).toBe(expected);
   });
 });

--- a/railyard/frontend/src/lib/version-compatibility.test.ts
+++ b/railyard/frontend/src/lib/version-compatibility.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { selectLatestCompatibleVersion } from './version-compatibility';
+import {
+  isInstalledCompatible,
+  selectLatestCompatibleVersion,
+} from './version-compatibility';
 
 describe('selectLatestCompatibleVersion', () => {
   const versions = [
@@ -20,5 +23,85 @@ describe('selectLatestCompatibleVersion', () => {
 
   it('does not fall back to an incompatible latest version', () => {
     expect(selectLatestCompatibleVersion(versions, '2.5.0')).toBeUndefined();
+  });
+
+  describe('map_buildings_constraint', () => {
+    const mapVersions = [
+      {
+        version: '2.0.0',
+        game_version: '>=1.0.0',
+        map_buildings_constraint: '>1.3.0',
+      },
+      {
+        version: '1.0.0',
+        game_version: '>=1.0.0',
+        map_buildings_constraint: '<=1.3.0',
+      },
+    ];
+
+    it('rejects versions whose buildings constraint fails', () => {
+      // game 1.2.0 — JSON-only game, map v2.0.0 needs binary (>1.3.0)
+      expect(
+        selectLatestCompatibleVersion(mapVersions, '1.2.0')?.version,
+      ).toBe('1.0.0');
+    });
+
+    it('accepts versions whose buildings constraint passes', () => {
+      // game 1.4.0 — binary game, map v2.0.0 ships binary (>1.3.0)
+      expect(
+        selectLatestCompatibleVersion(mapVersions, '1.4.0')?.version,
+      ).toBe('2.0.0');
+    });
+
+    it('ignores missing map_buildings_constraint', () => {
+      const plain = [{ version: '1.0.0', game_version: '>=1.0.0' }];
+      expect(selectLatestCompatibleVersion(plain, '1.4.0')?.version).toBe(
+        '1.0.0',
+      );
+    });
+  });
+});
+
+describe('isInstalledCompatible', () => {
+  it('returns null when game version is unknown', () => {
+    expect(
+      isInstalledCompatible('', [{ type: 'manifest', range: '>=1.0.0' }]),
+    ).toBeNull();
+  });
+
+  it('returns null when constraints list is empty', () => {
+    expect(isInstalledCompatible('1.4.0', [])).toBeNull();
+  });
+
+  it('returns true when all constraints pass', () => {
+    expect(
+      isInstalledCompatible('1.4.0', [
+        { type: 'manifest', range: '>=1.0.0' },
+        { type: 'buildings_index', range: '>1.3.0' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns false when any constraint fails', () => {
+    expect(
+      isInstalledCompatible('1.2.0', [
+        { type: 'manifest', range: '>=1.0.0' },
+        { type: 'buildings_index', range: '>1.3.0' },
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false when only the buildings_index constraint fails', () => {
+    expect(
+      isInstalledCompatible('1.2.0', [
+        { type: 'buildings_index', range: '>1.3.0' },
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false when only the manifest constraint fails', () => {
+    expect(
+      isInstalledCompatible('0.9.0', [{ type: 'manifest', range: '>=1.0.0' }]),
+    ).toBe(false);
   });
 });

--- a/railyard/frontend/src/lib/version-compatibility.test.ts
+++ b/railyard/frontend/src/lib/version-compatibility.test.ts
@@ -41,16 +41,16 @@ describe('selectLatestCompatibleVersion', () => {
 
     it('rejects versions whose buildings constraint fails', () => {
       // game 1.2.0 — JSON-only game, map v2.0.0 needs binary (>1.3.0)
-      expect(
-        selectLatestCompatibleVersion(mapVersions, '1.2.0')?.version,
-      ).toBe('1.0.0');
+      expect(selectLatestCompatibleVersion(mapVersions, '1.2.0')?.version).toBe(
+        '1.0.0',
+      );
     });
 
     it('accepts versions whose buildings constraint passes', () => {
       // game 1.4.0 — binary game, map v2.0.0 ships binary (>1.3.0)
-      expect(
-        selectLatestCompatibleVersion(mapVersions, '1.4.0')?.version,
-      ).toBe('2.0.0');
+      expect(selectLatestCompatibleVersion(mapVersions, '1.4.0')?.version).toBe(
+        '2.0.0',
+      );
     });
 
     it('ignores missing map_buildings_constraint', () => {

--- a/railyard/frontend/src/lib/version-compatibility.test.ts
+++ b/railyard/frontend/src/lib/version-compatibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  getFailingConstraints,
   isInstalledCompatible,
   selectLatestCompatibleVersion,
 } from './version-compatibility';
@@ -59,6 +60,45 @@ describe('selectLatestCompatibleVersion', () => {
         '1.0.0',
       );
     });
+  });
+});
+
+describe('getFailingConstraints', () => {
+  it('returns empty array when game version is unknown', () => {
+    expect(
+      getFailingConstraints('', [{ type: 'manifest', range: '>=1.0.0' }]),
+    ).toEqual([]);
+  });
+
+  it('returns empty array when constraints list is empty', () => {
+    expect(getFailingConstraints('1.4.0', [])).toEqual([]);
+  });
+
+  it('returns empty array when all constraints pass', () => {
+    expect(
+      getFailingConstraints('1.4.0', [
+        { type: 'manifest', range: '>=1.0.0' },
+        { type: 'buildings_index', range: '>1.3.0' },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('returns only the failing constraint', () => {
+    const result = getFailingConstraints('1.2.0', [
+      { type: 'manifest', range: '>=1.0.0' },
+      { type: 'buildings_index', range: '>1.3.0' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('buildings_index');
+  });
+
+  it('sorts buildings_index before manifest when both fail', () => {
+    const result = getFailingConstraints('0.5.0', [
+      { type: 'manifest', range: '>=1.0.0' },
+      { type: 'buildings_index', range: '>1.3.0' },
+    ]);
+    expect(result[0].type).toBe('buildings_index');
+    expect(result[1].type).toBe('manifest');
   });
 });
 

--- a/railyard/frontend/src/lib/version-compatibility.ts
+++ b/railyard/frontend/src/lib/version-compatibility.ts
@@ -2,6 +2,7 @@ import { isCompatible } from '@/lib/semver';
 
 interface GameCompatibleVersion {
   game_version: string;
+  map_buildings_constraint?: string;
 }
 
 export function selectLatestCompatibleVersion<T extends GameCompatibleVersion>(
@@ -11,7 +12,49 @@ export function selectLatestCompatibleVersion<T extends GameCompatibleVersion>(
   const latestVersion = versions[0];
   if (!latestVersion || !gameVersion) return latestVersion;
 
-  return versions.find(
-    (version) => isCompatible(gameVersion, version.game_version) !== false,
+  return versions.find((version) => {
+    if (isCompatible(gameVersion, version.game_version) === false) return false;
+    if (
+      version.map_buildings_constraint &&
+      isCompatible(gameVersion, version.map_buildings_constraint) === false
+    )
+      return false;
+    return true;
+  });
+}
+
+export interface InstalledConstraint {
+  type: string;
+  range: string;
+}
+
+/**
+ * Returns false if any constraint is violated, null when compatibility
+ * cannot be determined (no game version detected, or no constraints stored).
+ */
+export function isInstalledCompatible(
+  gameVersion: string,
+  constraints: InstalledConstraint[],
+): boolean | null {
+  if (!gameVersion) return null;
+  if (!constraints?.length) return null;
+  for (const c of constraints) {
+    if (isCompatible(gameVersion, c.range) === false) return false;
+  }
+  return true;
+}
+
+/**
+ * Returns the subset of constraints that fail for the given game version,
+ * sorted so buildings_index (more specific) comes before manifest.
+ */
+export function getFailingConstraints(
+  gameVersion: string,
+  constraints: InstalledConstraint[],
+): InstalledConstraint[] {
+  if (!gameVersion || !constraints?.length) return [];
+  const failing = constraints.filter(
+    (c) => isCompatible(gameVersion, c.range) === false,
   );
+  return failing.sort((a) => (a.type === 'buildings_index' ? -1 : 1));
 }

--- a/railyard/frontend/src/pages/LibraryPage.tsx
+++ b/railyard/frontend/src/pages/LibraryPage.tsx
@@ -32,7 +32,8 @@ import {
   SelectValue,
 } from '@subway-builder-modded/shared-ui';
 import { PageHeading } from '@subway-builder-modded/shared-ui';
-import { AlertTriangle, FileArchive, Inbox, Plus, SearchX } from 'lucide-react';
+import { AlertTriangle, CircleAlert, FileArchive, FlaskConical, HardDrive, Inbox, Plus, SearchX } from 'lucide-react';
+import { Separator } from '@subway-builder-modded/shared-ui';
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { useLocation } from 'wouter';
@@ -41,6 +42,8 @@ import { LibraryActionBar } from '@/components/library/LibraryActionBar';
 import { LibraryList } from '@/components/library/LibraryList';
 import { SidebarPanel } from '@/components/shared/SidebarPanel';
 import { useFilteredInstalledItems } from '@/hooks/use-filtered-installed-items';
+import { useGameVersion } from '@/hooks/use-game-version';
+import { isInstalledCompatible } from '@/lib/version-compatibility';
 import {
   handleSubscriptionMutationError,
   useSubscriptionMutationLockState,
@@ -57,8 +60,10 @@ import {
   InvalidMapCodeError,
   useInstalledStore,
 } from '@/stores/installed-store';
+import { useLibraryStore } from '@/stores/library-store';
 import { useRegistryStore } from '@/stores/registry-store';
 import { useUIStore } from '@/stores/ui-store';
+import { cn } from '@subway-builder-modded/shared-ui';
 
 import { OpenImportAssetDialog } from '../../wailsjs/go/main/App';
 import type { types } from '../../wailsjs/go/models';
@@ -143,22 +148,6 @@ function conflictSourceLabel(conflict: types.MapCodeConflict): string {
   return conflict.existingIsLocal ? 'Local' : 'Registry';
 }
 
-function renderPathWithSoftBreaks(path: string) {
-  // We want strict bounds in the dialog without breaking mid-segment.
-  // Insert optional break points after path separators.
-  const parts = path.split(/([\\/])/g);
-  return parts.map((part, idx) => {
-    if (part === '/' || part === '\\') {
-      return (
-        <Fragment key={`${idx}-sep`}>
-          {part}
-          <wbr />
-        </Fragment>
-      );
-    }
-    return <Fragment key={`${idx}-txt`}>{part}</Fragment>;
-  });
-}
 
 const INSTALL_ACCENT = getLocalAccentClasses('install');
 const IMPORT_ACCENT = getLocalAccentClasses('import');
@@ -180,6 +169,10 @@ export function LibraryPage() {
   );
   const [pendingUpdatesByKey, setPendingUpdatesByKey] =
     useState<PendingUpdatesByKey>({});
+
+  const statusFilters = useLibraryStore((s) => s.statusFilters);
+  const toggleStatusFilter = useLibraryStore((s) => s.toggleStatusFilter);
+  const gameVersion = useGameVersion();
 
   const mods = useRegistryStore((s) => s.mods);
   const maps = useRegistryStore((s) => s.maps);
@@ -264,6 +257,7 @@ export function LibraryPage() {
               installedVersion: installed.version,
               installedSizeBytes: installed.installedSizeBytes ?? 0,
               isLocal: installed.isLocal,
+              constraints: installed.constraints,
             },
           ]
         : [];
@@ -280,6 +274,7 @@ export function LibraryPage() {
             installedVersion: installed.version,
             installedSizeBytes: installed.installedSizeBytes ?? 0,
             isLocal: installed.isLocal,
+            constraints: installed.constraints,
           },
         ];
       }
@@ -306,6 +301,18 @@ export function LibraryPage() {
     modDownloadTotals,
     mapDownloadTotals,
   });
+
+  const statusCounts = useMemo(() => {
+    let local = 0, incompatible = 0, test = 0;
+    for (const item of installedItems) {
+      if (item.type !== filters.type) continue;
+      if (item.isLocal) local++;
+      if (!item.isLocal && item.item.is_test === true) test++;
+      if (isInstalledCompatible(gameVersion, item.constraints ?? []) === false)
+        incompatible++;
+    }
+    return { local, incompatible, test };
+  }, [installedItems, filters.type, gameVersion]);
 
   const handleInstallBrowse = useCallback(() => {
     useBrowseStore.getState().setType(filters.type);
@@ -470,6 +477,96 @@ export function LibraryPage() {
           formatSourceQuality={formatSourceQuality}
           emptyLabels={SEARCH_FILTER_EMPTY_LABELS}
           minimumVisibleOptions={2}
+          afterTypeContent={
+            <>
+              <Separator />
+              <div>
+                <p className="mb-1 px-1 py-1.5 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  Asset Status
+                </p>
+                <nav className="space-y-0.5" aria-label="Asset status filter">
+                  {(
+                    [
+                      {
+                        key: 'test' as const,
+                        label: 'Test',
+                        Icon: FlaskConical,
+                        iconColor: 'text-(--update-primary)',
+                        activeText: 'text-(--update-primary)',
+                        activeBg: 'bg-[color-mix(in_srgb,var(--update-primary)_12%,transparent)]',
+                        activePill: 'bg-[var(--update-primary)]',
+                        hoverBg: 'group-hover:bg-[color-mix(in_srgb,var(--update-primary)_10%,transparent)]',
+                        hoverText: 'group-hover:text-(--update-primary)',
+                        count: statusCounts.test,
+                      },
+                      {
+                        key: 'local' as const,
+                        label: 'Local',
+                        Icon: HardDrive,
+                        iconColor: 'text-amber-500',
+                        activeText: 'text-amber-600 dark:text-amber-400',
+                        activeBg: 'bg-amber-500/10',
+                        activePill: 'bg-amber-500',
+                        hoverBg: 'group-hover:bg-amber-500/10',
+                        hoverText: 'group-hover:text-amber-600 dark:group-hover:text-amber-400',
+                        count: statusCounts.local,
+                      },
+                      {
+                        key: 'incompatible' as const,
+                        label: 'Incompatible',
+                        Icon: CircleAlert,
+                        iconColor: 'text-red-500',
+                        activeText: 'text-red-600 dark:text-red-400',
+                        activeBg: 'bg-red-500/10',
+                        activePill: 'bg-red-500',
+                        hoverBg: 'group-hover:bg-red-500/10',
+                        hoverText: 'group-hover:text-red-600 dark:group-hover:text-red-400',
+                        count: statusCounts.incompatible,
+                      },
+                    ]
+                  ).filter(({ key, count }) => count > 0 || statusFilters.includes(key))
+                  .map(({ key, label, Icon, iconColor, activeText, activeBg, activePill, hoverBg, hoverText, count }) => {
+                    const active = statusFilters.includes(key);
+                    return (
+                      <button
+                        key={key}
+                        type="button"
+                        onClick={() => toggleStatusFilter(key)}
+                        aria-pressed={active}
+                        className="group relative w-full text-left"
+                      >
+                        <span
+                          className={cn(
+                            'mr-0.5 flex items-center gap-2 rounded-lg px-2',
+                            'py-[clamp(0.38rem,0.8vw,0.52rem)]',
+                            'text-[clamp(0.78rem,0.9vw,0.86rem)] font-semibold',
+                            'transition-all duration-150',
+                            active
+                              ? `${activeBg} ${activeText}`
+                              : `text-muted-foreground ${hoverBg} ${hoverText}`,
+                          )}
+                        >
+                          <Icon className={cn('h-3.5 w-3.5 shrink-0 transition-colors', iconColor)} />
+                          <span className="flex-1">{label}</span>
+                          {count > 0 && (
+                            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-border/65 bg-muted/45 px-1.5 text-[0.65rem] font-semibold tabular-nums text-muted-foreground">
+                              {count}
+                            </span>
+                          )}
+                        </span>
+                        {active && (
+                          <span
+                            aria-hidden
+                            className={cn('absolute right-0 top-0 h-full w-1.25 rounded-full', activePill)}
+                          />
+                        )}
+                      </button>
+                    );
+                  })}
+                </nav>
+              </div>
+            </>
+          }
         />
       </AssetSidebarPanel>
 
@@ -636,16 +733,13 @@ export function LibraryPage() {
           mutationLockedReason,
         )}
       >
-        <div className="min-w-0 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        <div
+          className={cn(
+            IMPORT_ACCENT.dialogPanel,
+            'min-w-0 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground',
+          )}
+        >
           Asset Type: <span className="font-medium text-foreground">Map</span>
-          {importSelectedPath ? (
-            <p className="mt-1 min-w-0 max-w-full overflow-hidden whitespace-normal">
-              Selected Archive:{' '}
-              <span className="text-foreground font-mono">
-                {renderPathWithSoftBreaks(importSelectedPath)}
-              </span>
-            </p>
-          ) : null}
         </div>
       </AppDialog>
 
@@ -673,7 +767,7 @@ export function LibraryPage() {
           )}
         >
           <div
-            className={`rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground ${FILES_ACCENT.dialogPanel}`}
+            className={cn(FILES_ACCENT.dialogPanel, 'rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground')}
           >
             <p className="font-medium text-foreground">
               Conflicting City Code: {importConflict.cityCode}

--- a/railyard/frontend/src/pages/LibraryPage.tsx
+++ b/railyard/frontend/src/pages/LibraryPage.tsx
@@ -493,7 +493,9 @@ export function LibraryPage() {
             <>
               <Separator />
               <div>
-                <p className={cn(FILTER_SECTION_TITLE_CLASS, 'mb-1 px-1 py-1.5')}>
+                <p
+                  className={cn(FILTER_SECTION_TITLE_CLASS, 'mb-1 px-1 py-1.5')}
+                >
                   Asset Status
                 </p>
                 <nav className="space-y-0.5" aria-label="Asset status filter">

--- a/railyard/frontend/src/pages/LibraryPage.tsx
+++ b/railyard/frontend/src/pages/LibraryPage.tsx
@@ -32,9 +32,19 @@ import {
   SelectValue,
 } from '@subway-builder-modded/shared-ui';
 import { PageHeading } from '@subway-builder-modded/shared-ui';
-import { AlertTriangle, CircleAlert, FileArchive, FlaskConical, HardDrive, Inbox, Plus, SearchX } from 'lucide-react';
 import { Separator } from '@subway-builder-modded/shared-ui';
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { cn } from '@subway-builder-modded/shared-ui';
+import {
+  AlertTriangle,
+  CircleAlert,
+  FileArchive,
+  FlaskConical,
+  HardDrive,
+  Inbox,
+  Plus,
+  SearchX,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { useLocation } from 'wouter';
 
@@ -43,7 +53,6 @@ import { LibraryList } from '@/components/library/LibraryList';
 import { SidebarPanel } from '@/components/shared/SidebarPanel';
 import { useFilteredInstalledItems } from '@/hooks/use-filtered-installed-items';
 import { useGameVersion } from '@/hooks/use-game-version';
-import { isInstalledCompatible } from '@/lib/version-compatibility';
 import {
   handleSubscriptionMutationError,
   useSubscriptionMutationLockState,
@@ -54,6 +63,7 @@ import {
   type PendingUpdatesByKey,
   requestLatestSubscriptionUpdatesForActiveProfile,
 } from '@/lib/subscription-updates';
+import { isInstalledCompatible } from '@/lib/version-compatibility';
 import { useBrowseStore } from '@/stores/browse-store';
 import {
   AssetConflictError,
@@ -63,7 +73,6 @@ import {
 import { useLibraryStore } from '@/stores/library-store';
 import { useRegistryStore } from '@/stores/registry-store';
 import { useUIStore } from '@/stores/ui-store';
-import { cn } from '@subway-builder-modded/shared-ui';
 
 import { OpenImportAssetDialog } from '../../wailsjs/go/main/App';
 import type { types } from '../../wailsjs/go/models';
@@ -147,7 +156,6 @@ function conflictSourceLabel(conflict: types.MapCodeConflict): string {
   if (conflict.existingAssetId?.startsWith('vanilla:')) return 'Vanilla';
   return conflict.existingIsLocal ? 'Local' : 'Registry';
 }
-
 
 const INSTALL_ACCENT = getLocalAccentClasses('install');
 const IMPORT_ACCENT = getLocalAccentClasses('import');
@@ -303,7 +311,9 @@ export function LibraryPage() {
   });
 
   const statusCounts = useMemo(() => {
-    let local = 0, incompatible = 0, test = 0;
+    let local = 0,
+      incompatible = 0,
+      test = 0;
     for (const item of installedItems) {
       if (item.type !== filters.type) continue;
       if (item.isLocal) local++;
@@ -485,84 +495,111 @@ export function LibraryPage() {
                   Asset Status
                 </p>
                 <nav className="space-y-0.5" aria-label="Asset status filter">
-                  {(
-                    [
-                      {
-                        key: 'test' as const,
-                        label: 'Test',
-                        Icon: FlaskConical,
-                        iconColor: 'text-(--update-primary)',
-                        activeText: 'text-(--update-primary)',
-                        activeBg: 'bg-[color-mix(in_srgb,var(--update-primary)_12%,transparent)]',
-                        activePill: 'bg-[var(--update-primary)]',
-                        hoverBg: 'group-hover:bg-[color-mix(in_srgb,var(--update-primary)_10%,transparent)]',
-                        hoverText: 'group-hover:text-(--update-primary)',
-                        count: statusCounts.test,
-                      },
-                      {
-                        key: 'local' as const,
-                        label: 'Local',
-                        Icon: HardDrive,
-                        iconColor: 'text-amber-500',
-                        activeText: 'text-amber-600 dark:text-amber-400',
-                        activeBg: 'bg-amber-500/10',
-                        activePill: 'bg-amber-500',
-                        hoverBg: 'group-hover:bg-amber-500/10',
-                        hoverText: 'group-hover:text-amber-600 dark:group-hover:text-amber-400',
-                        count: statusCounts.local,
-                      },
-                      {
-                        key: 'incompatible' as const,
-                        label: 'Incompatible',
-                        Icon: CircleAlert,
-                        iconColor: 'text-red-500',
-                        activeText: 'text-red-600 dark:text-red-400',
-                        activeBg: 'bg-red-500/10',
-                        activePill: 'bg-red-500',
-                        hoverBg: 'group-hover:bg-red-500/10',
-                        hoverText: 'group-hover:text-red-600 dark:group-hover:text-red-400',
-                        count: statusCounts.incompatible,
-                      },
-                    ]
-                  ).filter(({ key, count }) => count > 0 || statusFilters.includes(key))
-                  .map(({ key, label, Icon, iconColor, activeText, activeBg, activePill, hoverBg, hoverText, count }) => {
-                    const active = statusFilters.includes(key);
-                    return (
-                      <button
-                        key={key}
-                        type="button"
-                        onClick={() => toggleStatusFilter(key)}
-                        aria-pressed={active}
-                        className="group relative w-full text-left"
-                      >
-                        <span
-                          className={cn(
-                            'mr-0.5 flex items-center gap-2 rounded-lg px-2',
-                            'py-[clamp(0.38rem,0.8vw,0.52rem)]',
-                            'text-[clamp(0.78rem,0.9vw,0.86rem)] font-semibold',
-                            'transition-all duration-150',
-                            active
-                              ? `${activeBg} ${activeText}`
-                              : `text-muted-foreground ${hoverBg} ${hoverText}`,
-                          )}
-                        >
-                          <Icon className={cn('h-3.5 w-3.5 shrink-0 transition-colors', iconColor)} />
-                          <span className="flex-1">{label}</span>
-                          {count > 0 && (
-                            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-border/65 bg-muted/45 px-1.5 text-[0.65rem] font-semibold tabular-nums text-muted-foreground">
-                              {count}
+                  {[
+                    {
+                      key: 'test' as const,
+                      label: 'Test',
+                      Icon: FlaskConical,
+                      iconColor: 'text-(--update-primary)',
+                      activeText: 'text-(--update-primary)',
+                      activeBg:
+                        'bg-[color-mix(in_srgb,var(--update-primary)_12%,transparent)]',
+                      activePill: 'bg-[var(--update-primary)]',
+                      hoverBg:
+                        'group-hover:bg-[color-mix(in_srgb,var(--update-primary)_10%,transparent)]',
+                      hoverText: 'group-hover:text-(--update-primary)',
+                      count: statusCounts.test,
+                    },
+                    {
+                      key: 'local' as const,
+                      label: 'Local',
+                      Icon: HardDrive,
+                      iconColor: 'text-amber-500',
+                      activeText: 'text-amber-600 dark:text-amber-400',
+                      activeBg: 'bg-amber-500/10',
+                      activePill: 'bg-amber-500',
+                      hoverBg: 'group-hover:bg-amber-500/10',
+                      hoverText:
+                        'group-hover:text-amber-600 dark:group-hover:text-amber-400',
+                      count: statusCounts.local,
+                    },
+                    {
+                      key: 'incompatible' as const,
+                      label: 'Incompatible',
+                      Icon: CircleAlert,
+                      iconColor: 'text-red-500',
+                      activeText: 'text-red-600 dark:text-red-400',
+                      activeBg: 'bg-red-500/10',
+                      activePill: 'bg-red-500',
+                      hoverBg: 'group-hover:bg-red-500/10',
+                      hoverText:
+                        'group-hover:text-red-600 dark:group-hover:text-red-400',
+                      count: statusCounts.incompatible,
+                    },
+                  ]
+                    .filter(
+                      ({ key, count }) =>
+                        count > 0 || statusFilters.includes(key),
+                    )
+                    .map(
+                      ({
+                        key,
+                        label,
+                        Icon,
+                        iconColor,
+                        activeText,
+                        activeBg,
+                        activePill,
+                        hoverBg,
+                        hoverText,
+                        count,
+                      }) => {
+                        const active = statusFilters.includes(key);
+                        return (
+                          <button
+                            key={key}
+                            type="button"
+                            onClick={() => toggleStatusFilter(key)}
+                            aria-pressed={active}
+                            className="group relative w-full text-left"
+                          >
+                            <span
+                              className={cn(
+                                'mr-0.5 flex items-center gap-2 rounded-lg px-2',
+                                'py-[clamp(0.38rem,0.8vw,0.52rem)]',
+                                'text-[clamp(0.78rem,0.9vw,0.86rem)] font-semibold',
+                                'transition-all duration-150',
+                                active
+                                  ? `${activeBg} ${activeText}`
+                                  : `text-muted-foreground ${hoverBg} ${hoverText}`,
+                              )}
+                            >
+                              <Icon
+                                className={cn(
+                                  'h-3.5 w-3.5 shrink-0 transition-colors',
+                                  iconColor,
+                                )}
+                              />
+                              <span className="flex-1">{label}</span>
+                              {count > 0 && (
+                                <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-border/65 bg-muted/45 px-1.5 text-[0.65rem] font-semibold tabular-nums text-muted-foreground">
+                                  {count}
+                                </span>
+                              )}
                             </span>
-                          )}
-                        </span>
-                        {active && (
-                          <span
-                            aria-hidden
-                            className={cn('absolute right-0 top-0 h-full w-1.25 rounded-full', activePill)}
-                          />
-                        )}
-                      </button>
-                    );
-                  })}
+                            {active && (
+                              <span
+                                aria-hidden
+                                className={cn(
+                                  'absolute right-0 top-0 h-full w-1.25 rounded-full',
+                                  activePill,
+                                )}
+                              />
+                            )}
+                          </button>
+                        );
+                      },
+                    )}
                 </nav>
               </div>
             </>
@@ -767,7 +804,10 @@ export function LibraryPage() {
           )}
         >
           <div
-            className={cn(FILES_ACCENT.dialogPanel, 'rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground')}
+            className={cn(
+              FILES_ACCENT.dialogPanel,
+              'rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground',
+            )}
           >
             <p className="font-medium text-foreground">
               Conflicting City Code: {importConflict.cityCode}

--- a/railyard/frontend/src/pages/LibraryPage.tsx
+++ b/railyard/frontend/src/pages/LibraryPage.tsx
@@ -3,6 +3,8 @@ import {
   AssetSidebarPanel,
   EmptyState,
   ErrorBanner,
+  FILTER_COUNT_BADGE_CLASS,
+  FILTER_SECTION_TITLE_CLASS,
   Pagination,
   ResultsSummary,
   SearchBar,
@@ -487,11 +489,11 @@ export function LibraryPage() {
           formatSourceQuality={formatSourceQuality}
           emptyLabels={SEARCH_FILTER_EMPTY_LABELS}
           minimumVisibleOptions={2}
-          afterTypeContent={
+          statusContent={
             <>
               <Separator />
               <div>
-                <p className="mb-1 px-1 py-1.5 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                <p className={cn(FILTER_SECTION_TITLE_CLASS, 'mb-1 px-1 py-1.5')}>
                   Asset Status
                 </p>
                 <nav className="space-y-0.5" aria-label="Asset status filter">
@@ -582,7 +584,7 @@ export function LibraryPage() {
                               />
                               <span className="flex-1">{label}</span>
                               {count > 0 && (
-                                <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-border/65 bg-muted/45 px-1.5 text-[0.65rem] font-semibold tabular-nums text-muted-foreground">
+                                <span className={FILTER_COUNT_BADGE_CLASS}>
                                   {count}
                                 </span>
                               )}

--- a/railyard/frontend/src/stores/game-store.ts
+++ b/railyard/frontend/src/stores/game-store.ts
@@ -56,7 +56,7 @@ interface GameState {
   serverPort: number | null;
 
   initialize: () => void;
-  launch: () => Promise<void>;
+  launch: (skipIncompatibleMaps?: boolean) => Promise<void>;
   stop: () => Promise<void>;
   selectSession: (id: string) => void;
   clearLogs: () => void;
@@ -219,7 +219,7 @@ export const useGameStore = create<GameState>((set, get) => ({
     });
   },
 
-  launch: async () => {
+  launch: async (skipIncompatibleMaps = false) => {
     if (get().running || get().starting) {
       return;
     }
@@ -227,7 +227,7 @@ export const useGameStore = create<GameState>((set, get) => ({
     set({ starting: true });
 
     try {
-      const response = await LaunchGame();
+      const response = await LaunchGame(skipIncompatibleMaps);
       if (response.status === 'error') {
         throw new Error(response.message || 'Failed to launch game');
       }

--- a/railyard/frontend/src/stores/library-store.test.ts
+++ b/railyard/frontend/src/stores/library-store.test.ts
@@ -129,6 +129,51 @@ describe('useLibraryStore per-asset-type state', () => {
   });
 });
 
+describe('useLibraryStore statusFilters', () => {
+  beforeEach(() => {
+    useLibraryStore.setState({ statusFilters: [] });
+  });
+
+  it('toggleStatusFilter adds a filter when not present', () => {
+    useLibraryStore.getState().toggleStatusFilter('local');
+    expect(useLibraryStore.getState().statusFilters).toEqual(['local']);
+  });
+
+  it('toggleStatusFilter removes a filter when already present', () => {
+    useLibraryStore.setState({ statusFilters: ['local', 'incompatible'] });
+    useLibraryStore.getState().toggleStatusFilter('local');
+    expect(useLibraryStore.getState().statusFilters).toEqual(['incompatible']);
+  });
+
+  it('toggleStatusFilter supports all status types', () => {
+    useLibraryStore.getState().toggleStatusFilter('test');
+    expect(useLibraryStore.getState().statusFilters).toContain('test');
+  });
+
+  it('clearStatusFilters empties the list', () => {
+    useLibraryStore.setState({ statusFilters: ['local', 'incompatible', 'test'] });
+    useLibraryStore.getState().clearStatusFilters();
+    expect(useLibraryStore.getState().statusFilters).toEqual([]);
+  });
+});
+
+describe('useLibraryStore setPage', () => {
+  beforeEach(() => {
+    useLibraryStore.setState({ page: 1 });
+  });
+
+  it('updates page when the new value differs', () => {
+    useLibraryStore.getState().setPage(3);
+    expect(useLibraryStore.getState().page).toBe(3);
+  });
+
+  it('is a no-op when setting the same page', () => {
+    const before = useLibraryStore.getState();
+    useLibraryStore.getState().setPage(1);
+    expect(useLibraryStore.getState()).toBe(before);
+  });
+});
+
 describe('useLibraryStore selection', () => {
   beforeEach(() => {
     useLibraryStore.setState({ selectedIds: new Set<string>() });

--- a/railyard/frontend/src/stores/library-store.test.ts
+++ b/railyard/frontend/src/stores/library-store.test.ts
@@ -151,7 +151,9 @@ describe('useLibraryStore statusFilters', () => {
   });
 
   it('clearStatusFilters empties the list', () => {
-    useLibraryStore.setState({ statusFilters: ['local', 'incompatible', 'test'] });
+    useLibraryStore.setState({
+      statusFilters: ['local', 'incompatible', 'test'],
+    });
     useLibraryStore.getState().clearStatusFilters();
     expect(useLibraryStore.getState().statusFilters).toEqual([]);
   });

--- a/railyard/frontend/src/stores/library-store.ts
+++ b/railyard/frontend/src/stores/library-store.ts
@@ -37,6 +37,8 @@ const defaultLibraryFilters: LibraryFilters = {
   },
 };
 
+export type StatusFilter = 'local' | 'incompatible' | 'test';
+
 interface LibraryState extends AssetQueryFilterStoreState<
   LibraryFilters,
   LibraryFilterByAssetType
@@ -47,6 +49,9 @@ interface LibraryState extends AssetQueryFilterStoreState<
   removeSelected: (ids: string[]) => void;
   clearSelection: () => void;
   isSelected: (id: string) => boolean;
+  statusFilters: StatusFilter[];
+  toggleStatusFilter: (filter: StatusFilter) => void;
+  clearStatusFilters: () => void;
 }
 
 export const useLibraryStore = create<LibraryState>((set, get) => ({
@@ -54,6 +59,14 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
   page: 1,
   scopedByType: createFilterByAssetType(ASSET_TYPES, defaultLibraryFilters, 1),
   selectedIds: new Set<string>(),
+  statusFilters: [],
+  toggleStatusFilter: (filter) =>
+    set((state) => ({
+      statusFilters: state.statusFilters.includes(filter)
+        ? state.statusFilters.filter((f) => f !== filter)
+        : [...state.statusFilters, filter],
+    })),
+  clearStatusFilters: () => set({ statusFilters: [] }),
   setFilters: (updater) =>
     set((state) => {
       const nextFilters =

--- a/railyard/frontend/wailsjs/go/main/App.d.ts
+++ b/railyard/frontend/wailsjs/go/main/App.d.ts
@@ -23,7 +23,7 @@ export function IsGameRunning():Promise<types.GameRunningResponse>;
 
 export function IsStartupReady():Promise<types.StartupReadyResponse>;
 
-export function LaunchGame():Promise<types.GenericResponse>;
+export function LaunchGame(arg1:boolean):Promise<types.GenericResponse>;
 
 export function ManuallyCheckForUpdates():Promise<types.GenericResponse>;
 

--- a/railyard/frontend/wailsjs/go/main/App.js
+++ b/railyard/frontend/wailsjs/go/main/App.js
@@ -42,8 +42,8 @@ export function IsStartupReady() {
   return window['go']['main']['App']['IsStartupReady']();
 }
 
-export function LaunchGame() {
-  return window['go']['main']['App']['LaunchGame']();
+export function LaunchGame(arg1) {
+  return window['go']['main']['App']['LaunchGame'](arg1);
 }
 
 export function ManuallyCheckForUpdates() {


### PR DESCRIPTION
This PR does a lot of things
- Adds the `INCOMPATIBLE/TEST` chips to the Library to a new `Status` column
- Makes these chips filterable in the sidebar (and dynamic to the selected AssetType)
- Adds a new dialog at launch time to inform the user whether or not they have incompatible assets downloaded
- Prevents users from attempting download of incompatible version (by graying out the button)

<img width="2560" height="1417" alt="image" src="https://github.com/user-attachments/assets/42d0737e-7555-4f2a-9f90-bd6b4d4a366f" />
<img width="741" height="324" alt="image" src="https://github.com/user-attachments/assets/a3fcc337-e4f5-4de7-9efd-a6fe9ed1a0b6" />
<img width="574" height="349" alt="image" src="https://github.com/user-attachments/assets/e8d7d0dd-d9a9-4ff5-9107-a38db1ca7322" />
<img width="2560" height="1417" alt="image" src="https://github.com/user-attachments/assets/01149c35-9113-45fa-9609-1598a4eb71b6" />
